### PR TITLE
license: change license to GPLv3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rmsyn/jh71xx-pac"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board support package for the JH71xx boards"
 keywords = ["riscv", "jh7110", "bsp"]
-license = "AGPL"
+license = "GPL-3.0-only"
 
 [dependencies.jh7110-vf2-12a-pac]
 path = "./jh7110-vf2-12a-pac"

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,14 @@
 Copyleft (C) 2023 jh71xx-pac developers 
 
 This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
+it under the terms of the GNU General Public License as
 published by the Free Software Foundation, either version 3 of the
 License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
 
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/jh7110-vf2-12a-pac/Cargo.toml
+++ b/jh7110-vf2-12a-pac/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rmsyn/jh71xx-pac"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board support package for the JH7110 VisionFive2 v1.2a board"
 keywords = ["riscv", "jh7110", "bsp"]
-license = "AGPL"
+license = "GPL-3.0-only"
 
 [dependencies]
 critical-section = { version = "1.1.2", optional = true }

--- a/jh7110-vf2-13b-pac/Cargo.toml
+++ b/jh7110-vf2-13b-pac/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rmsyn/jh71xx-pac"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board support package for the JH7110 VisionFive2 v1.3b board"
 keywords = ["riscv", "jh7110", "bsp"]
-license = "AGPL"
+license = "GPL-3.0-only"
 
 [dependencies]
 critical-section = { version = "1.1.2", optional = true }


### PR DESCRIPTION
Changes from the GPL Affero license to GPL v3, and corrects the SPDX short identifiers in Cargo.toml.