### PR TITLE
feature: SVD PMU PWM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh71xx-pac"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["rmsyn <rmsynchls@gmail.com>"]
 repository = "https://github.com/rmsyn/jh71xx-pac"

--- a/jh7110-vf2-12a-pac/Cargo.toml
+++ b/jh7110-vf2-12a-pac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh7110-vf2-12a-pac"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["rmsyn <rmsynchls@gmail.com>"]
 repository = "https://github.com/rmsyn/jh71xx-pac"

--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.dts
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.dts
@@ -727,6 +727,15 @@
 			};
 		};
 
+                ptc: pwm@120d0000 {
+                        compatible = "starfive,jh7110-pwm";
+                        reg = <0x0 0x120d0000 0x0 0x10000>;
+                        clocks = <&syscrg 121>;
+                        resets = <&syscrg 108>;
+                        #pwm-cells = <3>;
+                        status = "disabled";
+                };
+
 		syscrg: clock-controller@13020000 {
 			compatible = "starfive,jh7110-syscrg";
 			reg = <0x00 0x13020000 0x00 0x10000>;

--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -5760,6 +5760,118 @@
       </addressBlock>
     </peripheral>
     <peripheral>
+      <name>starfive_jh7110_pwm_0</name>
+      <description>From starfive,jh7110-pwm, peripheral generator</description>
+      <baseAddress>0x120D0000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>cntr</name>
+          <description>PTC counter register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>cntr</name>
+              <description>PWM PTC counter</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hrc</name>
+          <description>PTC duty-cycle register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>hrc</name>
+              <description>PWM PTC duty-cycle value</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>lrc</name>
+          <description>PTC period register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>lrc</name>
+              <description>PWM PTC period value</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ctrl</name>
+          <description>PTC control register</description>
+          <addressOffset>0xc</addressOffset>
+          <fields>
+            <field>
+              <name>en</name>
+              <description>PWM PTC enable</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>eclk</name>
+              <description>PWM PTC enable clock</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>nec</name>
+              <description>PWM PTC nec</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>oe</name>
+              <description>PWM PTC oe</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>single</name>
+              <description>PWM PTC single</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>inte</name>
+              <description>PWM PTC interrupt enable</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>int</name>
+              <description>PWM PTC interrupt</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cntrrst</name>
+              <description>PWM PTC counter reset</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>capte</name>
+              <description>PWM PTC capte</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
       <name>starfive_jh7110_syscrg_0</name>
       <description>From starfive,jh7110-syscrg, peripheral generator</description>
       <baseAddress>0x13020000</baseAddress>
@@ -20379,6 +20491,7 @@
           <name>hard_event_turn_on_mask</name>
           <description>Hardware Event Turn-On Mask</description>
           <addressOffset>0x4</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>hard_event_0_on_mask</name>
@@ -20434,46 +20547,47 @@
           <name>soft_turn_on_power_mode</name>
           <description>Software Turn-On Power Mode</description>
           <addressOffset>0xc</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>systop_power_mode</name>
-              <description>SYSTOP turn-on power mode</description>
+              <description>SYSTOP turn-on power mode.</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>cpu_power_mode</name>
-              <description>CPU turn-on power mode</description>
+              <description>CPU turn-on power mode.</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>gpua_power_mode</name>
-              <description>GPUA turn-on power mode</description>
+              <description>GPUA turn-on power mode.</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>vdec_power_mode</name>
-              <description>VDEC turn-on power mode</description>
+              <description>VDEC turn-on power mode.</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>vout_power_mode</name>
-              <description>VOUT turn-on power mode</description>
+              <description>VOUT turn-on power mode.</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>isp_power_mode</name>
-              <description>ISP turn-on power mode</description>
+              <description>ISP turn-on power mode.</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>venc_power_mode</name>
-              <description>VENC turn-on power mode</description>
+              <description>VENC turn-on power mode.</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
@@ -20482,47 +20596,48 @@
         <register>
           <name>soft_turn_off_power_mode</name>
           <description>Software Turn-Off Power Mode</description>
-          <addressOffset>0xc</addressOffset>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>systop_power_mode</name>
-              <description>SYSTOP turn-off power mode</description>
+              <description>SYSTOP turn-off power mode.</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>cpu_power_mode</name>
-              <description>CPU turn-off power mode</description>
+              <description>CPU turn-off power mode.</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>gpua_power_mode</name>
-              <description>GPUA turn-off power mode</description>
+              <description>GPUA turn-off power mode.</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>vdec_power_mode</name>
-              <description>VDEC turn-off power mode</description>
+              <description>VDEC turn-off power mode.</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>vout_power_mode</name>
-              <description>VOUT turn-off power mode</description>
+              <description>VOUT turn-off power mode.</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>isp_power_mode</name>
-              <description>ISP turn-off power mode</description>
+              <description>ISP turn-off power mode.</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>venc_power_mode</name>
-              <description>VENC turn-off power mode</description>
+              <description>VENC turn-off power mode.</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
@@ -20532,10 +20647,11 @@
           <name>timeout_seq_thd</name>
           <description>Threshold Sequence Timeout</description>
           <addressOffset>0x14</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>timeout_seq_thd</name>
-              <description>Threshold sequence timeout</description>
+              <description>Threshold Sequence Timeout</description>
               <bitRange>[15:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -20545,6 +20661,7 @@
           <name>pdc0</name>
           <description>Powerdomain Cascade 0</description>
           <addressOffset>0x18</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pd0_off_cas</name>
@@ -20588,6 +20705,7 @@
           <name>pdc1</name>
           <description>Powerdomain Cascade 1</description>
           <addressOffset>0x1c</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pd3_off_cas</name>
@@ -20631,6 +20749,7 @@
           <name>pdc2</name>
           <description>Powerdomain Cascade 2</description>
           <addressOffset>0x20</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pd6_off_cas</name>
@@ -20672,12 +20791,13 @@
         </register>
         <register>
           <name>sw_encourage</name>
-          <description>Software Ecncourage</description>
+          <description>Software Encouragement</description>
           <addressOffset>0x44</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>sw_encourage</name>
-              <description>Software encouragement</description>
+              <description>Software Encouragement</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -20687,6 +20807,7 @@
           <name>tim</name>
           <description>TIMER Interrupt Mask</description>
           <addressOffset>0x48</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>seq_done_mask</name>
@@ -20722,8 +20843,9 @@
         </register>
         <register>
           <name>pch_bypass</name>
-          <description>P-channel bypass</description>
+          <description>P-channel Bypass</description>
           <addressOffset>0x4c</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pch_bypass</name>
@@ -20737,6 +20859,7 @@
           <name>pch_pstate</name>
           <description>P-channel PSTATE</description>
           <addressOffset>0x50</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pch_pstate</name>
@@ -20750,6 +20873,7 @@
           <name>pch_timeout</name>
           <description>P-channel Timeout Threshold</description>
           <addressOffset>0x54</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pch_timeout</name>
@@ -20763,6 +20887,7 @@
           <name>lp_timeout</name>
           <description>LP Cell Control Timeout Threshold</description>
           <addressOffset>0x58</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>lp_timeout</name>
@@ -20776,6 +20901,7 @@
           <name>hard_turn_on_power_mode</name>
           <description>Hardware Turn-On Power Mode</description>
           <addressOffset>0x5c</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>systop_power_mode</name>
@@ -20825,6 +20951,7 @@
           <name>current_power_mode</name>
           <description>Current Power Mode</description>
           <addressOffset>0x80</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>systop_power_mode</name>
@@ -20874,6 +21001,7 @@
           <name>current_seq_state</name>
           <description>Current Sequence State</description>
           <addressOffset>0x84</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>power_mode_cur</name>
@@ -20887,6 +21015,7 @@
           <name>event_status</name>
           <description>PMU Event Status</description>
           <addressOffset>0x88</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>seq_done_event</name>
@@ -20924,6 +21053,7 @@
           <name>int_status</name>
           <description>PMU Interrupt Status</description>
           <addressOffset>0x8c</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>seq_done_event</name>
@@ -20961,6 +21091,7 @@
           <name>hw_event_crd</name>
           <description>Hardware Event Record</description>
           <addressOffset>0x90</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>hw_event_crd</name>
@@ -20974,6 +21105,7 @@
           <name>encourage_type_crd</name>
           <description>Hardware Event Type Record</description>
           <addressOffset>0x94</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>encourage_type_crd</name>
@@ -20987,6 +21119,7 @@
           <name>pch_active</name>
           <description>P-channel PACTIVE Status</description>
           <addressOffset>0x98</addressOffset>
+          <size>32</size>
           <fields>
             <field>
               <name>pch_active</name>

--- a/jh7110-vf2-12a-pac/src/lib.rs
+++ b/jh7110-vf2-12a-pac/src/lib.rs
@@ -172,6 +172,52 @@ impl core::fmt::Debug for STARFIVE_JH7110_STG_SYSCON_0 {
 }
 #[doc = "From starfive,jh7110-stg-syscon, peripheral generator"]
 pub mod starfive_jh7110_stg_syscon_0;
+#[doc = "From starfive,jh7110-pwm, peripheral generator"]
+pub struct STARFIVE_JH7110_PWM_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for STARFIVE_JH7110_PWM_0 {}
+impl STARFIVE_JH7110_PWM_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const starfive_jh7110_pwm_0::RegisterBlock = 0x120d_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const starfive_jh7110_pwm_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for STARFIVE_JH7110_PWM_0 {
+    type Target = starfive_jh7110_pwm_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for STARFIVE_JH7110_PWM_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("STARFIVE_JH7110_PWM_0").finish()
+    }
+}
+#[doc = "From starfive,jh7110-pwm, peripheral generator"]
+pub mod starfive_jh7110_pwm_0;
 #[doc = "From starfive,jh7110-syscrg, peripheral generator"]
 pub struct STARFIVE_JH7110_SYSCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -551,6 +597,8 @@ pub struct Peripherals {
     pub STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0,
     #[doc = "STARFIVE_JH7110_STG_SYSCON_0"]
     pub STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0,
+    #[doc = "STARFIVE_JH7110_PWM_0"]
+    pub STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0,
     #[doc = "STARFIVE_JH7110_SYSCRG_0"]
     pub STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0,
     #[doc = "STARFIVE_JH7110_SYS_SYSCON_0"]
@@ -596,6 +644,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0 {
+                _marker: PhantomData,
+            },
+            STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0 {

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0.rs
@@ -5,8 +5,10 @@ pub struct RegisterBlock {
     #[doc = "0x04 - Hardware Event Turn-On Mask"]
     pub hard_event_turn_on_mask: HARD_EVENT_TURN_ON_MASK,
     _reserved1: [u8; 0x04],
-    _reserved_1_soft_turn: [u8; 0x04],
-    _reserved2: [u8; 0x04],
+    #[doc = "0x0c - Software Turn-On Power Mode"]
+    pub soft_turn_on_power_mode: SOFT_TURN_ON_POWER_MODE,
+    #[doc = "0x10 - Software Turn-Off Power Mode"]
+    pub soft_turn_off_power_mode: SOFT_TURN_OFF_POWER_MODE,
     #[doc = "0x14 - Threshold Sequence Timeout"]
     pub timeout_seq_thd: TIMEOUT_SEQ_THD,
     #[doc = "0x18 - Powerdomain Cascade 0"]
@@ -15,12 +17,12 @@ pub struct RegisterBlock {
     pub pdc1: PDC1,
     #[doc = "0x20 - Powerdomain Cascade 2"]
     pub pdc2: PDC2,
-    _reserved6: [u8; 0x20],
-    #[doc = "0x44 - Software Ecncourage"]
+    _reserved7: [u8; 0x20],
+    #[doc = "0x44 - Software Encouragement"]
     pub sw_encourage: SW_ENCOURAGE,
     #[doc = "0x48 - TIMER Interrupt Mask"]
     pub tim: TIM,
-    #[doc = "0x4c - P-channel bypass"]
+    #[doc = "0x4c - P-channel Bypass"]
     pub pch_bypass: PCH_BYPASS,
     #[doc = "0x50 - P-channel PSTATE"]
     pub pch_pstate: PCH_PSTATE,
@@ -30,7 +32,7 @@ pub struct RegisterBlock {
     pub lp_timeout: LP_TIMEOUT,
     #[doc = "0x5c - Hardware Turn-On Power Mode"]
     pub hard_turn_on_power_mode: HARD_TURN_ON_POWER_MODE,
-    _reserved13: [u8; 0x20],
+    _reserved14: [u8; 0x20],
     #[doc = "0x80 - Current Power Mode"]
     pub current_power_mode: CURRENT_POWER_MODE,
     #[doc = "0x84 - Current Sequence State"]
@@ -45,18 +47,6 @@ pub struct RegisterBlock {
     pub encourage_type_crd: ENCOURAGE_TYPE_CRD,
     #[doc = "0x98 - P-channel PACTIVE Status"]
     pub pch_active: PCH_ACTIVE,
-}
-impl RegisterBlock {
-    #[doc = "0x0c - Software Turn-Off Power Mode"]
-    #[inline(always)]
-    pub const fn soft_turn_off_power_mode(&self) -> &SOFT_TURN_OFF_POWER_MODE {
-        unsafe { &*(self as *const Self).cast::<u8>().add(12usize).cast() }
-    }
-    #[doc = "0x0c - Software Turn-On Power Mode"]
-    #[inline(always)]
-    pub const fn soft_turn_on_power_mode(&self) -> &SOFT_TURN_ON_POWER_MODE {
-        unsafe { &*(self as *const Self).cast::<u8>().add(12usize).cast() }
-    }
 }
 #[doc = "hard_event_turn_on_mask (rw) register accessor: Hardware Event Turn-On Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hard_event_turn_on_mask::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hard_event_turn_on_mask::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hard_event_turn_on_mask`]
 module"]
@@ -96,20 +86,20 @@ module"]
 pub type PDC2 = crate::Reg<pdc2::PDC2_SPEC>;
 #[doc = "Powerdomain Cascade 2"]
 pub mod pdc2;
-#[doc = "sw_encourage (rw) register accessor: Software Ecncourage\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`sw_encourage`]
+#[doc = "sw_encourage (rw) register accessor: Software Encouragement\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`sw_encourage`]
 module"]
 pub type SW_ENCOURAGE = crate::Reg<sw_encourage::SW_ENCOURAGE_SPEC>;
-#[doc = "Software Ecncourage"]
+#[doc = "Software Encouragement"]
 pub mod sw_encourage;
 #[doc = "tim (rw) register accessor: TIMER Interrupt Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`tim`]
 module"]
 pub type TIM = crate::Reg<tim::TIM_SPEC>;
 #[doc = "TIMER Interrupt Mask"]
 pub mod tim;
-#[doc = "pch_bypass (rw) register accessor: P-channel bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_bypass`]
+#[doc = "pch_bypass (rw) register accessor: P-channel Bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_bypass`]
 module"]
 pub type PCH_BYPASS = crate::Reg<pch_bypass::PCH_BYPASS_SPEC>;
-#[doc = "P-channel bypass"]
+#[doc = "P-channel Bypass"]
 pub mod pch_bypass;
 #[doc = "pch_pstate (rw) register accessor: P-channel PSTATE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_pstate::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_pstate::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_pstate`]
 module"]

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/pch_bypass.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/pch_bypass.rs
@@ -27,7 +27,7 @@ impl W {
         self
     }
 }
-#[doc = "P-channel bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "P-channel Bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PCH_BYPASS_SPEC;
 impl crate::RegisterSpec for PCH_BYPASS_SPEC {
     type Ux = u32;

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/soft_turn_off_power_mode.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/soft_turn_off_power_mode.rs
@@ -2,109 +2,109 @@
 pub type R = crate::R<SOFT_TURN_OFF_POWER_MODE_SPEC>;
 #[doc = "Register `soft_turn_off_power_mode` writer"]
 pub type W = crate::W<SOFT_TURN_OFF_POWER_MODE_SPEC>;
-#[doc = "Field `systop_power_mode` reader - SYSTOP turn-off power mode"]
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-off power mode."]
 pub type SYSTOP_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `systop_power_mode` writer - SYSTOP turn-off power mode"]
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-off power mode."]
 pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `cpu_power_mode` reader - CPU turn-off power mode"]
+#[doc = "Field `cpu_power_mode` reader - CPU turn-off power mode."]
 pub type CPU_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `cpu_power_mode` writer - CPU turn-off power mode"]
+#[doc = "Field `cpu_power_mode` writer - CPU turn-off power mode."]
 pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `gpua_power_mode` reader - GPUA turn-off power mode"]
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-off power mode."]
 pub type GPUA_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `gpua_power_mode` writer - GPUA turn-off power mode"]
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-off power mode."]
 pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `vdec_power_mode` reader - VDEC turn-off power mode"]
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-off power mode."]
 pub type VDEC_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `vdec_power_mode` writer - VDEC turn-off power mode"]
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-off power mode."]
 pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `vout_power_mode` reader - VOUT turn-off power mode"]
+#[doc = "Field `vout_power_mode` reader - VOUT turn-off power mode."]
 pub type VOUT_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `vout_power_mode` writer - VOUT turn-off power mode"]
+#[doc = "Field `vout_power_mode` writer - VOUT turn-off power mode."]
 pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `isp_power_mode` reader - ISP turn-off power mode"]
+#[doc = "Field `isp_power_mode` reader - ISP turn-off power mode."]
 pub type ISP_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `isp_power_mode` writer - ISP turn-off power mode"]
+#[doc = "Field `isp_power_mode` writer - ISP turn-off power mode."]
 pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `venc_power_mode` reader - VENC turn-off power mode"]
+#[doc = "Field `venc_power_mode` reader - VENC turn-off power mode."]
 pub type VENC_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `venc_power_mode` writer - VENC turn-off power mode"]
+#[doc = "Field `venc_power_mode` writer - VENC turn-off power mode."]
 pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 0 - SYSTOP turn-off power mode"]
+    #[doc = "Bit 0 - SYSTOP turn-off power mode."]
     #[inline(always)]
     pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
         SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - CPU turn-off power mode"]
+    #[doc = "Bit 1 - CPU turn-off power mode."]
     #[inline(always)]
     pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
         CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - GPUA turn-off power mode"]
+    #[doc = "Bit 2 - GPUA turn-off power mode."]
     #[inline(always)]
     pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
         GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - VDEC turn-off power mode"]
+    #[doc = "Bit 3 - VDEC turn-off power mode."]
     #[inline(always)]
     pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
         VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - VOUT turn-off power mode"]
+    #[doc = "Bit 4 - VOUT turn-off power mode."]
     #[inline(always)]
     pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
         VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - ISP turn-off power mode"]
+    #[doc = "Bit 5 - ISP turn-off power mode."]
     #[inline(always)]
     pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
         ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - VENC turn-off power mode"]
+    #[doc = "Bit 6 - VENC turn-off power mode."]
     #[inline(always)]
     pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
         VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - SYSTOP turn-off power mode"]
+    #[doc = "Bit 0 - SYSTOP turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 0> {
         SYSTOP_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 1 - CPU turn-off power mode"]
+    #[doc = "Bit 1 - CPU turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 1> {
         CPU_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 2 - GPUA turn-off power mode"]
+    #[doc = "Bit 2 - GPUA turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 2> {
         GPUA_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 3 - VDEC turn-off power mode"]
+    #[doc = "Bit 3 - VDEC turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 3> {
         VDEC_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 4 - VOUT turn-off power mode"]
+    #[doc = "Bit 4 - VOUT turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 4> {
         VOUT_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 5 - ISP turn-off power mode"]
+    #[doc = "Bit 5 - ISP turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 5> {
         ISP_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 6 - VENC turn-off power mode"]
+    #[doc = "Bit 6 - VENC turn-off power mode."]
     #[inline(always)]
     #[must_use]
     pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 6> {

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/soft_turn_on_power_mode.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/soft_turn_on_power_mode.rs
@@ -2,109 +2,109 @@
 pub type R = crate::R<SOFT_TURN_ON_POWER_MODE_SPEC>;
 #[doc = "Register `soft_turn_on_power_mode` writer"]
 pub type W = crate::W<SOFT_TURN_ON_POWER_MODE_SPEC>;
-#[doc = "Field `systop_power_mode` reader - SYSTOP turn-on power mode"]
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-on power mode."]
 pub type SYSTOP_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `systop_power_mode` writer - SYSTOP turn-on power mode"]
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-on power mode."]
 pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `cpu_power_mode` reader - CPU turn-on power mode"]
+#[doc = "Field `cpu_power_mode` reader - CPU turn-on power mode."]
 pub type CPU_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `cpu_power_mode` writer - CPU turn-on power mode"]
+#[doc = "Field `cpu_power_mode` writer - CPU turn-on power mode."]
 pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `gpua_power_mode` reader - GPUA turn-on power mode"]
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-on power mode."]
 pub type GPUA_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `gpua_power_mode` writer - GPUA turn-on power mode"]
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-on power mode."]
 pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `vdec_power_mode` reader - VDEC turn-on power mode"]
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-on power mode."]
 pub type VDEC_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `vdec_power_mode` writer - VDEC turn-on power mode"]
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-on power mode."]
 pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `vout_power_mode` reader - VOUT turn-on power mode"]
+#[doc = "Field `vout_power_mode` reader - VOUT turn-on power mode."]
 pub type VOUT_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `vout_power_mode` writer - VOUT turn-on power mode"]
+#[doc = "Field `vout_power_mode` writer - VOUT turn-on power mode."]
 pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `isp_power_mode` reader - ISP turn-on power mode"]
+#[doc = "Field `isp_power_mode` reader - ISP turn-on power mode."]
 pub type ISP_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `isp_power_mode` writer - ISP turn-on power mode"]
+#[doc = "Field `isp_power_mode` writer - ISP turn-on power mode."]
 pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
-#[doc = "Field `venc_power_mode` reader - VENC turn-on power mode"]
+#[doc = "Field `venc_power_mode` reader - VENC turn-on power mode."]
 pub type VENC_POWER_MODE_R = crate::BitReader;
-#[doc = "Field `venc_power_mode` writer - VENC turn-on power mode"]
+#[doc = "Field `venc_power_mode` writer - VENC turn-on power mode."]
 pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 0 - SYSTOP turn-on power mode"]
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
     #[inline(always)]
     pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
         SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - CPU turn-on power mode"]
+    #[doc = "Bit 1 - CPU turn-on power mode."]
     #[inline(always)]
     pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
         CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - GPUA turn-on power mode"]
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
     #[inline(always)]
     pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
         GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - VDEC turn-on power mode"]
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
     #[inline(always)]
     pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
         VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - VOUT turn-on power mode"]
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
     #[inline(always)]
     pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
         VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - ISP turn-on power mode"]
+    #[doc = "Bit 5 - ISP turn-on power mode."]
     #[inline(always)]
     pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
         ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - VENC turn-on power mode"]
+    #[doc = "Bit 6 - VENC turn-on power mode."]
     #[inline(always)]
     pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
         VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - SYSTOP turn-on power mode"]
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 0> {
         SYSTOP_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 1 - CPU turn-on power mode"]
+    #[doc = "Bit 1 - CPU turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 1> {
         CPU_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 2 - GPUA turn-on power mode"]
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 2> {
         GPUA_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 3 - VDEC turn-on power mode"]
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 3> {
         VDEC_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 4 - VOUT turn-on power mode"]
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 4> {
         VOUT_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 5 - ISP turn-on power mode"]
+    #[doc = "Bit 5 - ISP turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 5> {
         ISP_POWER_MODE_W::new(self)
     }
-    #[doc = "Bit 6 - VENC turn-on power mode"]
+    #[doc = "Bit 6 - VENC turn-on power mode."]
     #[inline(always)]
     #[must_use]
     pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 6> {

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/sw_encourage.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/sw_encourage.rs
@@ -2,19 +2,19 @@
 pub type R = crate::R<SW_ENCOURAGE_SPEC>;
 #[doc = "Register `sw_encourage` writer"]
 pub type W = crate::W<SW_ENCOURAGE_SPEC>;
-#[doc = "Field `sw_encourage` reader - Software encouragement"]
+#[doc = "Field `sw_encourage` reader - Software Encouragement"]
 pub type SW_ENCOURAGE_R = crate::FieldReader;
-#[doc = "Field `sw_encourage` writer - Software encouragement"]
+#[doc = "Field `sw_encourage` writer - Software Encouragement"]
 pub type SW_ENCOURAGE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
 impl R {
-    #[doc = "Bits 0:7 - Software encouragement"]
+    #[doc = "Bits 0:7 - Software Encouragement"]
     #[inline(always)]
     pub fn sw_encourage(&self) -> SW_ENCOURAGE_R {
         SW_ENCOURAGE_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - Software encouragement"]
+    #[doc = "Bits 0:7 - Software Encouragement"]
     #[inline(always)]
     #[must_use]
     pub fn sw_encourage(&mut self) -> SW_ENCOURAGE_W<SW_ENCOURAGE_SPEC, 0> {
@@ -27,7 +27,7 @@ impl W {
         self
     }
 }
-#[doc = "Software Ecncourage\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software Encouragement\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SW_ENCOURAGE_SPEC;
 impl crate::RegisterSpec for SW_ENCOURAGE_SPEC {
     type Ux = u32;

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/timeout_seq_thd.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pmu_0/timeout_seq_thd.rs
@@ -2,19 +2,19 @@
 pub type R = crate::R<TIMEOUT_SEQ_THD_SPEC>;
 #[doc = "Register `timeout_seq_thd` writer"]
 pub type W = crate::W<TIMEOUT_SEQ_THD_SPEC>;
-#[doc = "Field `timeout_seq_thd` reader - Threshold sequence timeout"]
+#[doc = "Field `timeout_seq_thd` reader - Threshold Sequence Timeout"]
 pub type TIMEOUT_SEQ_THD_R = crate::FieldReader<u16>;
-#[doc = "Field `timeout_seq_thd` writer - Threshold sequence timeout"]
+#[doc = "Field `timeout_seq_thd` writer - Threshold Sequence Timeout"]
 pub type TIMEOUT_SEQ_THD_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
 impl R {
-    #[doc = "Bits 0:15 - Threshold sequence timeout"]
+    #[doc = "Bits 0:15 - Threshold Sequence Timeout"]
     #[inline(always)]
     pub fn timeout_seq_thd(&self) -> TIMEOUT_SEQ_THD_R {
         TIMEOUT_SEQ_THD_R::new((self.bits & 0xffff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:15 - Threshold sequence timeout"]
+    #[doc = "Bits 0:15 - Threshold Sequence Timeout"]
     #[inline(always)]
     #[must_use]
     pub fn timeout_seq_thd(&mut self) -> TIMEOUT_SEQ_THD_W<TIMEOUT_SEQ_THD_SPEC, 0> {

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0.rs
@@ -1,0 +1,32 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - PTC counter register"]
+    pub cntr: CNTR,
+    #[doc = "0x04 - PTC duty-cycle register"]
+    pub hrc: HRC,
+    #[doc = "0x08 - PTC period register"]
+    pub lrc: LRC,
+    #[doc = "0x0c - PTC control register"]
+    pub ctrl: CTRL,
+}
+#[doc = "cntr (rw) register accessor: PTC counter register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cntr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cntr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`cntr`]
+module"]
+pub type CNTR = crate::Reg<cntr::CNTR_SPEC>;
+#[doc = "PTC counter register"]
+pub mod cntr;
+#[doc = "hrc (rw) register accessor: PTC duty-cycle register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hrc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hrc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hrc`]
+module"]
+pub type HRC = crate::Reg<hrc::HRC_SPEC>;
+#[doc = "PTC duty-cycle register"]
+pub mod hrc;
+#[doc = "lrc (rw) register accessor: PTC period register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lrc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lrc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`lrc`]
+module"]
+pub type LRC = crate::Reg<lrc::LRC_SPEC>;
+#[doc = "PTC period register"]
+pub mod lrc;
+#[doc = "ctrl (rw) register accessor: PTC control register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ctrl`]
+module"]
+pub type CTRL = crate::Reg<ctrl::CTRL_SPEC>;
+#[doc = "PTC control register"]
+pub mod ctrl;

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/cntr.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/cntr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `cntr` reader"]
+pub type R = crate::R<CNTR_SPEC>;
+#[doc = "Register `cntr` writer"]
+pub type W = crate::W<CNTR_SPEC>;
+#[doc = "Field `cntr` reader - PWM PTC counter"]
+pub type CNTR_R = crate::FieldReader<u32>;
+#[doc = "Field `cntr` writer - PWM PTC counter"]
+pub type CNTR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC counter"]
+    #[inline(always)]
+    pub fn cntr(&self) -> CNTR_R {
+        CNTR_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC counter"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cntr(&mut self) -> CNTR_W<CNTR_SPEC, 0> {
+        CNTR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC counter register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cntr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cntr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CNTR_SPEC;
+impl crate::RegisterSpec for CNTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cntr::R`](R) reader structure"]
+impl crate::Readable for CNTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cntr::W`](W) writer structure"]
+impl crate::Writable for CNTR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/ctrl.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/ctrl.rs
@@ -1,0 +1,161 @@
+#[doc = "Register `ctrl` reader"]
+pub type R = crate::R<CTRL_SPEC>;
+#[doc = "Register `ctrl` writer"]
+pub type W = crate::W<CTRL_SPEC>;
+#[doc = "Field `en` reader - PWM PTC enable"]
+pub type EN_R = crate::BitReader;
+#[doc = "Field `en` writer - PWM PTC enable"]
+pub type EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `eclk` reader - PWM PTC enable clock"]
+pub type ECLK_R = crate::BitReader;
+#[doc = "Field `eclk` writer - PWM PTC enable clock"]
+pub type ECLK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `nec` reader - PWM PTC nec"]
+pub type NEC_R = crate::BitReader;
+#[doc = "Field `nec` writer - PWM PTC nec"]
+pub type NEC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `oe` reader - PWM PTC oe"]
+pub type OE_R = crate::BitReader;
+#[doc = "Field `oe` writer - PWM PTC oe"]
+pub type OE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `single` reader - PWM PTC single"]
+pub type SINGLE_R = crate::BitReader;
+#[doc = "Field `single` writer - PWM PTC single"]
+pub type SINGLE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `inte` reader - PWM PTC interrupt enable"]
+pub type INTE_R = crate::BitReader;
+#[doc = "Field `inte` writer - PWM PTC interrupt enable"]
+pub type INTE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `int` reader - PWM PTC interrupt"]
+pub type INT_R = crate::BitReader;
+#[doc = "Field `int` writer - PWM PTC interrupt"]
+pub type INT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cntrrst` reader - PWM PTC counter reset"]
+pub type CNTRRST_R = crate::BitReader;
+#[doc = "Field `cntrrst` writer - PWM PTC counter reset"]
+pub type CNTRRST_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `capte` reader - PWM PTC capte"]
+pub type CAPTE_R = crate::BitReader;
+#[doc = "Field `capte` writer - PWM PTC capte"]
+pub type CAPTE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - PWM PTC enable"]
+    #[inline(always)]
+    pub fn en(&self) -> EN_R {
+        EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - PWM PTC enable clock"]
+    #[inline(always)]
+    pub fn eclk(&self) -> ECLK_R {
+        ECLK_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - PWM PTC nec"]
+    #[inline(always)]
+    pub fn nec(&self) -> NEC_R {
+        NEC_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - PWM PTC oe"]
+    #[inline(always)]
+    pub fn oe(&self) -> OE_R {
+        OE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PWM PTC single"]
+    #[inline(always)]
+    pub fn single(&self) -> SINGLE_R {
+        SINGLE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - PWM PTC interrupt enable"]
+    #[inline(always)]
+    pub fn inte(&self) -> INTE_R {
+        INTE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - PWM PTC interrupt"]
+    #[inline(always)]
+    pub fn int(&self) -> INT_R {
+        INT_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - PWM PTC counter reset"]
+    #[inline(always)]
+    pub fn cntrrst(&self) -> CNTRRST_R {
+        CNTRRST_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - PWM PTC capte"]
+    #[inline(always)]
+    pub fn capte(&self) -> CAPTE_R {
+        CAPTE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PWM PTC enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn en(&mut self) -> EN_W<CTRL_SPEC, 0> {
+        EN_W::new(self)
+    }
+    #[doc = "Bit 1 - PWM PTC enable clock"]
+    #[inline(always)]
+    #[must_use]
+    pub fn eclk(&mut self) -> ECLK_W<CTRL_SPEC, 1> {
+        ECLK_W::new(self)
+    }
+    #[doc = "Bit 2 - PWM PTC nec"]
+    #[inline(always)]
+    #[must_use]
+    pub fn nec(&mut self) -> NEC_W<CTRL_SPEC, 2> {
+        NEC_W::new(self)
+    }
+    #[doc = "Bit 3 - PWM PTC oe"]
+    #[inline(always)]
+    #[must_use]
+    pub fn oe(&mut self) -> OE_W<CTRL_SPEC, 3> {
+        OE_W::new(self)
+    }
+    #[doc = "Bit 4 - PWM PTC single"]
+    #[inline(always)]
+    #[must_use]
+    pub fn single(&mut self) -> SINGLE_W<CTRL_SPEC, 4> {
+        SINGLE_W::new(self)
+    }
+    #[doc = "Bit 5 - PWM PTC interrupt enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn inte(&mut self) -> INTE_W<CTRL_SPEC, 5> {
+        INTE_W::new(self)
+    }
+    #[doc = "Bit 6 - PWM PTC interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn int(&mut self) -> INT_W<CTRL_SPEC, 6> {
+        INT_W::new(self)
+    }
+    #[doc = "Bit 7 - PWM PTC counter reset"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cntrrst(&mut self) -> CNTRRST_W<CTRL_SPEC, 7> {
+        CNTRRST_W::new(self)
+    }
+    #[doc = "Bit 8 - PWM PTC capte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn capte(&mut self) -> CAPTE_W<CTRL_SPEC, 8> {
+        CAPTE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC control register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CTRL_SPEC;
+impl crate::RegisterSpec for CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ctrl::R`](R) reader structure"]
+impl crate::Readable for CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ctrl::W`](W) writer structure"]
+impl crate::Writable for CTRL_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/hrc.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/hrc.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `hrc` reader"]
+pub type R = crate::R<HRC_SPEC>;
+#[doc = "Register `hrc` writer"]
+pub type W = crate::W<HRC_SPEC>;
+#[doc = "Field `hrc` reader - PWM PTC duty-cycle value"]
+pub type HRC_R = crate::FieldReader<u32>;
+#[doc = "Field `hrc` writer - PWM PTC duty-cycle value"]
+pub type HRC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC duty-cycle value"]
+    #[inline(always)]
+    pub fn hrc(&self) -> HRC_R {
+        HRC_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC duty-cycle value"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hrc(&mut self) -> HRC_W<HRC_SPEC, 0> {
+        HRC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC duty-cycle register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hrc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hrc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HRC_SPEC;
+impl crate::RegisterSpec for HRC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hrc::R`](R) reader structure"]
+impl crate::Readable for HRC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hrc::W`](W) writer structure"]
+impl crate::Writable for HRC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/lrc.rs
+++ b/jh7110-vf2-12a-pac/src/starfive_jh7110_pwm_0/lrc.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `lrc` reader"]
+pub type R = crate::R<LRC_SPEC>;
+#[doc = "Register `lrc` writer"]
+pub type W = crate::W<LRC_SPEC>;
+#[doc = "Field `lrc` reader - PWM PTC period value"]
+pub type LRC_R = crate::FieldReader<u32>;
+#[doc = "Field `lrc` writer - PWM PTC period value"]
+pub type LRC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC period value"]
+    #[inline(always)]
+    pub fn lrc(&self) -> LRC_R {
+        LRC_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC period value"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lrc(&mut self) -> LRC_W<LRC_SPEC, 0> {
+        LRC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC period register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lrc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lrc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LRC_SPEC;
+impl crate::RegisterSpec for LRC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lrc::R`](R) reader structure"]
+impl crate::Readable for LRC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lrc::W`](W) writer structure"]
+impl crate::Writable for LRC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/Cargo.toml
+++ b/jh7110-vf2-13b-pac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh7110-vf2-13b-pac"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["rmsyn <rmsynchls@gmail.com>"]
 repository = "https://github.com/rmsyn/jh71xx-pac"

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.dts
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.dts
@@ -545,6 +545,15 @@
 			};
 		};
 
+                ptc: pwm@120d0000 {
+                        compatible = "starfive,jh7110-pwm";
+                        reg = <0x0 0x120d0000 0x0 0x10000>;
+                        clocks = <&syscrg 121>;
+                        resets = <&syscrg 108>;
+                        #pwm-cells = <3>;
+                        status = "disabled";
+                };
+
 		syscrg: clock-controller@13020000 {
 			compatible = "starfive,jh7110-syscrg";
 			reg = <0x00 0x13020000 0x00 0x10000>;

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -6452,6 +6452,118 @@
       </addressBlock>
     </peripheral>
     <peripheral>
+      <name>starfive_jh7110_pwm_0</name>
+      <description>From starfive,jh7110-pwm, peripheral generator</description>
+      <baseAddress>0x120D0000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>cntr</name>
+          <description>PTC counter register</description>
+          <addressOffset>0x0</addressOffset>
+          <fields>
+            <field>
+              <name>cntr</name>
+              <description>PWM PTC counter</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hrc</name>
+          <description>PTC duty-cycle register</description>
+          <addressOffset>0x4</addressOffset>
+          <fields>
+            <field>
+              <name>hrc</name>
+              <description>PWM PTC duty-cycle value</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>lrc</name>
+          <description>PTC period register</description>
+          <addressOffset>0x8</addressOffset>
+          <fields>
+            <field>
+              <name>lrc</name>
+              <description>PWM PTC period value</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ctrl</name>
+          <description>PTC control register</description>
+          <addressOffset>0xc</addressOffset>
+          <fields>
+            <field>
+              <name>en</name>
+              <description>PWM PTC enable</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>eclk</name>
+              <description>PWM PTC enable clock</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>nec</name>
+              <description>PWM PTC nec</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>oe</name>
+              <description>PWM PTC oe</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>single</name>
+              <description>PWM PTC single</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>inte</name>
+              <description>PWM PTC interrupt enable</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>int</name>
+              <description>PWM PTC interrupt</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cntrrst</name>
+              <description>PWM PTC counter reset</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>capte</name>
+              <description>PWM PTC capte</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
       <name>starfive_jh7110_syscrg_0</name>
       <description>From starfive,jh7110-syscrg, peripheral generator</description>
       <baseAddress>0x13020000</baseAddress>

--- a/jh7110-vf2-13b-pac/src/lib.rs
+++ b/jh7110-vf2-13b-pac/src/lib.rs
@@ -218,6 +218,52 @@ impl core::fmt::Debug for STARFIVE_JH7110_STG_SYSCON_0 {
 }
 #[doc = "From starfive,jh7110-stg-syscon, peripheral generator"]
 pub mod starfive_jh7110_stg_syscon_0;
+#[doc = "From starfive,jh7110-pwm, peripheral generator"]
+pub struct STARFIVE_JH7110_PWM_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for STARFIVE_JH7110_PWM_0 {}
+impl STARFIVE_JH7110_PWM_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const starfive_jh7110_pwm_0::RegisterBlock = 0x120d_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const starfive_jh7110_pwm_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for STARFIVE_JH7110_PWM_0 {
+    type Target = starfive_jh7110_pwm_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for STARFIVE_JH7110_PWM_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("STARFIVE_JH7110_PWM_0").finish()
+    }
+}
+#[doc = "From starfive,jh7110-pwm, peripheral generator"]
+pub mod starfive_jh7110_pwm_0;
 #[doc = "From starfive,jh7110-syscrg, peripheral generator"]
 pub struct STARFIVE_JH7110_SYSCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -507,6 +553,8 @@ pub struct Peripherals {
     pub STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0,
     #[doc = "STARFIVE_JH7110_STG_SYSCON_0"]
     pub STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0,
+    #[doc = "STARFIVE_JH7110_PWM_0"]
+    pub STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0,
     #[doc = "STARFIVE_JH7110_SYSCRG_0"]
     pub STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0,
     #[doc = "STARFIVE_JH7110_SYS_SYSCON_0"]
@@ -551,6 +599,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0 {
+                _marker: PhantomData,
+            },
+            STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0 {

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0.rs
@@ -1,0 +1,32 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - PTC counter register"]
+    pub cntr: CNTR,
+    #[doc = "0x04 - PTC duty-cycle register"]
+    pub hrc: HRC,
+    #[doc = "0x08 - PTC period register"]
+    pub lrc: LRC,
+    #[doc = "0x0c - PTC control register"]
+    pub ctrl: CTRL,
+}
+#[doc = "cntr (rw) register accessor: PTC counter register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cntr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cntr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`cntr`]
+module"]
+pub type CNTR = crate::Reg<cntr::CNTR_SPEC>;
+#[doc = "PTC counter register"]
+pub mod cntr;
+#[doc = "hrc (rw) register accessor: PTC duty-cycle register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hrc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hrc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hrc`]
+module"]
+pub type HRC = crate::Reg<hrc::HRC_SPEC>;
+#[doc = "PTC duty-cycle register"]
+pub mod hrc;
+#[doc = "lrc (rw) register accessor: PTC period register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lrc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lrc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`lrc`]
+module"]
+pub type LRC = crate::Reg<lrc::LRC_SPEC>;
+#[doc = "PTC period register"]
+pub mod lrc;
+#[doc = "ctrl (rw) register accessor: PTC control register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ctrl`]
+module"]
+pub type CTRL = crate::Reg<ctrl::CTRL_SPEC>;
+#[doc = "PTC control register"]
+pub mod ctrl;

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/cntr.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/cntr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `cntr` reader"]
+pub type R = crate::R<CNTR_SPEC>;
+#[doc = "Register `cntr` writer"]
+pub type W = crate::W<CNTR_SPEC>;
+#[doc = "Field `cntr` reader - PWM PTC counter"]
+pub type CNTR_R = crate::FieldReader<u32>;
+#[doc = "Field `cntr` writer - PWM PTC counter"]
+pub type CNTR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC counter"]
+    #[inline(always)]
+    pub fn cntr(&self) -> CNTR_R {
+        CNTR_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC counter"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cntr(&mut self) -> CNTR_W<CNTR_SPEC, 0> {
+        CNTR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC counter register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`cntr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`cntr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CNTR_SPEC;
+impl crate::RegisterSpec for CNTR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`cntr::R`](R) reader structure"]
+impl crate::Readable for CNTR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`cntr::W`](W) writer structure"]
+impl crate::Writable for CNTR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/ctrl.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/ctrl.rs
@@ -1,0 +1,161 @@
+#[doc = "Register `ctrl` reader"]
+pub type R = crate::R<CTRL_SPEC>;
+#[doc = "Register `ctrl` writer"]
+pub type W = crate::W<CTRL_SPEC>;
+#[doc = "Field `en` reader - PWM PTC enable"]
+pub type EN_R = crate::BitReader;
+#[doc = "Field `en` writer - PWM PTC enable"]
+pub type EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `eclk` reader - PWM PTC enable clock"]
+pub type ECLK_R = crate::BitReader;
+#[doc = "Field `eclk` writer - PWM PTC enable clock"]
+pub type ECLK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `nec` reader - PWM PTC nec"]
+pub type NEC_R = crate::BitReader;
+#[doc = "Field `nec` writer - PWM PTC nec"]
+pub type NEC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `oe` reader - PWM PTC oe"]
+pub type OE_R = crate::BitReader;
+#[doc = "Field `oe` writer - PWM PTC oe"]
+pub type OE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `single` reader - PWM PTC single"]
+pub type SINGLE_R = crate::BitReader;
+#[doc = "Field `single` writer - PWM PTC single"]
+pub type SINGLE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `inte` reader - PWM PTC interrupt enable"]
+pub type INTE_R = crate::BitReader;
+#[doc = "Field `inte` writer - PWM PTC interrupt enable"]
+pub type INTE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `int` reader - PWM PTC interrupt"]
+pub type INT_R = crate::BitReader;
+#[doc = "Field `int` writer - PWM PTC interrupt"]
+pub type INT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cntrrst` reader - PWM PTC counter reset"]
+pub type CNTRRST_R = crate::BitReader;
+#[doc = "Field `cntrrst` writer - PWM PTC counter reset"]
+pub type CNTRRST_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `capte` reader - PWM PTC capte"]
+pub type CAPTE_R = crate::BitReader;
+#[doc = "Field `capte` writer - PWM PTC capte"]
+pub type CAPTE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - PWM PTC enable"]
+    #[inline(always)]
+    pub fn en(&self) -> EN_R {
+        EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - PWM PTC enable clock"]
+    #[inline(always)]
+    pub fn eclk(&self) -> ECLK_R {
+        ECLK_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - PWM PTC nec"]
+    #[inline(always)]
+    pub fn nec(&self) -> NEC_R {
+        NEC_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - PWM PTC oe"]
+    #[inline(always)]
+    pub fn oe(&self) -> OE_R {
+        OE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PWM PTC single"]
+    #[inline(always)]
+    pub fn single(&self) -> SINGLE_R {
+        SINGLE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - PWM PTC interrupt enable"]
+    #[inline(always)]
+    pub fn inte(&self) -> INTE_R {
+        INTE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - PWM PTC interrupt"]
+    #[inline(always)]
+    pub fn int(&self) -> INT_R {
+        INT_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - PWM PTC counter reset"]
+    #[inline(always)]
+    pub fn cntrrst(&self) -> CNTRRST_R {
+        CNTRRST_R::new(((self.bits >> 7) & 1) != 0)
+    }
+    #[doc = "Bit 8 - PWM PTC capte"]
+    #[inline(always)]
+    pub fn capte(&self) -> CAPTE_R {
+        CAPTE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PWM PTC enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn en(&mut self) -> EN_W<CTRL_SPEC, 0> {
+        EN_W::new(self)
+    }
+    #[doc = "Bit 1 - PWM PTC enable clock"]
+    #[inline(always)]
+    #[must_use]
+    pub fn eclk(&mut self) -> ECLK_W<CTRL_SPEC, 1> {
+        ECLK_W::new(self)
+    }
+    #[doc = "Bit 2 - PWM PTC nec"]
+    #[inline(always)]
+    #[must_use]
+    pub fn nec(&mut self) -> NEC_W<CTRL_SPEC, 2> {
+        NEC_W::new(self)
+    }
+    #[doc = "Bit 3 - PWM PTC oe"]
+    #[inline(always)]
+    #[must_use]
+    pub fn oe(&mut self) -> OE_W<CTRL_SPEC, 3> {
+        OE_W::new(self)
+    }
+    #[doc = "Bit 4 - PWM PTC single"]
+    #[inline(always)]
+    #[must_use]
+    pub fn single(&mut self) -> SINGLE_W<CTRL_SPEC, 4> {
+        SINGLE_W::new(self)
+    }
+    #[doc = "Bit 5 - PWM PTC interrupt enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn inte(&mut self) -> INTE_W<CTRL_SPEC, 5> {
+        INTE_W::new(self)
+    }
+    #[doc = "Bit 6 - PWM PTC interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn int(&mut self) -> INT_W<CTRL_SPEC, 6> {
+        INT_W::new(self)
+    }
+    #[doc = "Bit 7 - PWM PTC counter reset"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cntrrst(&mut self) -> CNTRRST_W<CTRL_SPEC, 7> {
+        CNTRRST_W::new(self)
+    }
+    #[doc = "Bit 8 - PWM PTC capte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn capte(&mut self) -> CAPTE_W<CTRL_SPEC, 8> {
+        CAPTE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC control register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CTRL_SPEC;
+impl crate::RegisterSpec for CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ctrl::R`](R) reader structure"]
+impl crate::Readable for CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ctrl::W`](W) writer structure"]
+impl crate::Writable for CTRL_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/hrc.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/hrc.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `hrc` reader"]
+pub type R = crate::R<HRC_SPEC>;
+#[doc = "Register `hrc` writer"]
+pub type W = crate::W<HRC_SPEC>;
+#[doc = "Field `hrc` reader - PWM PTC duty-cycle value"]
+pub type HRC_R = crate::FieldReader<u32>;
+#[doc = "Field `hrc` writer - PWM PTC duty-cycle value"]
+pub type HRC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC duty-cycle value"]
+    #[inline(always)]
+    pub fn hrc(&self) -> HRC_R {
+        HRC_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC duty-cycle value"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hrc(&mut self) -> HRC_W<HRC_SPEC, 0> {
+        HRC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC duty-cycle register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hrc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hrc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HRC_SPEC;
+impl crate::RegisterSpec for HRC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hrc::R`](R) reader structure"]
+impl crate::Readable for HRC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hrc::W`](W) writer structure"]
+impl crate::Writable for HRC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/lrc.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pwm_0/lrc.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `lrc` reader"]
+pub type R = crate::R<LRC_SPEC>;
+#[doc = "Register `lrc` writer"]
+pub type W = crate::W<LRC_SPEC>;
+#[doc = "Field `lrc` reader - PWM PTC period value"]
+pub type LRC_R = crate::FieldReader<u32>;
+#[doc = "Field `lrc` writer - PWM PTC period value"]
+pub type LRC_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - PWM PTC period value"]
+    #[inline(always)]
+    pub fn lrc(&self) -> LRC_R {
+        LRC_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - PWM PTC period value"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lrc(&mut self) -> LRC_W<LRC_SPEC, 0> {
+        LRC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PTC period register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lrc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lrc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LRC_SPEC;
+impl crate::RegisterSpec for LRC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lrc::R`](R) reader structure"]
+impl crate::Readable for LRC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lrc::W`](W) writer structure"]
+impl crate::Writable for LRC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}


### PR DESCRIPTION
Updates the `cmsis-svd-generator` submodule, and adds an entry for the PMU in VisionFive2 DTS files.

PWM entry comes from the WIP upstream efforts from StarFive:

<https://patchwork.kernel.org/project/linux-riscv/patch/20230825081328.204442-4-william.qiu@starfivetech.com/>

Bumps the patch release version to `v0.1.1` to include change to PMU registers, and the addition of PWM registers.