### PR TITLE
pac: add ARM PL022 SPI register definitions

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -180,6 +180,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>snps_designware_i2c_1</name>
@@ -190,6 +1208,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>snps_designware_i2c_2</name>
@@ -200,6 +2236,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_pl022_0</name>
@@ -210,6 +3264,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_0</name>
@@ -240,6 +3692,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_1</name>
@@ -260,6 +4110,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_2</name>
@@ -5628,6 +9876,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>snps_designware_i2c_4</name>
@@ -5638,6 +10904,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>snps_designware_i2c_5</name>
@@ -5648,6 +11932,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>snps_designware_i2c_6</name>
@@ -5658,6 +12960,1024 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>con</name>
+          <description>DesignWare I2C CON</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>master</name>
+              <description>I2C Master Connection - 0: Slave, 1: Master</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>speed</name>
+              <description>I2C Speed - 01: Standard, 10: Fast, 11: High</description>
+              <bitRange>[2:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_10bitaddr</name>
+              <description>I2C Slave 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_10bitaddr</name>
+              <description>I2C Master 10-bit Address - 0: False, 1: True</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_en</name>
+              <description>I2C Restart Enable - 0: False, 1: True</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_disable</name>
+              <description>I2C Slave Disable - 0: False, 1: True</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det_ifaddressed</name>
+              <description>I2C Stop DET If Addressed - 0: False, 1: True</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty_ctrl</name>
+              <description>I2C TX Empty Control - 0: False, 1: True</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_fifo_full_hld_ctrl</name>
+              <description>I2C RX FIFO Full Hold Control - 0: False, 1: True</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>bus_clear_ctrl</name>
+              <description>I2C Bus Clear Control - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tar</name>
+          <description>DesignWare I2C TAR</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tar</name>
+              <description>tar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sar</name>
+          <description>DesignWare I2C SAR</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sar</name>
+              <description>sar</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>data_cmd</name>
+          <description>DesignWare I2C Data Command</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>dat</name>
+              <description>Data Command Data Byte</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>first_data_byte</name>
+              <description>Data Command First Data Byte - 0: False, 1: True</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_hcnt</name>
+          <description>DesignWare I2C SS SCL HCNT</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_hcnt</name>
+              <description>ss_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ss_scl_lcnt</name>
+          <description>DesignWare I2C SS SCL LCNT</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ss_scl_lcnt</name>
+              <description>ss_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_hcnt</name>
+          <description>DesignWare I2C FS SCL HCNT</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_hcnt</name>
+              <description>fs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>fs_scl_lcnt</name>
+          <description>DesignWare I2C FS SCL LCNT</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>fs_scl_lcnt</name>
+              <description>fs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_hcnt</name>
+          <description>DesignWare I2C HS SCL HCNT</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_hcnt</name>
+              <description>hs_scl_hcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hs_scl_lcnt</name>
+          <description>DesignWare I2C HS SCL LCNT</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hs_scl_lcnt</name>
+              <description>hs_scl_lcnt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_stat</name>
+          <description>DesignWare I2C Interrupt Status</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>intr_mask</name>
+          <description>DesignWare I2C Interrupt Mask</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>raw_intr_stat</name>
+          <description>DesignWare I2C Raw Interrupt Status</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rx_tl</name>
+          <description>DesignWare I2C RX TL</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_tl</name>
+              <description>rx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_tl</name>
+          <description>DesignWare I2C TX TL</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>tx_tl</name>
+              <description>tx_tl</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_intr</name>
+          <description>DesignWare I2C Clear Interrrupt</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rx_under</name>
+              <description>RX FIFO Underrun</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_over</name>
+              <description>RX FIFO Overrun</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_full</name>
+              <description>RX FIFO Full</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_over</name>
+              <description>TX FIFO Overrun</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_empty</name>
+              <description>TX FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rd_req</name>
+              <description>Read Request</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tx_abrt</name>
+              <description>TX Abort</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rx_done</name>
+              <description>RX Done</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>activity</name>
+              <description>Activity</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop_det</name>
+              <description>Stop DET</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>start_det</name>
+              <description>Start DET</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gen_call</name>
+              <description>General Call</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart_det</name>
+              <description>Restart DET</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mst_on_hold</name>
+              <description>Master on Hold</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_under</name>
+          <description>DesignWare I2C Clear RX Underrun</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_under</name>
+              <description>clr_rx_under</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_over</name>
+          <description>DesignWare I2C Clear RX Overrun</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_over</name>
+              <description>clr_rx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_over</name>
+          <description>DesignWare I2C Clear TX Overrun</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_over</name>
+              <description>clr_tx_over</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rd_req</name>
+          <description>DesignWare I2C Clear Read Request</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rd_req</name>
+              <description>clr_rd_req</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_tx_abrt</name>
+          <description>DesignWare I2C Clear TX Abort</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_tx_abrt</name>
+              <description>clr_tx_abrt</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_rx_done</name>
+          <description>DesignWare I2C Clear RX Done</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_rx_done</name>
+              <description>clr_rx_done</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_activity</name>
+          <description>DesignWare I2C Clear Activity</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_activity</name>
+              <description>clr_activity</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_stop_det</name>
+          <description>DesignWare I2C Clear Stop DET</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_stop_det</name>
+              <description>clr_stop_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_start_det</name>
+          <description>DesignWare I2C Clear Start DET</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_start_det</name>
+              <description>clr_start_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_gen_call</name>
+          <description>DesignWare I2C Clear General Call</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_gen_call</name>
+              <description>clr_gen_call</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable</name>
+          <description>DesignWare I2C Enable</description>
+          <addressOffset>0x6c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>abort</name>
+              <description>abort</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>status</name>
+          <description>DesignWare I2C Status</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>txflr</name>
+          <description>DesignWare I2C TX Failure</description>
+          <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>txflr</name>
+              <description>txflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rxflr</name>
+          <description>DesignWare I2C RX Failure</description>
+          <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rxflr</name>
+              <description>rxflr</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sda_hold</name>
+          <description>DesignWare I2C SDA Hold</description>
+          <addressOffset>0x7c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sda_hold</name>
+              <description>sda_hold</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tx_abrt_source</name>
+          <description>DesignWare I2C TX Abort Source</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>b7_addr_noack</name>
+              <description>b7_addr_noack</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr1_noack</name>
+              <description>b10_addr1_noack</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_addr2_noack</name>
+              <description>b10_addr2_noack</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txdata_noack</name>
+              <description>txdata_noack</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_noack</name>
+              <description>gcall_noack</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>gcall_read</name>
+              <description>gcall_read</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_ackdet</name>
+              <description>sbyte_ackdet</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sbyte_norstrt</name>
+              <description>sbyte_norstrt</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>b10_rd_norstrt</name>
+              <description>b10_rd_norstrt</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>master_dis</name>
+              <description>master_dis</description>
+              <bitRange>[11:11]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>arb_lost</name>
+              <description>arb_lost</description>
+              <bitRange>[12:12]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_flush_txfifo</name>
+              <description>slave_flush_txfifo</description>
+              <bitRange>[13:13]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_arblost</name>
+              <description>slave_arblost</description>
+              <bitRange>[14:14]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>slave_rd_intx</name>
+              <description>slave_rd_intx</description>
+              <bitRange>[15:15]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>enable_status</name>
+          <description>DesignWare I2C Enable Status</description>
+          <addressOffset>0x9c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>activity</name>
+              <description>activity</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>tfe</name>
+              <description>tfe</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rfne</name>
+              <description>rfne</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>master_activity</name>
+              <description>master_activity</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>slave_activity</name>
+              <description>slave_activity</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>clr_restart_det</name>
+          <description>DesignWare I2C Clear Restart DET</description>
+          <addressOffset>0xa8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>clr_restart_det</name>
+              <description>clr_restart_det</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_param_1</name>
+          <description>DesignWare I2C Compatibility Parameter 1</description>
+          <addressOffset>0xf4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>speed</name>
+              <description>Speed mask - 01: Standard, 10: Full, 11: High</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_version</name>
+          <description>DesignWare I2C Compatibility Version</description>
+          <addressOffset>0xf8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_version</name>
+              <description>comp_version</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>comp_type</name>
+          <description>DesignWare I2C Compatibility Type</description>
+          <addressOffset>0xfc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>comp_type</name>
+              <description>comp_type</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_pl022_3</name>
@@ -5668,6 +13988,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_3</name>
@@ -5688,6 +14406,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_4</name>
@@ -5708,6 +14824,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_5</name>
@@ -5728,6 +15242,404 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
     </peripheral>
     <peripheral>
       <name>arm_primecell_6</name>

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_0/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_1/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_2/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_3/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_4/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_5/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cpsr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cr0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cr1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_dmacr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_dr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_icr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_imsc.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_mis.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id0.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id1.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id2.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id3.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_ris.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_sr.rs
+++ b/jh7110-vf2-12a-pac/src/arm_pl022_6/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-12a-pac/src/lib.rs
+++ b/jh7110-vf2-12a-pac/src/lib.rs
@@ -80,6 +80,282 @@ impl core::fmt::Debug for SIFIVE_CLINT0_0 {
 }
 #[doc = "From sifive,clint0, peripheral generator"]
 pub mod sifive_clint0_0;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_0 {}
+impl SNPS_DESIGNWARE_I2C_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_0::RegisterBlock = 0x1003_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_0 {
+    type Target = snps_designware_i2c_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_0").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_0;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_1 {}
+impl SNPS_DESIGNWARE_I2C_1 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_1::RegisterBlock = 0x1004_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_1::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_1 {
+    type Target = snps_designware_i2c_1::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_1").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_1;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_2 {}
+impl SNPS_DESIGNWARE_I2C_2 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_2::RegisterBlock = 0x1005_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_2::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_2 {
+    type Target = snps_designware_i2c_2::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_2").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_2;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_0 {}
+impl ARM_PL022_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_0::RegisterBlock = 0x1006_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_0 {
+    type Target = arm_pl022_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_0").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_0;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_1 {}
+impl ARM_PL022_1 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_1::RegisterBlock = 0x1007_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_1::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_1 {
+    type Target = arm_pl022_1::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_1").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_1;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_2 {}
+impl ARM_PL022_2 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_2::RegisterBlock = 0x1008_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_2::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_2 {
+    type Target = arm_pl022_2::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_2").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_2;
 #[doc = "From starfive,jh7110-stgcrg, peripheral generator"]
 pub struct STARFIVE_JH7110_STGCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -172,6 +448,374 @@ impl core::fmt::Debug for STARFIVE_JH7110_STG_SYSCON_0 {
 }
 #[doc = "From starfive,jh7110-stg-syscon, peripheral generator"]
 pub mod starfive_jh7110_stg_syscon_0;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_3 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_3 {}
+impl SNPS_DESIGNWARE_I2C_3 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_3::RegisterBlock = 0x1203_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_3::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_3 {
+    type Target = snps_designware_i2c_3::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_3").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_3;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_4 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_4 {}
+impl SNPS_DESIGNWARE_I2C_4 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_4::RegisterBlock = 0x1204_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_4::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_4 {
+    type Target = snps_designware_i2c_4::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_4").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_4;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_5 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_5 {}
+impl SNPS_DESIGNWARE_I2C_5 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_5::RegisterBlock = 0x1205_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_5::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_5 {
+    type Target = snps_designware_i2c_5::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_5 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_5").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_5;
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub struct SNPS_DESIGNWARE_I2C_6 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SNPS_DESIGNWARE_I2C_6 {}
+impl SNPS_DESIGNWARE_I2C_6 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const snps_designware_i2c_6::RegisterBlock = 0x1206_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const snps_designware_i2c_6::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for SNPS_DESIGNWARE_I2C_6 {
+    type Target = snps_designware_i2c_6::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_6 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SNPS_DESIGNWARE_I2C_6").finish()
+    }
+}
+#[doc = "From snps,designware-i2c, peripheral generator"]
+pub mod snps_designware_i2c_6;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_3 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_3 {}
+impl ARM_PL022_3 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_3::RegisterBlock = 0x1207_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_3::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_3 {
+    type Target = arm_pl022_3::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_3").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_3;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_4 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_4 {}
+impl ARM_PL022_4 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_4::RegisterBlock = 0x1208_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_4::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_4 {
+    type Target = arm_pl022_4::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_4").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_4;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_5 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_5 {}
+impl ARM_PL022_5 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_5::RegisterBlock = 0x1209_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_5::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_5 {
+    type Target = arm_pl022_5::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_5 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_5").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_5;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_6 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_6 {}
+impl ARM_PL022_6 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_6::RegisterBlock = 0x120a_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_6::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_6 {
+    type Target = arm_pl022_6::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_6 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_6").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_6;
 #[doc = "From starfive,jh7110-pwm, peripheral generator"]
 pub struct STARFIVE_JH7110_PWM_0 {
     _marker: PhantomData<*const ()>,
@@ -593,10 +1237,38 @@ static mut DEVICE_PERIPHERALS: bool = false;
 pub struct Peripherals {
     #[doc = "SIFIVE_CLINT0_0"]
     pub SIFIVE_CLINT0_0: SIFIVE_CLINT0_0,
+    #[doc = "SNPS_DESIGNWARE_I2C_0"]
+    pub SNPS_DESIGNWARE_I2C_0: SNPS_DESIGNWARE_I2C_0,
+    #[doc = "SNPS_DESIGNWARE_I2C_1"]
+    pub SNPS_DESIGNWARE_I2C_1: SNPS_DESIGNWARE_I2C_1,
+    #[doc = "SNPS_DESIGNWARE_I2C_2"]
+    pub SNPS_DESIGNWARE_I2C_2: SNPS_DESIGNWARE_I2C_2,
+    #[doc = "ARM_PL022_0"]
+    pub ARM_PL022_0: ARM_PL022_0,
+    #[doc = "ARM_PL022_1"]
+    pub ARM_PL022_1: ARM_PL022_1,
+    #[doc = "ARM_PL022_2"]
+    pub ARM_PL022_2: ARM_PL022_2,
     #[doc = "STARFIVE_JH7110_STGCRG_0"]
     pub STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0,
     #[doc = "STARFIVE_JH7110_STG_SYSCON_0"]
     pub STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0,
+    #[doc = "SNPS_DESIGNWARE_I2C_3"]
+    pub SNPS_DESIGNWARE_I2C_3: SNPS_DESIGNWARE_I2C_3,
+    #[doc = "SNPS_DESIGNWARE_I2C_4"]
+    pub SNPS_DESIGNWARE_I2C_4: SNPS_DESIGNWARE_I2C_4,
+    #[doc = "SNPS_DESIGNWARE_I2C_5"]
+    pub SNPS_DESIGNWARE_I2C_5: SNPS_DESIGNWARE_I2C_5,
+    #[doc = "SNPS_DESIGNWARE_I2C_6"]
+    pub SNPS_DESIGNWARE_I2C_6: SNPS_DESIGNWARE_I2C_6,
+    #[doc = "ARM_PL022_3"]
+    pub ARM_PL022_3: ARM_PL022_3,
+    #[doc = "ARM_PL022_4"]
+    pub ARM_PL022_4: ARM_PL022_4,
+    #[doc = "ARM_PL022_5"]
+    pub ARM_PL022_5: ARM_PL022_5,
+    #[doc = "ARM_PL022_6"]
+    pub ARM_PL022_6: ARM_PL022_6,
     #[doc = "STARFIVE_JH7110_PWM_0"]
     pub STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0,
     #[doc = "STARFIVE_JH7110_SYSCRG_0"]
@@ -640,10 +1312,52 @@ impl Peripherals {
             SIFIVE_CLINT0_0: SIFIVE_CLINT0_0 {
                 _marker: PhantomData,
             },
+            SNPS_DESIGNWARE_I2C_0: SNPS_DESIGNWARE_I2C_0 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_1: SNPS_DESIGNWARE_I2C_1 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_2: SNPS_DESIGNWARE_I2C_2 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_0: ARM_PL022_0 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_1: ARM_PL022_1 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_2: ARM_PL022_2 {
+                _marker: PhantomData,
+            },
             STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_STG_SYSCON_0: STARFIVE_JH7110_STG_SYSCON_0 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_3: SNPS_DESIGNWARE_I2C_3 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_4: SNPS_DESIGNWARE_I2C_4 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_5: SNPS_DESIGNWARE_I2C_5 {
+                _marker: PhantomData,
+            },
+            SNPS_DESIGNWARE_I2C_6: SNPS_DESIGNWARE_I2C_6 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_3: ARM_PL022_3 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_4: ARM_PL022_4 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_5: ARM_PL022_5 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_6: ARM_PL022_6 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0 {

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.dts
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.dts
@@ -1,10 +1,10 @@
 /dts-v1/;
 
 / {
-	model = "StarFive VisionFive 2 v1.3b";
 	compatible = "starfive,visionfive-2-v1.3b", "starfive,jh7110";
 	#address-cells = <0x02>;
 	#size-cells = <0x02>;
+	model = "StarFive VisionFive 2 v1.3B";
 
 	cpus {
 		#address-cells = <0x01>;
@@ -21,13 +21,13 @@
 			next-level-cache = <&ccache>;
 			riscv,isa = "rv64imac_zba_zbb";
 			status = "disabled";
-			phandle = <0x02>;
+			phandle = <0x05>;
 
 			cpu0_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
 				#interrupt-cells = <0x01>;
-				phandle = <0x07>;
+				phandle = <0x0d>;
 			};
 		};
 
@@ -49,13 +49,18 @@
 			next-level-cache = <&ccache>;
 			riscv,isa = "rv64imafdc_zba_zbb";
 			tlb-split;
-			phandle = <0x03>;
+			operating-points-v2 = <&cpu_opp>;
+			clocks = <&syscrg 0x01>;
+			clock-names = "cpu";
+			#cooling-cells = <0x02>;
+			cpu-supply = <&vdd_cpu>;
+			phandle = <0x06>;
 
 			cpu1_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
 				#interrupt-cells = <0x01>;
-				phandle = <0x08>;
+				phandle = <0x0e>;
 			};
 		};
 
@@ -77,13 +82,18 @@
 			next-level-cache = <&ccache>;
 			riscv,isa = "rv64imafdc_zba_zbb";
 			tlb-split;
-			phandle = <0x04>;
+			operating-points-v2 = <&cpu_opp>;
+			clocks = <&syscrg 0x01>;
+			clock-names = "cpu";
+			#cooling-cells = <0x02>;
+			cpu-supply = <&vdd_cpu>;
+			phandle = <0x07>;
 
 			cpu2_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
 				#interrupt-cells = <0x01>;
-				phandle = <0x09>;
+				phandle = <0x0f>;
 			};
 		};
 
@@ -105,13 +115,18 @@
 			next-level-cache = <&ccache>;
 			riscv,isa = "rv64imafdc_zba_zbb";
 			tlb-split;
-			phandle = <0x05>;
+			operating-points-v2 = <&cpu_opp>;
+			clocks = <&syscrg 0x01>;
+			clock-names = "cpu";
+			#cooling-cells = <0x02>;
+			cpu-supply = <&vdd_cpu>;
+			phandle = <0x08>;
 
 			cpu3_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
 				#interrupt-cells = <0x01>;
-				phandle = <0x0a>;
+				phandle = <0x10>;
 			};
 		};
 
@@ -133,70 +148,28 @@
 			next-level-cache = <&ccache>;
 			riscv,isa = "rv64imafdc_zba_zbb";
 			tlb-split;
-			phandle = <0x06>;
+			operating-points-v2 = <&cpu_opp>;
+			clocks = <&syscrg 0x01>;
+			clock-names = "cpu";
+			#cooling-cells = <0x02>;
+			cpu-supply = <&vdd_cpu>;
+			phandle = <0x09>;
 
 			cpu4_intc: interrupt-controller {
 				compatible = "riscv,cpu-intc";
 				interrupt-controller;
 				#interrupt-cells = <0x01>;
-				phandle = <0x0b>;
-			};
-		};
-
-		cpu-map {
-
-			cluster0 {
-
-				core0 {
-					cpu = <&S7_0>;
-				};
-
-				core1 {
-					cpu = <&U74_1>;
-				};
-
-				core2 {
-					cpu = <&U74_2>;
-				};
-
-				core3 {
-					cpu = <&U74_3>;
-				};
-
-				core4 {
-					cpu = <&U74_4>;
-				};
+				phandle = <0x11>;
 			};
 		};
 	};
 
-	timer {
-		compatible = "riscv,timer";
-		interrupts-extended = <&cpu0_intc 0x05>, <&cpu1_intc 0x05>, <&cpu2_intc 0x05>, <&cpu3_intc 0x05>, <&cpu4_intc 0x05>;
-	};
-
-	osc: oscillator {
+	dvp_clk: dvp-clock {
 		compatible = "fixed-clock";
-		clock-output-names = "osc";
+		clock-output-names = "dvp_clk";
 		#clock-cells = <0x00>;
-		clock-frequency = <0x16e3600>;
-		phandle = <0x13>;
-	};
-
-	rtc_osc: rtc-oscillator {
-		compatible = "fixed-clock";
-		clock-output-names = "rtc_osc";
-		#clock-cells = <0x00>;
-		clock-frequency = <0x8000>;
-		phandle = <0x25>;
-	};
-
-	gmac0_rmii_refin: gmac0-rmii-refin-clock {
-		compatible = "fixed-clock";
-		clock-output-names = "gmac0_rmii_refin";
-		#clock-cells = <0x00>;
-		clock-frequency = <0x2faf080>;
-		phandle = <0x26>;
+		clock-frequency = <0x46cf710>;
+		phandle = <0x35>;
 	};
 
 	gmac0_rgmii_rxin: gmac0-rgmii-rxin-clock {
@@ -204,15 +177,15 @@
 		clock-output-names = "gmac0_rgmii_rxin";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x7735940>;
-		phandle = <0x27>;
+		phandle = <0x33>;
 	};
 
-	gmac1_rmii_refin: gmac1-rmii-refin-clock {
+	gmac0_rmii_refin: gmac0-rmii-refin-clock {
 		compatible = "fixed-clock";
-		clock-output-names = "gmac1_rmii_refin";
+		clock-output-names = "gmac0_rmii_refin";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x2faf080>;
-		phandle = <0x14>;
+		phandle = <0x32>;
 	};
 
 	gmac1_rgmii_rxin: gmac1-rgmii-rxin-clock {
@@ -220,23 +193,23 @@
 		clock-output-names = "gmac1_rgmii_rxin";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x7735940>;
-		phandle = <0x15>;
+		phandle = <0x20>;
 	};
 
-	i2stx_bclk_ext: i2stx-bclk-ext-clock {
+	gmac1_rmii_refin: gmac1-rmii-refin-clock {
 		compatible = "fixed-clock";
-		clock-output-names = "i2stx_bclk_ext";
+		clock-output-names = "gmac1_rmii_refin";
 		#clock-cells = <0x00>;
-		clock-frequency = <0xbb8000>;
-		phandle = <0x16>;
+		clock-frequency = <0x2faf080>;
+		phandle = <0x1f>;
 	};
 
-	i2stx_lrck_ext: i2stx-lrck-ext-clock {
+	hdmitx0_pixelclk: hdmitx0-pixel-clock {
 		compatible = "fixed-clock";
-		clock-output-names = "i2stx_lrck_ext";
+		clock-output-names = "hdmitx0_pixelclk";
 		#clock-cells = <0x00>;
-		clock-frequency = <0x2ee00>;
-		phandle = <0x17>;
+		clock-frequency = <0x11b3dc40>;
+		phandle = <0x37>;
 	};
 
 	i2srx_bclk_ext: i2srx-bclk-ext-clock {
@@ -244,7 +217,7 @@
 		clock-output-names = "i2srx_bclk_ext";
 		#clock-cells = <0x00>;
 		clock-frequency = <0xbb8000>;
-		phandle = <0x18>;
+		phandle = <0x23>;
 	};
 
 	i2srx_lrck_ext: i2srx-lrck-ext-clock {
@@ -252,15 +225,23 @@
 		clock-output-names = "i2srx_lrck_ext";
 		#clock-cells = <0x00>;
 		clock-frequency = <0x2ee00>;
-		phandle = <0x19>;
+		phandle = <0x24>;
 	};
 
-	tdm_ext: tdm-ext-clock {
+	i2stx_bclk_ext: i2stx-bclk-ext-clock {
 		compatible = "fixed-clock";
-		clock-output-names = "tdm_ext";
+		clock-output-names = "i2stx_bclk_ext";
 		#clock-cells = <0x00>;
-		clock-frequency = <0x2ee0000>;
-		phandle = <0x1a>;
+		clock-frequency = <0xbb8000>;
+		phandle = <0x21>;
+	};
+
+	i2stx_lrck_ext: i2stx-lrck-ext-clock {
+		compatible = "fixed-clock";
+		clock-output-names = "i2stx_lrck_ext";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x2ee00>;
+		phandle = <0x22>;
 	};
 
 	mclk_ext: mclk-ext-clock {
@@ -268,15 +249,39 @@
 		clock-output-names = "mclk_ext";
 		#clock-cells = <0x00>;
 		clock-frequency = <0xbb8000>;
-		phandle = <0x1b>;
+		phandle = <0x25>;
+	};
+
+	osc: oscillator {
+		compatible = "fixed-clock";
+		clock-output-names = "osc";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x16e3600>;
+		phandle = <0x1c>;
+	};
+
+	rtc_osc: rtc-oscillator {
+		compatible = "fixed-clock";
+		clock-output-names = "rtc_osc";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x8000>;
+		phandle = <0x34>;
 	};
 
 	stmmac_axi_setup: stmmac-axi-config {
 		snps,lpi_en;
-		snps,wr_osr_lmt = <0x04>;
-		snps,rd_osr_lmt = <0x04>;
+		snps,wr_osr_lmt = <0x0f>;
+		snps,rd_osr_lmt = <0x0f>;
 		snps,blen = <0x100 0x80 0x40 0x20 0x00 0x00 0x00>;
-		phandle = <0x21>;
+		phandle = <0x2e>;
+	};
+
+	tdm_ext: tdm-ext-clock {
+		compatible = "fixed-clock";
+		clock-output-names = "tdm_ext";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x2ee0000>;
+		phandle = <0x16>;
 	};
 
 	soc {
@@ -292,17 +297,6 @@
 			interrupts-extended = <&cpu0_intc 0x03>, <&cpu0_intc 0x07>, <&cpu1_intc 0x03>, <&cpu1_intc 0x07>, <&cpu2_intc 0x03>, <&cpu2_intc 0x07>, <&cpu3_intc 0x03>, <&cpu3_intc 0x07>, <&cpu4_intc 0x03>, <&cpu4_intc 0x07>;
 		};
 
-		plic: interrupt-controller@c000000 {
-			compatible = "starfive,jh7110-plic", "sifive,plic0";
-			reg = <0x00 0xc000000 0x00 0x4000000>;
-			interrupts-extended = <&cpu0_intc 0x0b>, <&cpu1_intc 0x0b>, <&cpu1_intc 0x09>, <&cpu2_intc 0x0b>, <&cpu2_intc 0x09>, <&cpu3_intc 0x0b>, <&cpu3_intc 0x09>, <&cpu4_intc 0x0b>, <&cpu4_intc 0x09>;
-			interrupt-controller;
-			#interrupt-cells = <0x01>;
-			#address-cells = <0x00>;
-			riscv,ndev = <0x88>;
-			phandle = <0x0c>;
-		};
-
 		ccache: cache-controller@2010000 {
 			compatible = "starfive,jh7110-ccache", "sifive,ccache0", "cache";
 			reg = <0x00 0x2010000 0x00 0x4000>;
@@ -315,19 +309,27 @@
 			phandle = <0x01>;
 		};
 
+		plic: interrupt-controller@c000000 {
+			compatible = "starfive,jh7110-plic", "sifive,plic";
+			reg = <0x00 0xc000000 0x00 0x4000000>;
+			interrupts-extended = <&cpu0_intc 0x0b>, <&cpu1_intc 0x0b>, <&cpu1_intc 0x09>, <&cpu2_intc 0x0b>, <&cpu2_intc 0x09>, <&cpu3_intc 0x0b>, <&cpu3_intc 0x09>, <&cpu4_intc 0x0b>, <&cpu4_intc 0x09>;
+			interrupt-controller;
+			#interrupt-cells = <0x01>;
+			#address-cells = <0x00>;
+			riscv,ndev = <0x88>;
+			phandle = <0x0c>;
+		};
+
 		uart0: serial@10000000 {
 			compatible = "snps,dw-apb-uart";
 			reg = <0x00 0x10000000 0x00 0x10000>;
 			clocks = <&syscrg 0x92>, <&syscrg 0x91>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x53>, <&syscrg 0x54>;
+			resets = <&syscrg 0x53>;
 			interrupts = <0x20>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
 			status = "okay";
-			reg-offset = <0x00>;
-			current-speed = <0x1c200>;
-			clock-frequency = <0x16e3600>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&uart0_pins>;
 		};
@@ -337,7 +339,7 @@
 			reg = <0x00 0x10010000 0x00 0x10000>;
 			clocks = <&syscrg 0x94>, <&syscrg 0x93>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x55>, <&syscrg 0x56>;
+			resets = <&syscrg 0x55>;
 			interrupts = <0x21>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
@@ -349,7 +351,7 @@
 			reg = <0x00 0x10020000 0x00 0x10000>;
 			clocks = <&syscrg 0x96>, <&syscrg 0x95>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x57>, <&syscrg 0x58>;
+			resets = <&syscrg 0x57>;
 			interrupts = <0x22>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
@@ -404,18 +406,129 @@
 			pinctrl-0 = <&i2c2_pins>;
 		};
 
+		spi0: spi@10060000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x10060000 0x00 0x10000>;
+			clocks = <&syscrg 0x83>, <&syscrg 0x83>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x45>;
+			interrupts = <0x26>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_pins>;
+
+			spi_dev0: spi@0 {
+				compatible = "rohm,dh2228fv";
+				reg = <0x00>;
+				spi-max-frequency = <0x989680>;
+			};
+		};
+
+		spi1: spi@10070000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x10070000 0x00 0x10000>;
+			clocks = <&syscrg 0x84>, <&syscrg 0x84>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x46>;
+			interrupts = <0x27>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "disabled";
+		};
+
+		spi2: spi@10080000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x10080000 0x00 0x10000>;
+			clocks = <&syscrg 0x85>, <&syscrg 0x85>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x47>;
+			interrupts = <0x28>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "disabled";
+		};
+
+		tdm: tdm@10090000 {
+			compatible = "starfive,jh7110-tdm";
+			reg = <0x00 0x10090000 0x00 0x1000>;
+			clocks = <&syscrg 0xb8>, <&syscrg 0xb9>, <&syscrg 0xba>, <&syscrg 0xbb>, <&syscrg 0x11>, <&tdm_ext>;
+			clock-names = "tdm_ahb", "tdm_apb", "tdm_internal", "tdm", "mclk_inner", "tdm_ext";
+			resets = <&syscrg 0x69>, <&syscrg 0x6b>, <&syscrg 0x6a>;
+			dmas = <&dma 0x14>, <&dma 0x15>;
+			dma-names = "rx", "tx";
+			#sound-dai-cells = <0x00>;
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&tdm_pins>;
+		};
+
+		usb0: usb@10100000 {
+			compatible = "starfive,jh7110-usb";
+			ranges = <0x00 0x00 0x10100000 0x100000>;
+			#address-cells = <0x01>;
+			#size-cells = <0x01>;
+			starfive,stg-syscon = <&stg_syscon 0x04>;
+			clocks = <&stgcrg 0x04>, <&stgcrg 0x05>, <&stgcrg 0x01>, <&stgcrg 0x03>, <&stgcrg 0x02>;
+			clock-names = "lpm", "stb", "apb", "axi", "utmi_apb";
+			resets = <&stgcrg 0x0a>, <&stgcrg 0x08>, <&stgcrg 0x07>, <&stgcrg 0x09>;
+			reset-names = "pwrup", "apb", "axi", "utmi_apb";
+			status = "disabled";
+			dr_mode = "peripheral";
+
+			usb_cdns3: usb@0 {
+				compatible = "cdns,usb3";
+				reg = <0x00 0x10000>, <0x10000 0x10000>, <0x20000 0x10000>;
+				reg-names = "otg", "xhci", "dev";
+				interrupts = <0x64>, <0x6c>, <0x6e>;
+				interrupt-names = "host", "peripheral", "otg";
+				phys = <&usbphy0>;
+				phy-names = "cdns3,usb2-phy";
+			};
+		};
+
+		usbphy0: phy@10200000 {
+			compatible = "starfive,jh7110-usb-phy";
+			reg = <0x00 0x10200000 0x00 0x10000>;
+			clocks = <&syscrg 0x5f>, <&stgcrg 0x06>;
+			clock-names = "125m", "app_125m";
+			#phy-cells = <0x00>;
+			phandle = <0x1b>;
+		};
+
+		pciephy0: phy@10210000 {
+			compatible = "starfive,jh7110-pcie-phy";
+			reg = <0x00 0x10210000 0x00 0x10000>;
+			#phy-cells = <0x00>;
+		};
+
+		pciephy1: phy@10220000 {
+			compatible = "starfive,jh7110-pcie-phy";
+			reg = <0x00 0x10220000 0x00 0x10000>;
+			#phy-cells = <0x00>;
+		};
+
 		stgcrg: clock-controller@10230000 {
 			compatible = "starfive,jh7110-stgcrg";
 			reg = <0x00 0x10230000 0x00 0x10000>;
+			clocks = <&osc>, <&syscrg 0x36>, <&syscrg 0x08>, <&syscrg 0x5f>, <&syscrg 0x02>, <&syscrg 0x37>, <&syscrg 0x06>, <&syscrg 0x0b>;
+			clock-names = "osc", "hifi4_core", "stg_axiahb", "usb_125m", "cpu_bus", "hifi4_axi", "nocstg_bus", "apb_bus";
 			#clock-cells = <0x01>;
 			#reset-cells = <0x01>;
-			phandle = <0x29>;
+			phandle = <0x1a>;
 		};
 
-		stg_syscon: stg_syscon@10240000 {
+		stg_syscon: syscon@10240000 {
 			compatible = "starfive,jh7110-stg-syscon", "syscon";
 			reg = <0x00 0x10240000 0x00 0x1000>;
-			phandle = <0x28>;
+			phandle = <0x19>;
 		};
 
 		uart3: serial@12000000 {
@@ -423,7 +536,7 @@
 			reg = <0x00 0x12000000 0x00 0x10000>;
 			clocks = <&syscrg 0x98>, <&syscrg 0x97>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x59>, <&syscrg 0x5a>;
+			resets = <&syscrg 0x59>;
 			interrupts = <0x2d>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
@@ -435,7 +548,7 @@
 			reg = <0x00 0x12010000 0x00 0x10000>;
 			clocks = <&syscrg 0x9a>, <&syscrg 0x99>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x5b>, <&syscrg 0x5c>;
+			resets = <&syscrg 0x5b>;
 			interrupts = <0x2e>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
@@ -447,7 +560,7 @@
 			reg = <0x00 0x12020000 0x00 0x10000>;
 			clocks = <&syscrg 0x9c>, <&syscrg 0x9b>;
 			clock-names = "baudclk", "apb_pclk";
-			resets = <&syscrg 0x5d>, <&syscrg 0x5e>;
+			resets = <&syscrg 0x5d>;
 			interrupts = <0x2f>;
 			reg-io-width = <0x04>;
 			reg-shift = <0x02>;
@@ -495,10 +608,41 @@
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c5_pins>;
 
-			eeprom@50 {
-				compatible = "atmel,24c04";
-				reg = <0x50>;
-				pagesize = <0x10>;
+			axp15060: pmic@36 {
+				compatible = "x-powers,axp15060";
+				reg = <0x36>;
+				interrupts = <0x00>;
+				interrupt-controller;
+				#interrupt-cells = <0x01>;
+
+				regulators {
+
+					vcc_3v3: dcdc1 {
+						regulator-boot-on;
+						regulator-always-on;
+						regulator-min-microvolt = <0x325aa0>;
+						regulator-max-microvolt = <0x325aa0>;
+						regulator-name = "vcc_3v3";
+						phandle = <0x2a>;
+					};
+
+					vdd_cpu: dcdc2 {
+						regulator-always-on;
+						regulator-min-microvolt = <0x7a120>;
+						regulator-max-microvolt = <0x177fa0>;
+						regulator-name = "vdd-cpu";
+						phandle = <0x04>;
+					};
+
+					emmc_vdd: aldo4 {
+						regulator-boot-on;
+						regulator-always-on;
+						regulator-min-microvolt = <0x1b7740>;
+						regulator-max-microvolt = <0x1b7740>;
+						regulator-name = "emmc_vdd";
+						phandle = <0x2b>;
+					};
+				};
 			};
 		};
 
@@ -520,39 +664,99 @@
 			pinctrl-0 = <&i2c6_pins>;
 		};
 
-		qspi: spi@13010000 {
-			compatible = "cdns,qspi-nor";
-			reg = <0x00 0x13010000 0x00 0x10000 0x00 0x21000000 0x00 0x400000>;
-			clocks = <&syscrg 0x5a>;
-			clock-names = "clk_ref";
-			resets = <&syscrg 0x3e>, <&syscrg 0x3d>, <&syscrg 0x3f>;
-			reset-names = "rst_apb", "rst_ahb", "rst_ref";
-			cdns,fifo-depth = <0x100>;
-			cdns,fifo-width = <0x04>;
+		spi3: spi@12070000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x12070000 0x00 0x10000>;
+			clocks = <&syscrg 0x86>, <&syscrg 0x86>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x48>;
+			interrupts = <0x34>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
 			#address-cells = <0x01>;
 			#size-cells = <0x00>;
-			spi-max-frequency = <0xee6b280>;
-			status = "okay";
+			status = "disabled";
+		};
 
-			nor-flash@0 {
+		spi4: spi@12080000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x12080000 0x00 0x10000>;
+			clocks = <&syscrg 0x87>, <&syscrg 0x87>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x49>;
+			interrupts = <0x35>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "disabled";
+		};
+
+		spi5: spi@12090000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x12090000 0x00 0x10000>;
+			clocks = <&syscrg 0x88>, <&syscrg 0x88>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x4a>;
+			interrupts = <0x36>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "disabled";
+		};
+
+		spi6: spi@120a0000 {
+			compatible = "arm,pl022", "arm,primecell";
+			reg = <0x00 0x120a0000 0x00 0x10000>;
+			clocks = <&syscrg 0x89>, <&syscrg 0x89>;
+			clock-names = "sspclk", "apb_pclk";
+			resets = <&syscrg 0x4b>;
+			interrupts = <0x37>;
+			arm,primecell-periphid = <0x41022>;
+			num-cs = <0x01>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "disabled";
+		};
+
+		sfctemp: temperature-sensor@120e0000 {
+			compatible = "starfive,jh7110-temp";
+			reg = <0x00 0x120e0000 0x00 0x10000>;
+			clocks = <&syscrg 0x82>, <&syscrg 0x81>;
+			clock-names = "sense", "bus";
+			resets = <&syscrg 0x7c>, <&syscrg 0x7b>;
+			reset-names = "sense", "bus";
+			#thermal-sensor-cells = <0x00>;
+			phandle = <0x0a>;
+		};
+
+		qspi: spi@13010000 {
+			compatible = "starfive,jh7110-qspi", "cdns,qspi-nor";
+			reg = <0x00 0x13010000 0x00 0x10000>, <0x00 0x21000000 0x00 0x400000>;
+			interrupts = <0x19>;
+			clocks = <&syscrg 0x5a>, <&syscrg 0x57>, <&syscrg 0x58>;
+			clock-names = "ref", "ahb", "apb";
+			resets = <&syscrg 0x3e>, <&syscrg 0x3d>, <&syscrg 0x3f>;
+			reset-names = "qspi", "qspi-ocp", "rstc_ref";
+			cdns,fifo-depth = <0x100>;
+			cdns,fifo-width = <0x04>;
+			cdns,trigger-address = <0x00>;
+			status = "okay";
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+
+			nor_flash: flash@0 {
 				compatible = "jedec,spi-nor";
 				reg = <0x00>;
-				spi-max-frequency = <0x5f5e100>;
+				cdns,read-delay = <0x05>;
+				spi-max-frequency = <0xb71b00>;
 				cdns,tshsl-ns = <0x01>;
 				cdns,tsd2d-ns = <0x01>;
 				cdns,tchsh-ns = <0x01>;
 				cdns,tslch-ns = <0x01>;
 			};
 		};
-
-                ptc: pwm@120d0000 {
-                        compatible = "starfive,jh7110-pwm";
-                        reg = <0x0 0x120d0000 0x0 0x10000>;
-                        clocks = <&syscrg 121>;
-                        resets = <&syscrg 108>;
-                        #pwm-cells = <3>;
-                        status = "disabled";
-                };
 
 		syscrg: clock-controller@13020000 {
 			compatible = "starfive,jh7110-syscrg";
@@ -561,22 +765,19 @@
 			clock-names = "osc", "gmac1_rmii_refin", "gmac1_rgmii_rxin", "i2stx_bclk_ext", "i2stx_lrck_ext", "i2srx_bclk_ext", "i2srx_lrck_ext", "tdm_ext", "mclk_ext", "pll0_out", "pll1_out", "pll2_out";
 			#clock-cells = <0x01>;
 			#reset-cells = <0x01>;
-			assigned-clocks = <&syscrg 0x00>, <&syscrg 0x05>, <&syscrg 0x04>, <&syscrg 0x5a>;
-			assigned-clock-parents = <&pllclk 0x00>, <&pllclk 0x02>, <&pllclk 0x02>, <&syscrg 0x59>;
-			assigned-clock-rates = <0x00>, <0x00>, <0x00>, <0x00>;
-			phandle = <0x0d>;
+			phandle = <0x03>;
 		};
 
-		sys_syscon: sys_syscon@13030000 {
+		sys_syscon: syscon@13030000 {
 			compatible = "starfive,jh7110-sys-syscon", "syscon", "simple-mfd";
 			reg = <0x00 0x13030000 0x00 0x1000>;
-			phandle = <0x1d>;
+			phandle = <0x28>;
 
 			pllclk: clock-controller {
 				compatible = "starfive,jh7110-pll";
 				clocks = <&osc>;
 				#clock-cells = <0x01>;
-				phandle = <0x1c>;
+				phandle = <0x26>;
 			};
 		};
 
@@ -590,11 +791,128 @@
 			#interrupt-cells = <0x02>;
 			gpio-controller;
 			#gpio-cells = <0x02>;
-			status = "okay";
-			phandle = <0x2a>;
+			phandle = <0x38>;
+
+			i2c0_pins: i2c0-0 {
+				phandle = <0x13>;
+
+				i2c-pins {
+					pinmux = <0x9001439>, <0xa00183a>;
+					bias-disable;
+					input-enable;
+					input-schmitt-enable;
+				};
+			};
+
+			i2c2_pins: i2c2-0 {
+				phandle = <0x14>;
+
+				i2c-pins {
+					pinmux = <0x3b007803>, <0x3c007c02>;
+					bias-disable;
+					input-enable;
+					input-schmitt-enable;
+				};
+			};
+
+			i2c5_pins: i2c5-0 {
+				phandle = <0x1d>;
+
+				i2c-pins {
+					pinmux = <0x4f00a813>, <0x5000ac14>;
+					bias-disable;
+					input-enable;
+					input-schmitt-enable;
+				};
+			};
+
+			i2c6_pins: i2c6-0 {
+				phandle = <0x1e>;
+
+				i2c-pins {
+					pinmux = <0x5600b810>, <0x5700bc11>;
+					bias-disable;
+					input-enable;
+					input-schmitt-enable;
+				};
+			};
+
+			mmc0_pins: mmc0-0 {
+				phandle = <0x29>;
+
+				rst-pins {
+					pinmux = <0xff13003e>;
+					bias-pull-up;
+					drive-strength = <0x0c>;
+					input-disable;
+					input-schmitt-disable;
+					slew-rate = <0x00>;
+				};
+
+				mmc-pins {
+					pinmux = <0x440>, <0x441>, <0x442>, <0x443>, <0x444>, <0x445>, <0x446>, <0x447>, <0x448>, <0x449>;
+					bias-pull-up;
+					drive-strength = <0x0c>;
+					input-enable;
+				};
+			};
+
+			mmc1_pins: mmc1-0 {
+				phandle = <0x2c>;
+
+				clk-pins {
+					pinmux = <0xff37000a>;
+					bias-pull-up;
+					drive-strength = <0x0c>;
+					input-disable;
+					input-schmitt-disable;
+					slew-rate = <0x00>;
+				};
+
+				mmc-pins {
+					pinmux = <0x2c394c09>, <0x2d3a500b>, <0x2e3b540c>, <0x2f3c5807>, <0x303d5c08>;
+					bias-pull-up;
+					drive-strength = <0x0c>;
+					input-enable;
+					input-schmitt-enable;
+					slew-rate = <0x00>;
+				};
+			};
+
+			spi0_pins: spi0-0 {
+				phandle = <0x15>;
+
+				mosi-pins {
+					pinmux = <0xff200034>;
+					bias-disable;
+					input-disable;
+					input-schmitt-disable;
+				};
+
+				miso-pins {
+					pinmux = <0x1c000435>;
+					bias-pull-up;
+					input-enable;
+					input-schmitt-enable;
+				};
+
+				sck-pins {
+					pinmux = <0x1a1e0030>;
+					bias-disable;
+					input-disable;
+					input-schmitt-disable;
+				};
+
+				ss-pins {
+					pinmux = <0x1b1f0030>;
+					bias-disable;
+					input-disable;
+					input-schmitt-disable;
+				};
+			};
 
 			uart0_pins: uart0-0 {
-				phandle = <0x0e>;
+				phandle = <0x12>;
 
 				tx-pins {
 					pinmux = <0xff140005>;
@@ -615,88 +933,81 @@
 				};
 			};
 
-			i2c0_pins: i2c0-0 {
-				phandle = <0x0f>;
+			tdm_pins: tdm-0 {
+				phandle = <0x18>;
 
-				i2c-pins {
-					pinmux = <0x9001439>, <0xa00183a>;
-					bias-disable;
-					input-enable;
-					input-schmitt-enable;
-				};
-			};
-
-			i2c2_pins: i2c2-0 {
-				phandle = <0x10>;
-
-				i2c-pins {
-					pinmux = <0x3b007803>, <0x3c007c02>;
-					bias-disable;
-					input-enable;
-					input-schmitt-enable;
-				};
-			};
-
-			i2c5_pins: i2c5-0 {
-				phandle = <0x11>;
-
-				i2c-pins {
-					pinmux = <0x4f00a813>, <0x5000ac14>;
-					bias-disable;
-					input-enable;
-					input-schmitt-enable;
-				};
-			};
-
-			i2c6_pins: i2c6-0 {
-				phandle = <0x12>;
-
-				i2c-pins {
-					pinmux = <0x5600b810>, <0x5700bc11>;
-					bias-disable;
-					input-enable;
-					input-schmitt-enable;
-				};
-			};
-
-			mmc0_pins: mmc0-pins {
-				phandle = <0x1e>;
-
-				mmc0-pins-rest {
-					pinmux = <0xff13003e>;
+				tx-pins {
+					pinmux = <0xff29002c>;
 					bias-pull-up;
-					drive-strength = <0x0c>;
-					input-disable;
-					input-schmitt-disable;
-					slew-rate = <0x00>;
-				};
-			};
-
-			mmc1_pins: mmc1-pins {
-				phandle = <0x1f>;
-
-				mmc1-pins0 {
-					pinmux = <0xff37000a>;
-					bias-pull-up;
-					drive-strength = <0x0c>;
+					drive-strength = <0x02>;
 					input-disable;
 					input-schmitt-disable;
 					slew-rate = <0x00>;
 				};
 
-				mmc1-pins1 {
-					pinmux = <0x2c394c09>, <0x2d3a500b>, <0x2e3b540c>, <0x2f3c5807>, <0x303d5c08>;
-					bias-pull-up;
-					drive-strength = <0x0c>;
+				rx-pins {
+					pinmux = <0x2401043d>;
 					input-enable;
-					input-schmitt-enable;
-					slew-rate = <0x00>;
+				};
+
+				sync-pins {
+					pinmux = <0x2501043f>;
+					input-enable;
+				};
+
+				pcmclk-pins {
+					pinmux = <0x23010426>;
+					input-enable;
 				};
 			};
 		};
 
+		watchdog@13070000 {
+			compatible = "starfive,jh7110-wdt";
+			reg = <0x00 0x13070000 0x00 0x10000>;
+			clocks = <&syscrg 0x7a>, <&syscrg 0x7b>;
+			clock-names = "apb", "core";
+			resets = <&syscrg 0x6d>, <&syscrg 0x6e>;
+		};
+
+		crypto: crypto@16000000 {
+			compatible = "starfive,jh7110-crypto";
+			reg = <0x00 0x16000000 0x00 0x4000>;
+			clocks = <&stgcrg 0x0f>, <&stgcrg 0x10>;
+			clock-names = "hclk", "ahb";
+			interrupts = <0x1c>;
+			resets = <&stgcrg 0x03>;
+			dmas = <&sdma 0x01 0x02>, <&sdma 0x00 0x02>;
+			dma-names = "tx", "rx";
+		};
+
+		sdma: dma-controller@16008000 {
+			compatible = "arm,pl080", "arm,primecell";
+			arm,primecell-periphid = <0x41080>;
+			reg = <0x00 0x16008000 0x00 0x4000>;
+			interrupts = <0x1d>;
+			clocks = <&stgcrg 0x0f>;
+			clock-names = "apb_pclk";
+			resets = <&stgcrg 0x03>;
+			lli-bus-interface-ahb1;
+			mem-bus-interface-ahb1;
+			memcpy-burst-size = <0x100>;
+			memcpy-bus-width = <0x20>;
+			#dma-cells = <0x02>;
+			phandle = <0x27>;
+		};
+
+		rng: rng@1600c000 {
+			compatible = "starfive,jh7110-trng";
+			reg = <0x00 0x1600c000 0x00 0x4000>;
+			clocks = <&stgcrg 0x0f>, <&stgcrg 0x10>;
+			clock-names = "hclk", "ahb";
+			resets = <&stgcrg 0x03>;
+			interrupts = <0x1e>;
+		};
+
 		mmc0: mmc@16010000 {
-			compatible = "snps,dw-mshc";
+			compatible = "starfive,jh7110-mmc";
 			reg = <0x00 0x16010000 0x00 0x10000>;
 			clocks = <&syscrg 0x5b>, <&syscrg 0x5d>;
 			clock-names = "biu", "ciu";
@@ -710,18 +1021,20 @@
 			status = "okay";
 			max-frequency = <0x5f5e100>;
 			bus-width = <0x08>;
-			pinctrl-names = "default";
-			pinctrl-0 = <&mmc0_pins>;
 			cap-mmc-highspeed;
 			mmc-ddr-1_8v;
 			mmc-hs200-1_8v;
 			non-removable;
 			cap-mmc-hw-reset;
 			post-power-on-delay-ms = <0xc8>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&mmc0_pins>;
+			vmmc-supply = <&vcc_3v3>;
+			vqmmc-supply = <&emmc_vdd>;
 		};
 
 		mmc1: mmc@16020000 {
-			compatible = "snps,dw-mshc";
+			compatible = "starfive,jh7110-mmc";
 			reg = <0x00 0x16020000 0x00 0x10000>;
 			clocks = <&syscrg 0x5c>, <&syscrg 0x5e>;
 			clock-names = "biu", "ciu";
@@ -735,17 +1048,17 @@
 			status = "okay";
 			max-frequency = <0x5f5e100>;
 			bus-width = <0x04>;
-			pinctrl-names = "default";
-			pinctrl-0 = <&mmc1_pins>;
 			no-sdio;
 			no-mmc;
 			broken-cd;
 			cap-sd-highspeed;
 			post-power-on-delay-ms = <0xc8>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&mmc1_pins>;
 		};
 
 		gmac0: ethernet@16030000 {
-			compatible = "starfive,jh7110-dwmac", "snps,dwmac-5_20";
+			compatible = "starfive,jh7110-dwmac", "snps,dwmac";
 			reg = <0x00 0x16030000 0x00 0x10000>;
 			clocks = <&aoncrg 0x03>, <&aoncrg 0x02>, <&syscrg 0x6d>, <&aoncrg 0x06>, <&syscrg 0x6f>;
 			clock-names = "stmmaceth", "pclk", "ptp_ref", "tx", "gtx";
@@ -753,10 +1066,10 @@
 			reset-names = "stmmaceth", "ahb";
 			interrupts = <0x07>, <0x06>, <0x05>;
 			interrupt-names = "macirq", "eth_wake_irq", "eth_lpi";
-			snps,multicast-filter-bins = <0x40>;
-			snps,perfect-filter-entries = <0x08>;
 			rx-fifo-depth = <0x800>;
 			tx-fifo-depth = <0x800>;
+			snps,multicast-filter-bins = <0x40>;
+			snps,perfect-filter-entries = <0x100>;
 			snps,fixed-burst;
 			snps,no-pbl-x8;
 			snps,force_thresh_dma_mode;
@@ -769,6 +1082,9 @@
 			status = "okay";
 			phy-handle = <&phy0>;
 			phy-mode = "rgmii-id";
+			starfive,tx-use-rgmii-clk;
+			assigned-clocks = <&aoncrg 0x05>;
+			assigned-clock-parents = <&aoncrg 0x04>;
 
 			mdio {
 				#address-cells = <0x01>;
@@ -777,13 +1093,20 @@
 
 				phy0: ethernet-phy@0 {
 					reg = <0x00>;
-					phandle = <0x23>;
+					motorcomm,tx-clk-adj-enabled;
+					motorcomm,tx-clk-100-inverted;
+					motorcomm,tx-clk-1000-inverted;
+					motorcomm,rx-clk-drv-microamp = <0xf82>;
+					motorcomm,rx-data-drv-microamp = <0xb5e>;
+					rx-internal-delay-ps = <0x5dc>;
+					tx-internal-delay-ps = <0x5dc>;
+					phandle = <0x30>;
 				};
 			};
 		};
 
 		gmac1: ethernet@16040000 {
-			compatible = "starfive,jh7110-dwmac", "snps,dwmac-5_20";
+			compatible = "starfive,jh7110-dwmac", "snps,dwmac";
 			reg = <0x00 0x16040000 0x00 0x10000>;
 			clocks = <&syscrg 0x62>, <&syscrg 0x61>, <&syscrg 0x66>, <&syscrg 0x6a>, <&syscrg 0x6b>;
 			clock-names = "stmmaceth", "pclk", "ptp_ref", "tx", "gtx";
@@ -791,10 +1114,10 @@
 			reset-names = "stmmaceth", "ahb";
 			interrupts = <0x4e>, <0x4d>, <0x4c>;
 			interrupt-names = "macirq", "eth_wake_irq", "eth_lpi";
-			snps,multicast-filter-bins = <0x40>;
-			snps,perfect-filter-entries = <0x08>;
 			rx-fifo-depth = <0x800>;
 			tx-fifo-depth = <0x800>;
+			snps,multicast-filter-bins = <0x40>;
+			snps,perfect-filter-entries = <0x100>;
 			snps,fixed-burst;
 			snps,no-pbl-x8;
 			snps,force_thresh_dma_mode;
@@ -807,6 +1130,9 @@
 			status = "okay";
 			phy-handle = <&phy1>;
 			phy-mode = "rgmii-id";
+			starfive,tx-use-rgmii-clk;
+			assigned-clocks = <&syscrg 0x69>;
+			assigned-clock-parents = <&syscrg 0x65>;
 
 			mdio {
 				#address-cells = <0x01>;
@@ -815,28 +1141,49 @@
 
 				phy1: ethernet-phy@1 {
 					reg = <0x00>;
-					phandle = <0x24>;
+					motorcomm,tx-clk-adj-enabled;
+					motorcomm,tx-clk-100-inverted;
+					motorcomm,rx-clk-drv-microamp = <0xf82>;
+					motorcomm,rx-data-drv-microamp = <0xb5e>;
+					rx-internal-delay-ps = <0x12c>;
+					tx-internal-delay-ps = <0x00>;
+					phandle = <0x31>;
 				};
 			};
+		};
+
+		dma: dma-controller@16050000 {
+			compatible = "starfive,jh7110-axi-dma";
+			reg = <0x00 0x16050000 0x00 0x10000>;
+			clocks = <&stgcrg 0x1b>, <&stgcrg 0x1c>;
+			clock-names = "core-clk", "cfgr-clk";
+			resets = <&stgcrg 0x05>, <&stgcrg 0x06>;
+			interrupts = <0x49>;
+			#dma-cells = <0x01>;
+			dma-channels = <0x04>;
+			snps,dma-masters = <0x01>;
+			snps,data-width = <0x03>;
+			snps,block-size = <0x10000 0x10000 0x10000 0x10000>;
+			snps,priority = <0x00 0x01 0x02 0x03>;
+			snps,axi-max-burst-len = <0x10>;
+			phandle = <0x17>;
 		};
 
 		aoncrg: clock-controller@17000000 {
 			compatible = "starfive,jh7110-aoncrg";
 			reg = <0x00 0x17000000 0x00 0x10000>;
-			clocks = <&osc>, <&rtc_osc>, <&gmac0_rmii_refin>, <&gmac0_rgmii_rxin>, <&syscrg 0x08>, <&syscrg 0x0b>, <&syscrg 0x6c>;
-			clock-names = "osc", "rtc_osc", "gmac0_rmii_refin", "gmac0_rgmii_rxin", "stg_axiahb", "apb_bus", "gmac0_gtxclk";
+			clocks = <&osc>, <&gmac0_rmii_refin>, <&gmac0_rgmii_rxin>, <&syscrg 0x08>, <&syscrg 0x0b>, <&syscrg 0x6c>, <&rtc_osc>;
+			clock-names = "osc", "gmac0_rmii_refin", "gmac0_rgmii_rxin", "stg_axiahb", "apb_bus", "gmac0_gtxclk", "rtc_osc";
 			#clock-cells = <0x01>;
 			#reset-cells = <0x01>;
-			assigned-clocks = <&aoncrg 0x01>;
-			assigned-clock-parents = <&osc>;
-			assigned-clock-rates = <0x00>;
-			phandle = <0x20>;
+			phandle = <0x2d>;
 		};
 
-		aon_syscon: aon_syscon@17010000 {
+		aon_syscon: syscon@17010000 {
 			compatible = "starfive,jh7110-aon-syscon", "syscon";
 			reg = <0x00 0x17010000 0x00 0x1000>;
-			phandle = <0x22>;
+			#power-domain-cells = <0x01>;
+			phandle = <0x2f>;
 		};
 
 		aongpio: pinctrl@17020000 {
@@ -850,66 +1197,47 @@
 			#gpio-cells = <0x02>;
 		};
 
-		pcie0: pcie@2b000000 {
-			compatible = "starfive,jh7110-pcie";
-			reg = <0x00 0x2b000000 0x00 0x1000000 0x09 0x40000000 0x00 0x10000000>;
-			reg-names = "reg", "config";
-			#address-cells = <0x03>;
-			#size-cells = <0x02>;
-			#interrupt-cells = <0x01>;
-			ranges = <0x82000000 0x00 0x30000000 0x00 0x30000000 0x00 0x8000000>, <0xc3000000 0x09 0x00 0x09 0x00 0x00 0x40000000>;
-			interrupts = <0x38>;
-			interrupt-parent = <&plic>;
-			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
-			interrupt-map = <0x00 0x00 0x00 0x01&plic 0x01>, <0x00 0x00 0x00 0x02&plic 0x02>, <0x00 0x00 0x00 0x03&plic 0x03>, <0x00 0x00 0x00 0x04&plic 0x04>;
-			msi-parent = <&plic>;
-			device_type = "pci";
-			starfive,stg-syscon = <&stg_syscon 0xc0 0xc4 0x130 0x1b8>;
-			bus-range = <0x00 0xff>;
-			clocks = <&syscrg 0x60>, <&stgcrg 0x0a>, <&stgcrg 0x08>, <&stgcrg 0x09>;
-			clock-names = "noc", "tl", "axi", "apb";
-			resets = <&stgcrg 0x0b>, <&stgcrg 0x0c>, <&stgcrg 0x0d>, <&stgcrg 0x0e>, <&stgcrg 0x0f>, <&stgcrg 0x10>;
-			reset-names = "mst0", "slv0", "slv", "brg", "core", "apb";
-			status = "okay";
-			reset-gpios = <&sysgpio 0x1a 0x01>;
+		pwrc: power-controller@17030000 {
+			compatible = "starfive,jh7110-pmu";
+			reg = <0x00 0x17030000 0x00 0x10000>;
+			interrupts = <0x6f>;
+			#power-domain-cells = <0x01>;
+			phandle = <0x36>;
 		};
 
-		pcie1: pcie@2c000000 {
-			compatible = "starfive,jh7110-pcie";
-			reg = <0x00 0x2c000000 0x00 0x1000000 0x09 0xc0000000 0x00 0x10000000>;
-			reg-names = "reg", "config";
-			#address-cells = <0x03>;
-			#size-cells = <0x02>;
-			#interrupt-cells = <0x01>;
-			ranges = <0x82000000 0x00 0x38000000 0x00 0x38000000 0x00 0x8000000>, <0xc3000000 0x09 0x80000000 0x09 0x80000000 0x00 0x40000000>;
-			interrupts = <0x39>;
-			interrupt-parent = <&plic>;
-			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
-			interrupt-map = <0x00 0x00 0x00 0x01&plic 0x01>, <0x00 0x00 0x00 0x02&plic 0x02>, <0x00 0x00 0x00 0x03&plic 0x03>, <0x00 0x00 0x00 0x04&plic 0x04>;
-			msi-parent = <&plic>;
-			device_type = "pci";
-			starfive,stg-syscon = <&stg_syscon 0x270 0x274 0x2e0 0x368>;
-			bus-range = <0x00 0xff>;
-			clocks = <&syscrg 0x60>, <&stgcrg 0x0d>, <&stgcrg 0x0b>, <&stgcrg 0x0c>;
-			clock-names = "noc", "tl", "axi", "apb";
-			resets = <&stgcrg 0x11>, <&stgcrg 0x12>, <&stgcrg 0x13>, <&stgcrg 0x14>, <&stgcrg 0x15>, <&stgcrg 0x16>;
-			reset-names = "mst0", "slv0", "slv", "brg", "core", "apb";
-			status = "okay";
-			reset-gpios = <&sysgpio 0x1c 0x01>;
+		ispcrg: clock-controller@19810000 {
+			compatible = "starfive,jh7110-ispcrg";
+			reg = <0x00 0x19810000 0x00 0x10000>;
+			clocks = <&syscrg 0x33>, <&syscrg 0x34>, <&syscrg 0x35>, <&dvp_clk>;
+			clock-names = "isp_top_core", "isp_top_axi", "noc_bus_isp_axi", "dvp_clk";
+			resets = <&syscrg 0x29>, <&syscrg 0x2a>, <&syscrg 0x1c>;
+			#clock-cells = <0x01>;
+			#reset-cells = <0x01>;
+			power-domains = <&pwrc 0x05>;
+		};
+
+		voutcrg: clock-controller@295c0000 {
+			compatible = "starfive,jh7110-voutcrg";
+			reg = <0x00 0x295c0000 0x00 0x10000>;
+			clocks = <&syscrg 0x3a>, <&syscrg 0x3d>, <&syscrg 0x3e>, <&syscrg 0x3f>, <&syscrg 0xa5>, <&hdmitx0_pixelclk>;
+			clock-names = "vout_src", "vout_top_ahb", "vout_top_axi", "vout_top_hdmitx0_mclk", "i2stx0_bclk", "hdmitx0_pixelclk";
+			resets = <&syscrg 0x2b>;
+			#clock-cells = <0x01>;
+			#reset-cells = <0x01>;
+			power-domains = <&pwrc 0x04>;
 		};
 	};
 
 	aliases {
-		serial0 = "/soc/serial@10000000";
-		spi0 = "/soc/spi@13010000";
-		mmc0 = "/soc/mmc@16010000";
-		mmc1 = "/soc/mmc@16020000";
+		ethernet0 = "/soc/ethernet@16030000";
+		ethernet1 = "/soc/ethernet@16040000";
 		i2c0 = "/soc/i2c@10030000";
 		i2c2 = "/soc/i2c@10050000";
 		i2c5 = "/soc/i2c@12050000";
 		i2c6 = "/soc/i2c@12060000";
-		ethernet0 = "/soc/ethernet@16030000";
-		ethernet1 = "/soc/ethernet@16040000";
+		mmc0 = "/soc/mmc@16010000";
+		mmc1 = "/soc/mmc@16020000";
+		serial0 = "/soc/serial@10000000";
 	};
 
 	chosen {
@@ -918,6 +1246,12 @@
 
 	memory@40000000 {
 		device_type = "memory";
-		reg = <0x00 0x40000000 0x02 0x00>;
+		reg = <0x00 0x40000000 0x01 0x00>;
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&sysgpio 0x23 0x00>;
+		priority = <0xe0>;
 	};
 };

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <device schemaVersion="1.3" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
-  <name>StarFive VisionFive 2 v1.3b</name>
+  <name>StarFive VisionFive 2 v1.3B</name>
   <version>0.1</version>
-  <description>From StarFive VisionFive 2 v1.3b,model device generator</description>
+  <description>From StarFive VisionFive 2 v1.3B,model device generator</description>
   <addressUnitBits>8</addressUnitBits>
   <width>32</width>
   <size>32</size>
@@ -92,908 +92,6 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>starfive_jh7110_plic_0</name>
-      <description>From starfive,jh7110-plic, peripheral generator</description>
-      <baseAddress>0xC000000</baseAddress>
-      <addressBlock>
-        <offset>0</offset>
-        <size>0x4000000</size>
-        <usage>registers</usage>
-      </addressBlock>
-    </peripheral>
-    <peripheral>
-      <name>sifive_plic0_0</name>
-      <description>From sifive,plic0, peripheral generator</description>
-      <baseAddress>0xC000000</baseAddress>
-      <addressBlock>
-        <offset>0</offset>
-        <size>0x4000000</size>
-        <usage>registers</usage>
-      </addressBlock>
-      <registers>
-        <register>
-          <name>priority_1</name>
-          <description>PRIORITY Register for interrupt id 1</description>
-          <addressOffset>0x4</addressOffset>
-        </register>
-        <register>
-          <name>priority_2</name>
-          <description>PRIORITY Register for interrupt id 2</description>
-          <addressOffset>0x8</addressOffset>
-        </register>
-        <register>
-          <name>priority_3</name>
-          <description>PRIORITY Register for interrupt id 3</description>
-          <addressOffset>0xC</addressOffset>
-        </register>
-        <register>
-          <name>priority_4</name>
-          <description>PRIORITY Register for interrupt id 4</description>
-          <addressOffset>0x10</addressOffset>
-        </register>
-        <register>
-          <name>priority_5</name>
-          <description>PRIORITY Register for interrupt id 5</description>
-          <addressOffset>0x14</addressOffset>
-        </register>
-        <register>
-          <name>priority_6</name>
-          <description>PRIORITY Register for interrupt id 6</description>
-          <addressOffset>0x18</addressOffset>
-        </register>
-        <register>
-          <name>priority_7</name>
-          <description>PRIORITY Register for interrupt id 7</description>
-          <addressOffset>0x1C</addressOffset>
-        </register>
-        <register>
-          <name>priority_8</name>
-          <description>PRIORITY Register for interrupt id 8</description>
-          <addressOffset>0x20</addressOffset>
-        </register>
-        <register>
-          <name>priority_9</name>
-          <description>PRIORITY Register for interrupt id 9</description>
-          <addressOffset>0x24</addressOffset>
-        </register>
-        <register>
-          <name>priority_10</name>
-          <description>PRIORITY Register for interrupt id 10</description>
-          <addressOffset>0x28</addressOffset>
-        </register>
-        <register>
-          <name>priority_11</name>
-          <description>PRIORITY Register for interrupt id 11</description>
-          <addressOffset>0x2C</addressOffset>
-        </register>
-        <register>
-          <name>priority_12</name>
-          <description>PRIORITY Register for interrupt id 12</description>
-          <addressOffset>0x30</addressOffset>
-        </register>
-        <register>
-          <name>priority_13</name>
-          <description>PRIORITY Register for interrupt id 13</description>
-          <addressOffset>0x34</addressOffset>
-        </register>
-        <register>
-          <name>priority_14</name>
-          <description>PRIORITY Register for interrupt id 14</description>
-          <addressOffset>0x38</addressOffset>
-        </register>
-        <register>
-          <name>priority_15</name>
-          <description>PRIORITY Register for interrupt id 15</description>
-          <addressOffset>0x3C</addressOffset>
-        </register>
-        <register>
-          <name>priority_16</name>
-          <description>PRIORITY Register for interrupt id 16</description>
-          <addressOffset>0x40</addressOffset>
-        </register>
-        <register>
-          <name>priority_17</name>
-          <description>PRIORITY Register for interrupt id 17</description>
-          <addressOffset>0x44</addressOffset>
-        </register>
-        <register>
-          <name>priority_18</name>
-          <description>PRIORITY Register for interrupt id 18</description>
-          <addressOffset>0x48</addressOffset>
-        </register>
-        <register>
-          <name>priority_19</name>
-          <description>PRIORITY Register for interrupt id 19</description>
-          <addressOffset>0x4C</addressOffset>
-        </register>
-        <register>
-          <name>priority_20</name>
-          <description>PRIORITY Register for interrupt id 20</description>
-          <addressOffset>0x50</addressOffset>
-        </register>
-        <register>
-          <name>priority_21</name>
-          <description>PRIORITY Register for interrupt id 21</description>
-          <addressOffset>0x54</addressOffset>
-        </register>
-        <register>
-          <name>priority_22</name>
-          <description>PRIORITY Register for interrupt id 22</description>
-          <addressOffset>0x58</addressOffset>
-        </register>
-        <register>
-          <name>priority_23</name>
-          <description>PRIORITY Register for interrupt id 23</description>
-          <addressOffset>0x5C</addressOffset>
-        </register>
-        <register>
-          <name>priority_24</name>
-          <description>PRIORITY Register for interrupt id 24</description>
-          <addressOffset>0x60</addressOffset>
-        </register>
-        <register>
-          <name>priority_25</name>
-          <description>PRIORITY Register for interrupt id 25</description>
-          <addressOffset>0x64</addressOffset>
-        </register>
-        <register>
-          <name>priority_26</name>
-          <description>PRIORITY Register for interrupt id 26</description>
-          <addressOffset>0x68</addressOffset>
-        </register>
-        <register>
-          <name>priority_27</name>
-          <description>PRIORITY Register for interrupt id 27</description>
-          <addressOffset>0x6C</addressOffset>
-        </register>
-        <register>
-          <name>priority_28</name>
-          <description>PRIORITY Register for interrupt id 28</description>
-          <addressOffset>0x70</addressOffset>
-        </register>
-        <register>
-          <name>priority_29</name>
-          <description>PRIORITY Register for interrupt id 29</description>
-          <addressOffset>0x74</addressOffset>
-        </register>
-        <register>
-          <name>priority_30</name>
-          <description>PRIORITY Register for interrupt id 30</description>
-          <addressOffset>0x78</addressOffset>
-        </register>
-        <register>
-          <name>priority_31</name>
-          <description>PRIORITY Register for interrupt id 31</description>
-          <addressOffset>0x7C</addressOffset>
-        </register>
-        <register>
-          <name>priority_32</name>
-          <description>PRIORITY Register for interrupt id 32</description>
-          <addressOffset>0x80</addressOffset>
-        </register>
-        <register>
-          <name>priority_33</name>
-          <description>PRIORITY Register for interrupt id 33</description>
-          <addressOffset>0x84</addressOffset>
-        </register>
-        <register>
-          <name>priority_34</name>
-          <description>PRIORITY Register for interrupt id 34</description>
-          <addressOffset>0x88</addressOffset>
-        </register>
-        <register>
-          <name>priority_35</name>
-          <description>PRIORITY Register for interrupt id 35</description>
-          <addressOffset>0x8C</addressOffset>
-        </register>
-        <register>
-          <name>priority_36</name>
-          <description>PRIORITY Register for interrupt id 36</description>
-          <addressOffset>0x90</addressOffset>
-        </register>
-        <register>
-          <name>priority_37</name>
-          <description>PRIORITY Register for interrupt id 37</description>
-          <addressOffset>0x94</addressOffset>
-        </register>
-        <register>
-          <name>priority_38</name>
-          <description>PRIORITY Register for interrupt id 38</description>
-          <addressOffset>0x98</addressOffset>
-        </register>
-        <register>
-          <name>priority_39</name>
-          <description>PRIORITY Register for interrupt id 39</description>
-          <addressOffset>0x9C</addressOffset>
-        </register>
-        <register>
-          <name>priority_40</name>
-          <description>PRIORITY Register for interrupt id 40</description>
-          <addressOffset>0xA0</addressOffset>
-        </register>
-        <register>
-          <name>priority_41</name>
-          <description>PRIORITY Register for interrupt id 41</description>
-          <addressOffset>0xA4</addressOffset>
-        </register>
-        <register>
-          <name>priority_42</name>
-          <description>PRIORITY Register for interrupt id 42</description>
-          <addressOffset>0xA8</addressOffset>
-        </register>
-        <register>
-          <name>priority_43</name>
-          <description>PRIORITY Register for interrupt id 43</description>
-          <addressOffset>0xAC</addressOffset>
-        </register>
-        <register>
-          <name>priority_44</name>
-          <description>PRIORITY Register for interrupt id 44</description>
-          <addressOffset>0xB0</addressOffset>
-        </register>
-        <register>
-          <name>priority_45</name>
-          <description>PRIORITY Register for interrupt id 45</description>
-          <addressOffset>0xB4</addressOffset>
-        </register>
-        <register>
-          <name>priority_46</name>
-          <description>PRIORITY Register for interrupt id 46</description>
-          <addressOffset>0xB8</addressOffset>
-        </register>
-        <register>
-          <name>priority_47</name>
-          <description>PRIORITY Register for interrupt id 47</description>
-          <addressOffset>0xBC</addressOffset>
-        </register>
-        <register>
-          <name>priority_48</name>
-          <description>PRIORITY Register for interrupt id 48</description>
-          <addressOffset>0xC0</addressOffset>
-        </register>
-        <register>
-          <name>priority_49</name>
-          <description>PRIORITY Register for interrupt id 49</description>
-          <addressOffset>0xC4</addressOffset>
-        </register>
-        <register>
-          <name>priority_50</name>
-          <description>PRIORITY Register for interrupt id 50</description>
-          <addressOffset>0xC8</addressOffset>
-        </register>
-        <register>
-          <name>priority_51</name>
-          <description>PRIORITY Register for interrupt id 51</description>
-          <addressOffset>0xCC</addressOffset>
-        </register>
-        <register>
-          <name>priority_52</name>
-          <description>PRIORITY Register for interrupt id 52</description>
-          <addressOffset>0xD0</addressOffset>
-        </register>
-        <register>
-          <name>priority_53</name>
-          <description>PRIORITY Register for interrupt id 53</description>
-          <addressOffset>0xD4</addressOffset>
-        </register>
-        <register>
-          <name>priority_54</name>
-          <description>PRIORITY Register for interrupt id 54</description>
-          <addressOffset>0xD8</addressOffset>
-        </register>
-        <register>
-          <name>priority_55</name>
-          <description>PRIORITY Register for interrupt id 55</description>
-          <addressOffset>0xDC</addressOffset>
-        </register>
-        <register>
-          <name>priority_56</name>
-          <description>PRIORITY Register for interrupt id 56</description>
-          <addressOffset>0xE0</addressOffset>
-        </register>
-        <register>
-          <name>priority_57</name>
-          <description>PRIORITY Register for interrupt id 57</description>
-          <addressOffset>0xE4</addressOffset>
-        </register>
-        <register>
-          <name>priority_58</name>
-          <description>PRIORITY Register for interrupt id 58</description>
-          <addressOffset>0xE8</addressOffset>
-        </register>
-        <register>
-          <name>priority_59</name>
-          <description>PRIORITY Register for interrupt id 59</description>
-          <addressOffset>0xEC</addressOffset>
-        </register>
-        <register>
-          <name>priority_60</name>
-          <description>PRIORITY Register for interrupt id 60</description>
-          <addressOffset>0xF0</addressOffset>
-        </register>
-        <register>
-          <name>priority_61</name>
-          <description>PRIORITY Register for interrupt id 61</description>
-          <addressOffset>0xF4</addressOffset>
-        </register>
-        <register>
-          <name>priority_62</name>
-          <description>PRIORITY Register for interrupt id 62</description>
-          <addressOffset>0xF8</addressOffset>
-        </register>
-        <register>
-          <name>priority_63</name>
-          <description>PRIORITY Register for interrupt id 63</description>
-          <addressOffset>0xFC</addressOffset>
-        </register>
-        <register>
-          <name>priority_64</name>
-          <description>PRIORITY Register for interrupt id 64</description>
-          <addressOffset>0x100</addressOffset>
-        </register>
-        <register>
-          <name>priority_65</name>
-          <description>PRIORITY Register for interrupt id 65</description>
-          <addressOffset>0x104</addressOffset>
-        </register>
-        <register>
-          <name>priority_66</name>
-          <description>PRIORITY Register for interrupt id 66</description>
-          <addressOffset>0x108</addressOffset>
-        </register>
-        <register>
-          <name>priority_67</name>
-          <description>PRIORITY Register for interrupt id 67</description>
-          <addressOffset>0x10C</addressOffset>
-        </register>
-        <register>
-          <name>priority_68</name>
-          <description>PRIORITY Register for interrupt id 68</description>
-          <addressOffset>0x110</addressOffset>
-        </register>
-        <register>
-          <name>priority_69</name>
-          <description>PRIORITY Register for interrupt id 69</description>
-          <addressOffset>0x114</addressOffset>
-        </register>
-        <register>
-          <name>priority_70</name>
-          <description>PRIORITY Register for interrupt id 70</description>
-          <addressOffset>0x118</addressOffset>
-        </register>
-        <register>
-          <name>priority_71</name>
-          <description>PRIORITY Register for interrupt id 71</description>
-          <addressOffset>0x11C</addressOffset>
-        </register>
-        <register>
-          <name>priority_72</name>
-          <description>PRIORITY Register for interrupt id 72</description>
-          <addressOffset>0x120</addressOffset>
-        </register>
-        <register>
-          <name>priority_73</name>
-          <description>PRIORITY Register for interrupt id 73</description>
-          <addressOffset>0x124</addressOffset>
-        </register>
-        <register>
-          <name>priority_74</name>
-          <description>PRIORITY Register for interrupt id 74</description>
-          <addressOffset>0x128</addressOffset>
-        </register>
-        <register>
-          <name>priority_75</name>
-          <description>PRIORITY Register for interrupt id 75</description>
-          <addressOffset>0x12C</addressOffset>
-        </register>
-        <register>
-          <name>priority_76</name>
-          <description>PRIORITY Register for interrupt id 76</description>
-          <addressOffset>0x130</addressOffset>
-        </register>
-        <register>
-          <name>priority_77</name>
-          <description>PRIORITY Register for interrupt id 77</description>
-          <addressOffset>0x134</addressOffset>
-        </register>
-        <register>
-          <name>priority_78</name>
-          <description>PRIORITY Register for interrupt id 78</description>
-          <addressOffset>0x138</addressOffset>
-        </register>
-        <register>
-          <name>priority_79</name>
-          <description>PRIORITY Register for interrupt id 79</description>
-          <addressOffset>0x13C</addressOffset>
-        </register>
-        <register>
-          <name>priority_80</name>
-          <description>PRIORITY Register for interrupt id 80</description>
-          <addressOffset>0x140</addressOffset>
-        </register>
-        <register>
-          <name>priority_81</name>
-          <description>PRIORITY Register for interrupt id 81</description>
-          <addressOffset>0x144</addressOffset>
-        </register>
-        <register>
-          <name>priority_82</name>
-          <description>PRIORITY Register for interrupt id 82</description>
-          <addressOffset>0x148</addressOffset>
-        </register>
-        <register>
-          <name>priority_83</name>
-          <description>PRIORITY Register for interrupt id 83</description>
-          <addressOffset>0x14C</addressOffset>
-        </register>
-        <register>
-          <name>priority_84</name>
-          <description>PRIORITY Register for interrupt id 84</description>
-          <addressOffset>0x150</addressOffset>
-        </register>
-        <register>
-          <name>priority_85</name>
-          <description>PRIORITY Register for interrupt id 85</description>
-          <addressOffset>0x154</addressOffset>
-        </register>
-        <register>
-          <name>priority_86</name>
-          <description>PRIORITY Register for interrupt id 86</description>
-          <addressOffset>0x158</addressOffset>
-        </register>
-        <register>
-          <name>priority_87</name>
-          <description>PRIORITY Register for interrupt id 87</description>
-          <addressOffset>0x15C</addressOffset>
-        </register>
-        <register>
-          <name>priority_88</name>
-          <description>PRIORITY Register for interrupt id 88</description>
-          <addressOffset>0x160</addressOffset>
-        </register>
-        <register>
-          <name>priority_89</name>
-          <description>PRIORITY Register for interrupt id 89</description>
-          <addressOffset>0x164</addressOffset>
-        </register>
-        <register>
-          <name>priority_90</name>
-          <description>PRIORITY Register for interrupt id 90</description>
-          <addressOffset>0x168</addressOffset>
-        </register>
-        <register>
-          <name>priority_91</name>
-          <description>PRIORITY Register for interrupt id 91</description>
-          <addressOffset>0x16C</addressOffset>
-        </register>
-        <register>
-          <name>priority_92</name>
-          <description>PRIORITY Register for interrupt id 92</description>
-          <addressOffset>0x170</addressOffset>
-        </register>
-        <register>
-          <name>priority_93</name>
-          <description>PRIORITY Register for interrupt id 93</description>
-          <addressOffset>0x174</addressOffset>
-        </register>
-        <register>
-          <name>priority_94</name>
-          <description>PRIORITY Register for interrupt id 94</description>
-          <addressOffset>0x178</addressOffset>
-        </register>
-        <register>
-          <name>priority_95</name>
-          <description>PRIORITY Register for interrupt id 95</description>
-          <addressOffset>0x17C</addressOffset>
-        </register>
-        <register>
-          <name>priority_96</name>
-          <description>PRIORITY Register for interrupt id 96</description>
-          <addressOffset>0x180</addressOffset>
-        </register>
-        <register>
-          <name>priority_97</name>
-          <description>PRIORITY Register for interrupt id 97</description>
-          <addressOffset>0x184</addressOffset>
-        </register>
-        <register>
-          <name>priority_98</name>
-          <description>PRIORITY Register for interrupt id 98</description>
-          <addressOffset>0x188</addressOffset>
-        </register>
-        <register>
-          <name>priority_99</name>
-          <description>PRIORITY Register for interrupt id 99</description>
-          <addressOffset>0x18C</addressOffset>
-        </register>
-        <register>
-          <name>priority_100</name>
-          <description>PRIORITY Register for interrupt id 100</description>
-          <addressOffset>0x190</addressOffset>
-        </register>
-        <register>
-          <name>priority_101</name>
-          <description>PRIORITY Register for interrupt id 101</description>
-          <addressOffset>0x194</addressOffset>
-        </register>
-        <register>
-          <name>priority_102</name>
-          <description>PRIORITY Register for interrupt id 102</description>
-          <addressOffset>0x198</addressOffset>
-        </register>
-        <register>
-          <name>priority_103</name>
-          <description>PRIORITY Register for interrupt id 103</description>
-          <addressOffset>0x19C</addressOffset>
-        </register>
-        <register>
-          <name>priority_104</name>
-          <description>PRIORITY Register for interrupt id 104</description>
-          <addressOffset>0x1A0</addressOffset>
-        </register>
-        <register>
-          <name>priority_105</name>
-          <description>PRIORITY Register for interrupt id 105</description>
-          <addressOffset>0x1A4</addressOffset>
-        </register>
-        <register>
-          <name>priority_106</name>
-          <description>PRIORITY Register for interrupt id 106</description>
-          <addressOffset>0x1A8</addressOffset>
-        </register>
-        <register>
-          <name>priority_107</name>
-          <description>PRIORITY Register for interrupt id 107</description>
-          <addressOffset>0x1AC</addressOffset>
-        </register>
-        <register>
-          <name>priority_108</name>
-          <description>PRIORITY Register for interrupt id 108</description>
-          <addressOffset>0x1B0</addressOffset>
-        </register>
-        <register>
-          <name>priority_109</name>
-          <description>PRIORITY Register for interrupt id 109</description>
-          <addressOffset>0x1B4</addressOffset>
-        </register>
-        <register>
-          <name>priority_110</name>
-          <description>PRIORITY Register for interrupt id 110</description>
-          <addressOffset>0x1B8</addressOffset>
-        </register>
-        <register>
-          <name>priority_111</name>
-          <description>PRIORITY Register for interrupt id 111</description>
-          <addressOffset>0x1BC</addressOffset>
-        </register>
-        <register>
-          <name>priority_112</name>
-          <description>PRIORITY Register for interrupt id 112</description>
-          <addressOffset>0x1C0</addressOffset>
-        </register>
-        <register>
-          <name>priority_113</name>
-          <description>PRIORITY Register for interrupt id 113</description>
-          <addressOffset>0x1C4</addressOffset>
-        </register>
-        <register>
-          <name>priority_114</name>
-          <description>PRIORITY Register for interrupt id 114</description>
-          <addressOffset>0x1C8</addressOffset>
-        </register>
-        <register>
-          <name>priority_115</name>
-          <description>PRIORITY Register for interrupt id 115</description>
-          <addressOffset>0x1CC</addressOffset>
-        </register>
-        <register>
-          <name>priority_116</name>
-          <description>PRIORITY Register for interrupt id 116</description>
-          <addressOffset>0x1D0</addressOffset>
-        </register>
-        <register>
-          <name>priority_117</name>
-          <description>PRIORITY Register for interrupt id 117</description>
-          <addressOffset>0x1D4</addressOffset>
-        </register>
-        <register>
-          <name>priority_118</name>
-          <description>PRIORITY Register for interrupt id 118</description>
-          <addressOffset>0x1D8</addressOffset>
-        </register>
-        <register>
-          <name>priority_119</name>
-          <description>PRIORITY Register for interrupt id 119</description>
-          <addressOffset>0x1DC</addressOffset>
-        </register>
-        <register>
-          <name>priority_120</name>
-          <description>PRIORITY Register for interrupt id 120</description>
-          <addressOffset>0x1E0</addressOffset>
-        </register>
-        <register>
-          <name>priority_121</name>
-          <description>PRIORITY Register for interrupt id 121</description>
-          <addressOffset>0x1E4</addressOffset>
-        </register>
-        <register>
-          <name>priority_122</name>
-          <description>PRIORITY Register for interrupt id 122</description>
-          <addressOffset>0x1E8</addressOffset>
-        </register>
-        <register>
-          <name>priority_123</name>
-          <description>PRIORITY Register for interrupt id 123</description>
-          <addressOffset>0x1EC</addressOffset>
-        </register>
-        <register>
-          <name>priority_124</name>
-          <description>PRIORITY Register for interrupt id 124</description>
-          <addressOffset>0x1F0</addressOffset>
-        </register>
-        <register>
-          <name>priority_125</name>
-          <description>PRIORITY Register for interrupt id 125</description>
-          <addressOffset>0x1F4</addressOffset>
-        </register>
-        <register>
-          <name>priority_126</name>
-          <description>PRIORITY Register for interrupt id 126</description>
-          <addressOffset>0x1F8</addressOffset>
-        </register>
-        <register>
-          <name>priority_127</name>
-          <description>PRIORITY Register for interrupt id 127</description>
-          <addressOffset>0x1FC</addressOffset>
-        </register>
-        <register>
-          <name>priority_128</name>
-          <description>PRIORITY Register for interrupt id 128</description>
-          <addressOffset>0x200</addressOffset>
-        </register>
-        <register>
-          <name>priority_129</name>
-          <description>PRIORITY Register for interrupt id 129</description>
-          <addressOffset>0x204</addressOffset>
-        </register>
-        <register>
-          <name>priority_130</name>
-          <description>PRIORITY Register for interrupt id 130</description>
-          <addressOffset>0x208</addressOffset>
-        </register>
-        <register>
-          <name>priority_131</name>
-          <description>PRIORITY Register for interrupt id 131</description>
-          <addressOffset>0x20C</addressOffset>
-        </register>
-        <register>
-          <name>priority_132</name>
-          <description>PRIORITY Register for interrupt id 132</description>
-          <addressOffset>0x210</addressOffset>
-        </register>
-        <register>
-          <name>priority_133</name>
-          <description>PRIORITY Register for interrupt id 133</description>
-          <addressOffset>0x214</addressOffset>
-        </register>
-        <register>
-          <name>priority_134</name>
-          <description>PRIORITY Register for interrupt id 134</description>
-          <addressOffset>0x218</addressOffset>
-        </register>
-        <register>
-          <name>priority_135</name>
-          <description>PRIORITY Register for interrupt id 135</description>
-          <addressOffset>0x21C</addressOffset>
-        </register>
-        <register>
-          <name>priority_136</name>
-          <description>PRIORITY Register for interrupt id 136</description>
-          <addressOffset>0x220</addressOffset>
-        </register>
-        <register>
-          <name>pending_0</name>
-          <description>PENDING Register for interrupt ids 31 to 0</description>
-          <addressOffset>0x1000</addressOffset>
-        </register>
-        <register>
-          <name>pending_1</name>
-          <description>PENDING Register for interrupt ids 63 to 32</description>
-          <addressOffset>0x1004</addressOffset>
-        </register>
-        <register>
-          <name>pending_2</name>
-          <description>PENDING Register for interrupt ids 95 to 64</description>
-          <addressOffset>0x1008</addressOffset>
-        </register>
-        <register>
-          <name>pending_3</name>
-          <description>PENDING Register for interrupt ids 127 to 96</description>
-          <addressOffset>0x100C</addressOffset>
-        </register>
-        <register>
-          <name>pending_4</name>
-          <description>PENDING Register for interrupt ids 136 to 128</description>
-          <addressOffset>0x1010</addressOffset>
-        </register>
-        <register>
-          <name>enable_0_0</name>
-          <description>ENABLE Register for interrupt ids 31 to 0 for hart 0</description>
-          <addressOffset>0x2000</addressOffset>
-        </register>
-        <register>
-          <name>enable_1_0</name>
-          <description>ENABLE Register for interrupt ids 63 to 32 for hart 0</description>
-          <addressOffset>0x2004</addressOffset>
-        </register>
-        <register>
-          <name>enable_2_0</name>
-          <description>ENABLE Register for interrupt ids 95 to 64 for hart 0</description>
-          <addressOffset>0x2008</addressOffset>
-        </register>
-        <register>
-          <name>enable_3_0</name>
-          <description>ENABLE Register for interrupt ids 127 to 96 for hart 0</description>
-          <addressOffset>0x200C</addressOffset>
-        </register>
-        <register>
-          <name>enable_4_0</name>
-          <description>ENABLE Register for interrupt ids 136 to 128 for hart 0</description>
-          <addressOffset>0x2010</addressOffset>
-        </register>
-        <register>
-          <name>enable_0_1</name>
-          <description>ENABLE Register for interrupt ids 31 to 0 for hart 1</description>
-          <addressOffset>0x2080</addressOffset>
-        </register>
-        <register>
-          <name>enable_1_1</name>
-          <description>ENABLE Register for interrupt ids 63 to 32 for hart 1</description>
-          <addressOffset>0x2084</addressOffset>
-        </register>
-        <register>
-          <name>enable_2_1</name>
-          <description>ENABLE Register for interrupt ids 95 to 64 for hart 1</description>
-          <addressOffset>0x2088</addressOffset>
-        </register>
-        <register>
-          <name>enable_3_1</name>
-          <description>ENABLE Register for interrupt ids 127 to 96 for hart 1</description>
-          <addressOffset>0x208C</addressOffset>
-        </register>
-        <register>
-          <name>enable_4_1</name>
-          <description>ENABLE Register for interrupt ids 136 to 128 for hart 1</description>
-          <addressOffset>0x2090</addressOffset>
-        </register>
-        <register>
-          <name>enable_0_2</name>
-          <description>ENABLE Register for interrupt ids 31 to 0 for hart 2</description>
-          <addressOffset>0x2100</addressOffset>
-        </register>
-        <register>
-          <name>enable_1_2</name>
-          <description>ENABLE Register for interrupt ids 63 to 32 for hart 2</description>
-          <addressOffset>0x2104</addressOffset>
-        </register>
-        <register>
-          <name>enable_2_2</name>
-          <description>ENABLE Register for interrupt ids 95 to 64 for hart 2</description>
-          <addressOffset>0x2108</addressOffset>
-        </register>
-        <register>
-          <name>enable_3_2</name>
-          <description>ENABLE Register for interrupt ids 127 to 96 for hart 2</description>
-          <addressOffset>0x210C</addressOffset>
-        </register>
-        <register>
-          <name>enable_4_2</name>
-          <description>ENABLE Register for interrupt ids 136 to 128 for hart 2</description>
-          <addressOffset>0x2110</addressOffset>
-        </register>
-        <register>
-          <name>enable_0_3</name>
-          <description>ENABLE Register for interrupt ids 31 to 0 for hart 3</description>
-          <addressOffset>0x2180</addressOffset>
-        </register>
-        <register>
-          <name>enable_1_3</name>
-          <description>ENABLE Register for interrupt ids 63 to 32 for hart 3</description>
-          <addressOffset>0x2184</addressOffset>
-        </register>
-        <register>
-          <name>enable_2_3</name>
-          <description>ENABLE Register for interrupt ids 95 to 64 for hart 3</description>
-          <addressOffset>0x2188</addressOffset>
-        </register>
-        <register>
-          <name>enable_3_3</name>
-          <description>ENABLE Register for interrupt ids 127 to 96 for hart 3</description>
-          <addressOffset>0x218C</addressOffset>
-        </register>
-        <register>
-          <name>enable_4_3</name>
-          <description>ENABLE Register for interrupt ids 136 to 128 for hart 3</description>
-          <addressOffset>0x2190</addressOffset>
-        </register>
-        <register>
-          <name>enable_0_4</name>
-          <description>ENABLE Register for interrupt ids 31 to 0 for hart 4</description>
-          <addressOffset>0x2200</addressOffset>
-        </register>
-        <register>
-          <name>enable_1_4</name>
-          <description>ENABLE Register for interrupt ids 63 to 32 for hart 4</description>
-          <addressOffset>0x2204</addressOffset>
-        </register>
-        <register>
-          <name>enable_2_4</name>
-          <description>ENABLE Register for interrupt ids 95 to 64 for hart 4</description>
-          <addressOffset>0x2208</addressOffset>
-        </register>
-        <register>
-          <name>enable_3_4</name>
-          <description>ENABLE Register for interrupt ids 127 to 96 for hart 4</description>
-          <addressOffset>0x220C</addressOffset>
-        </register>
-        <register>
-          <name>enable_4_4</name>
-          <description>ENABLE Register for interrupt ids 136 to 128 for hart 4</description>
-          <addressOffset>0x2210</addressOffset>
-        </register>
-        <register>
-          <name>threshold_0</name>
-          <description>PRIORITY THRESHOLD Register for hart 0</description>
-          <addressOffset>0x200000</addressOffset>
-        </register>
-        <register>
-          <name>claimplete_0</name>
-          <description>CLAIM and COMPLETE Register for hart 0</description>
-          <addressOffset>0x200004</addressOffset>
-        </register>
-        <register>
-          <name>threshold_1</name>
-          <description>PRIORITY THRESHOLD Register for hart 1</description>
-          <addressOffset>0x201000</addressOffset>
-        </register>
-        <register>
-          <name>claimplete_1</name>
-          <description>CLAIM and COMPLETE Register for hart 1</description>
-          <addressOffset>0x201004</addressOffset>
-        </register>
-        <register>
-          <name>threshold_2</name>
-          <description>PRIORITY THRESHOLD Register for hart 2</description>
-          <addressOffset>0x202000</addressOffset>
-        </register>
-        <register>
-          <name>claimplete_2</name>
-          <description>CLAIM and COMPLETE Register for hart 2</description>
-          <addressOffset>0x202004</addressOffset>
-        </register>
-        <register>
-          <name>threshold_3</name>
-          <description>PRIORITY THRESHOLD Register for hart 3</description>
-          <addressOffset>0x203000</addressOffset>
-        </register>
-        <register>
-          <name>claimplete_3</name>
-          <description>CLAIM and COMPLETE Register for hart 3</description>
-          <addressOffset>0x203004</addressOffset>
-        </register>
-        <register>
-          <name>threshold_4</name>
-          <description>PRIORITY THRESHOLD Register for hart 4</description>
-          <addressOffset>0x204000</addressOffset>
-        </register>
-        <register>
-          <name>claimplete_4</name>
-          <description>CLAIM and COMPLETE Register for hart 4</description>
-          <addressOffset>0x204004</addressOffset>
-        </register>
-      </registers>
-    </peripheral>
-    <peripheral>
       <name>starfive_jh7110_ccache_0</name>
       <description>From starfive,jh7110-ccache, peripheral generator</description>
       <baseAddress>0x2010000</baseAddress>
@@ -1020,6 +118,26 @@
       <addressBlock>
         <offset>0</offset>
         <size>0x4000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_plic_0</name>
+      <description>From starfive,jh7110-plic, peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>sifive_plic_0</name>
+      <description>From sifive,plic, peripheral generator</description>
+      <baseAddress>0xC000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000000</size>
         <usage>registers</usage>
       </addressBlock>
     </peripheral>
@@ -4136,6 +3254,1310 @@
           </fields>
         </register>
       </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_0</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x10060000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_0</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x10060000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>rohm_dh2228fv_0</name>
+      <description>From rohm,dh2228fv, peripheral generator</description>
+      <baseAddress>0x0</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x0</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_1</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x10070000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_1</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x10070000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_2</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x10080000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_2</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x10080000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_tdm_0</name>
+      <description>From starfive,jh7110-tdm, peripheral generator</description>
+      <baseAddress>0x10090000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_usb_phy_0</name>
+      <description>From starfive,jh7110-usb-phy, peripheral generator</description>
+      <baseAddress>0x10200000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_pcie_phy_0</name>
+      <description>From starfive,jh7110-pcie-phy, peripheral generator</description>
+      <baseAddress>0x10210000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_pcie_phy_1</name>
+      <description>From starfive,jh7110-pcie-phy, peripheral generator</description>
+      <baseAddress>0x10220000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
     </peripheral>
     <peripheral>
       <name>starfive_jh7110_stgcrg_0</name>
@@ -12530,12 +12952,12 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>atmel_24c04_0</name>
-      <description>From atmel,24c04, peripheral generator</description>
-      <baseAddress>0x50</baseAddress>
+      <name>x_powers_axp15060_0</name>
+      <description>From x-powers,axp15060, peripheral generator</description>
+      <baseAddress>0x36</baseAddress>
       <addressBlock>
         <offset>0</offset>
-        <size>0x50</size>
+        <size>0x36</size>
         <usage>registers</usage>
       </addressBlock>
     </peripheral>
@@ -13568,6 +13990,1688 @@
       </registers>
     </peripheral>
     <peripheral>
+      <name>arm_pl022_3</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x12070000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_3</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x12070000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_4</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x12080000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_4</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x12080000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_5</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x12090000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_5</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x12090000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl022_6</name>
+      <description>From arm,pl022, peripheral generator</description>
+      <baseAddress>0x120A0000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ssp_cr0</name>
+          <description>SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>dss</name>
+              <description>Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>frf</name>
+              <description>Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>spo</name>
+              <description>SSPCLKOUT polarity, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sph</name>
+              <description>SSPCLKOUT phase, applicable to Motorola SPI frame format only.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>scr</name>
+              <description>Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F[sspclk] / (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from [2:254], programmed through the SSPCPSR register and SCR is a value from [0:255]</description>
+              <bitRange>[15:8]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cr1</name>
+          <description>SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.</description>
+          <addressOffset>0x4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>lbm</name>
+              <description>Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sse</name>
+              <description>Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>ms</name>
+              <description>Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sod</name>
+              <description>Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dr</name>
+          <description>SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>data</name>
+              <description>Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies.</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_sr</name>
+          <description>SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.</description>
+          <addressOffset>0xc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>tfe</name>
+              <description>Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>tnf</name>
+              <description>Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rne</name>
+              <description>Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rff</name>
+              <description>Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>bsy</name>
+              <description>PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_cpsr</name>
+          <description>SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between [2:254]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>cpsdvsr</name>
+              <description>Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_imsc</name>
+          <description>The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorim</name>
+              <description>Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtim</name>
+              <description>Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rxim</name>
+              <description>Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txim</name>
+              <description>Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_ris</name>
+          <description>The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rorris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txris</name>
+              <description>Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_mis</name>
+          <description>The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rormis</name>
+              <description>Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rtmis</name>
+              <description>Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rxmis</name>
+              <description>Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>txmis</name>
+              <description>Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_icr</name>
+          <description>The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>roric</name>
+              <description>Clears the SSPRORINTR interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>rtic</name>
+              <description>Clears the SSPRTINTR interrupt</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_dmacr</name>
+          <description>The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>rxdmae</name>
+              <description>Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>txdmae</name>
+              <description>Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id0</name>
+          <description>The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number0</name>
+              <description>These bits read back as 0x22</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id1</name>
+          <description>The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>part_number1</name>
+              <description>These bits read back as 0x0</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>designer0</name>
+              <description>These bits read back as 0x1</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id2</name>
+          <description>The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfe8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>designer1</name>
+              <description>These bits read back as 0x4</description>
+              <bitRange>[3:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>revision</name>
+              <description>These bits return the peripheral revision</description>
+              <bitRange>[7:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_periph_id3</name>
+          <description>The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.</description>
+          <addressOffset>0xfec</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>configuration</name>
+              <description>These bits read back as 0x80</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id0</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff0</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id0</name>
+              <description>The bits are read as 0xD</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id1</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff4</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id1</name>
+              <description>The bits are read as 0xF0</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id2</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xff8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id2</name>
+              <description>The bits are read as 0x5</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ssp_pcell_id3</name>
+          <description>The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.</description>
+          <addressOffset>0xffc</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ssp_pcell_id3</name>
+              <description>The bits are read as 0xB1</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_6</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x120A0000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_temp_0</name>
+      <description>From starfive,jh7110-temp, peripheral generator</description>
+      <baseAddress>0x120E0000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
       <name>jedec_spi_nor_0</name>
       <description>From jedec,spi-nor, peripheral generator</description>
       <baseAddress>0x0</baseAddress>
@@ -13576,118 +15680,6 @@
         <size>0x0</size>
         <usage>registers</usage>
       </addressBlock>
-    </peripheral>
-    <peripheral>
-      <name>starfive_jh7110_pwm_0</name>
-      <description>From starfive,jh7110-pwm, peripheral generator</description>
-      <baseAddress>0x120D0000</baseAddress>
-      <addressBlock>
-        <offset>0</offset>
-        <size>0x10000</size>
-        <usage>registers</usage>
-      </addressBlock>
-      <registers>
-        <register>
-          <name>cntr</name>
-          <description>PTC counter register</description>
-          <addressOffset>0x0</addressOffset>
-          <fields>
-            <field>
-              <name>cntr</name>
-              <description>PWM PTC counter</description>
-              <bitRange>[31:0]</bitRange>
-              <access>read-write</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>hrc</name>
-          <description>PTC duty-cycle register</description>
-          <addressOffset>0x4</addressOffset>
-          <fields>
-            <field>
-              <name>hrc</name>
-              <description>PWM PTC duty-cycle value</description>
-              <bitRange>[31:0]</bitRange>
-              <access>read-write</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>lrc</name>
-          <description>PTC period register</description>
-          <addressOffset>0x8</addressOffset>
-          <fields>
-            <field>
-              <name>lrc</name>
-              <description>PWM PTC period value</description>
-              <bitRange>[31:0]</bitRange>
-              <access>read-write</access>
-            </field>
-          </fields>
-        </register>
-        <register>
-          <name>ctrl</name>
-          <description>PTC control register</description>
-          <addressOffset>0xc</addressOffset>
-          <fields>
-            <field>
-              <name>en</name>
-              <description>PWM PTC enable</description>
-              <bitRange>[0:0]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>eclk</name>
-              <description>PWM PTC enable clock</description>
-              <bitRange>[1:1]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>nec</name>
-              <description>PWM PTC nec</description>
-              <bitRange>[2:2]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>oe</name>
-              <description>PWM PTC oe</description>
-              <bitRange>[3:3]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>single</name>
-              <description>PWM PTC single</description>
-              <bitRange>[4:4]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>inte</name>
-              <description>PWM PTC interrupt enable</description>
-              <bitRange>[5:5]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>int</name>
-              <description>PWM PTC interrupt</description>
-              <bitRange>[6:6]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>cntrrst</name>
-              <description>PWM PTC counter reset</description>
-              <bitRange>[7:7]</bitRange>
-              <access>read-write</access>
-            </field>
-            <field>
-              <name>capte</name>
-              <description>PWM PTC capte</description>
-              <bitRange>[8:8]</bitRange>
-              <access>read-write</access>
-            </field>
-          </fields>
-        </register>
-      </registers>
     </peripheral>
     <peripheral>
       <name>starfive_jh7110_syscrg_0</name>
@@ -26502,8 +28494,422 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>snps_dw_mshc_0</name>
-      <description>From snps,dw-mshc, peripheral generator</description>
+      <name>starfive_jh7110_wdt_0</name>
+      <description>From starfive,jh7110-wdt, peripheral generator</description>
+      <baseAddress>0x13070000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_crypto_0</name>
+      <description>From starfive,jh7110-crypto, peripheral generator</description>
+      <baseAddress>0x16000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_pl080_0</name>
+      <description>From arm,pl080, peripheral generator</description>
+      <baseAddress>0x16008000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>arm_primecell_7</name>
+      <description>From arm,primecell, peripheral generator</description>
+      <baseAddress>0x16008000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_trng_0</name>
+      <description>From starfive,jh7110-trng, peripheral generator</description>
+      <baseAddress>0x1600C000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x4000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ctrl</name>
+          <description>TRNG CTRL Register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>exec_nop</name>
+              <description>Execute a NOP instruction</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gene_randnum</name>
+              <description>Generate a random number</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>exec_randreseed</name>
+              <description>Reseed the TRNG from noise sources</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>stat</name>
+          <description>TRNG STAT Register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>nonce_mode</name>
+              <description>TRNG Nonce operating mode</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>r256</name>
+              <description>TRNG 256-bit random number operating mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>mission_mode</name>
+              <description>TRNG Mission Mode operating mode</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>seeded</name>
+              <description>TRNG Seeded operating mode</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed0</name>
+              <description>TRNG Last Reseed 0 status</description>
+              <bitRange>[16:16]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed1</name>
+              <description>TRNG Last Reseed 1 status</description>
+              <bitRange>[17:17]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed2</name>
+              <description>TRNG Last Reseed 2 status</description>
+              <bitRange>[18:18]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed3</name>
+              <description>TRNG Last Reseed 3 status</description>
+              <bitRange>[19:19]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed4</name>
+              <description>TRNG Last Reseed 4 status</description>
+              <bitRange>[20:20]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed5</name>
+              <description>TRNG Last Reseed 5 status</description>
+              <bitRange>[21:21]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed6</name>
+              <description>TRNG Last Reseed 6 status</description>
+              <bitRange>[22:22]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>last_reseed7</name>
+              <description>TRNG Last Reseed 7 status</description>
+              <bitRange>[23:23]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>srvc_rqst</name>
+              <description>TRNG Service Request</description>
+              <bitRange>[27:27]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rand_generating</name>
+              <description>TRNG Random Number Generating Status</description>
+              <bitRange>[30:30]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>rand_seeding</name>
+              <description>TRNG Random Number Seeding Status</description>
+              <bitRange>[31:31]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>mode</name>
+          <description>TRNG MODE Register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>r256</name>
+              <description>256-bit operation mode: 0 - 128-bit mode, 1 - 256-bit mode</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>smode</name>
+          <description>TRNG SMODE Register</description>
+          <addressOffset>0xc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>nonce_mode</name>
+              <description>Nonce operation mode</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mission_mode</name>
+              <description>Mission operation mode</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>max_rejects</name>
+              <description>TRNG Maximum Rejects</description>
+              <bitRange>[31:16]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ie</name>
+          <description>TRNG Interrupt Enable Register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand_rdy_en</name>
+              <description>RAND Ready Enable</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>seed_done_en</name>
+              <description>Seed Done Enable</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>lfsr_lockup_en</name>
+              <description>LFSR Lockup Enable</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>glbl_en</name>
+              <description>Global Enable</description>
+              <bitRange>[31:31]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>istat</name>
+          <description>TRNG Interrupt Status Register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand_rdy</name>
+              <description>RAND Ready Enable</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>seed_done</name>
+              <description>Seed Done Enable</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>lfsr_lockup_en</name>
+              <description>LFSR Lockup Enable</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand0</name>
+          <description>TRNG RAND 0 Status Register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand1</name>
+          <description>TRNG RAND 1 Status Register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand2</name>
+          <description>TRNG RAND 2 Status Register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand3</name>
+          <description>TRNG RAND 3 Status Register</description>
+          <addressOffset>0x2c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand4</name>
+          <description>TRNG RAND 4 Status Register</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand5</name>
+          <description>TRNG RAND 5 Status Register</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand6</name>
+          <description>TRNG RAND 6 Status Register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>rand7</name>
+          <description>TRNG RAND 7 Status Register</description>
+          <addressOffset>0x3c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rand</name>
+              <description>Random number bits</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>auto_rqsts</name>
+          <description>Auto-reseeding after random number requests by host reaches specified counter: 0 - disable counter, other - reload value for internal counter</description>
+          <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>rqsts</name>
+              <description>Threshold number of reseed requests for auto-reseed counter</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>auto_age</name>
+          <description>Auto-reseeding after specified timer countdowns to 0: 0 - disable timer, other - reload value for internal timer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>age</name>
+              <description>Countdown value for auto-reseed timer</description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_mmc_0</name>
+      <description>From starfive,jh7110-mmc, peripheral generator</description>
       <baseAddress>0x16010000</baseAddress>
       <addressBlock>
         <offset>0</offset>
@@ -26512,8 +28918,8 @@
       </addressBlock>
     </peripheral>
     <peripheral>
-      <name>snps_dw_mshc_1</name>
-      <description>From snps,dw-mshc, peripheral generator</description>
+      <name>starfive_jh7110_mmc_1</name>
+      <description>From starfive,jh7110-mmc, peripheral generator</description>
       <baseAddress>0x16020000</baseAddress>
       <addressBlock>
         <offset>0</offset>
@@ -26532,8 +28938,8 @@
       </addressBlock>
     </peripheral>
     <peripheral>
-      <name>snps_dwmac_5_20_0</name>
-      <description>From snps,dwmac-5_20, peripheral generator</description>
+      <name>snps_dwmac_0</name>
+      <description>From snps,dwmac, peripheral generator</description>
       <baseAddress>0x16030000</baseAddress>
       <addressBlock>
         <offset>0</offset>
@@ -26552,9 +28958,19 @@
       </addressBlock>
     </peripheral>
     <peripheral>
-      <name>snps_dwmac_5_20_1</name>
-      <description>From snps,dwmac-5_20, peripheral generator</description>
+      <name>snps_dwmac_1</name>
+      <description>From snps,dwmac, peripheral generator</description>
       <baseAddress>0x16040000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_axi_dma_0</name>
+      <description>From starfive,jh7110-axi-dma, peripheral generator</description>
+      <baseAddress>0x16050000</baseAddress>
       <addressBlock>
         <offset>0</offset>
         <size>0x10000</size>
@@ -27872,42 +30288,676 @@
       </registers>
     </peripheral>
     <peripheral>
-      <name>starfive_jh7110_pcie_0</name>
-      <description>From starfive,jh7110-pcie,reg peripheral generator</description>
-      <baseAddress>0x2B000000</baseAddress>
+      <name>starfive_jh7110_pmu_0</name>
+      <description>From starfive,jh7110-pmu, peripheral generator</description>
+      <baseAddress>0x17030000</baseAddress>
       <addressBlock>
         <offset>0</offset>
-        <size>0x1000000</size>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>hard_event_turn_on_mask</name>
+          <description>Hardware Event Turn-On Mask</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hard_event_0_on_mask</name>
+              <description>RTC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_1_on_mask</name>
+              <description>GMAC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_2_on_mask</name>
+              <description>RFU, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_3_on_mask</name>
+              <description>RGPIO0 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_4_on_mask</name>
+              <description>RGPIO1 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_5_on_mask</name>
+              <description>RGPIO2 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_6_on_mask</name>
+              <description>RGPIO3 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hard_event_7_on_mask</name>
+              <description>GPU event, 1: mask hardware event, 0: enable hardware event</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>soft_turn_on_power_mode</name>
+          <description>Software Turn-On Power Mode</description>
+          <addressOffset>0xc</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>systop_power_mode</name>
+              <description>SYSTOP turn-on power mode.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cpu_power_mode</name>
+              <description>CPU turn-on power mode.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gpua_power_mode</name>
+              <description>GPUA turn-on power mode.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vdec_power_mode</name>
+              <description>VDEC turn-on power mode.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vout_power_mode</name>
+              <description>VOUT turn-on power mode.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>isp_power_mode</name>
+              <description>ISP turn-on power mode.</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>venc_power_mode</name>
+              <description>VENC turn-on power mode.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>soft_turn_off_power_mode</name>
+          <description>Software Turn-Off Power Mode</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>systop_power_mode</name>
+              <description>SYSTOP turn-off power mode.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cpu_power_mode</name>
+              <description>CPU turn-off power mode.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gpua_power_mode</name>
+              <description>GPUA turn-off power mode.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vdec_power_mode</name>
+              <description>VDEC turn-off power mode.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vout_power_mode</name>
+              <description>VOUT turn-off power mode.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>isp_power_mode</name>
+              <description>ISP turn-off power mode.</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>venc_power_mode</name>
+              <description>VENC turn-off power mode.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>timeout_seq_thd</name>
+          <description>Threshold Sequence Timeout</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>timeout_seq_thd</name>
+              <description>Threshold Sequence Timeout</description>
+              <bitRange>[15:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pdc0</name>
+          <description>Powerdomain Cascade 0</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pd0_off_cas</name>
+              <description>Power domain 0 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[4:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd0_on_cas</name>
+              <description>Power domain 0 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[9:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd1_off_cas</name>
+              <description>Power domain 1 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[14:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd1_on_cas</name>
+              <description>Power domain 1 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[19:15]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd2_off_cas</name>
+              <description>Power domain 2 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[24:20]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd2_on_cas</name>
+              <description>Power domain 2 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[29:25]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pdc1</name>
+          <description>Powerdomain Cascade 1</description>
+          <addressOffset>0x1c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pd3_off_cas</name>
+              <description>Power domain 3 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[4:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd3_on_cas</name>
+              <description>Power domain 3 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[9:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd4_off_cas</name>
+              <description>Power domain 4 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[14:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd4_on_cas</name>
+              <description>Power domain 4 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[19:15]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd5_off_cas</name>
+              <description>Power domain 5 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[24:20]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd5_on_cas</name>
+              <description>Power domain 5 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[29:25]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pdc2</name>
+          <description>Powerdomain Cascade 2</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pd6_off_cas</name>
+              <description>Power domain 6 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[4:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd6_on_cas</name>
+              <description>Power domain 6 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[9:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd7_off_cas</name>
+              <description>Power domain 7 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[14:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd7_on_cas</name>
+              <description>Power domain 7 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[19:15]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd8_off_cas</name>
+              <description>Power domain 8 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[24:20]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pd8_on_cas</name>
+              <description>Power domain 8 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid.</description>
+              <bitRange>[29:25]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>sw_encourage</name>
+          <description>Software Encouragement</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>sw_encourage</name>
+              <description>Software Encouragement</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>tim</name>
+          <description>TIMER Interrupt Mask</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>seq_done_mask</name>
+              <description>Mask the sequence complete event. 0: mask, 1: unmask</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hw_req_mask</name>
+              <description>Mask the hardware encouragement request. 0: mask, 1: unmask</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>sw_fail_mask</name>
+              <description>Mask the software encouragement failure event. 0: mask, 1: unmask</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>hw_fail_mask</name>
+              <description>Mask the hardware encouragement failure event. 0: mask, 1: unmask</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>pch_fail_mask</name>
+              <description>Mask the P-channel encouragement failure event. 0: mask, 1: unmask</description>
+              <bitRange>[8:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pch_bypass</name>
+          <description>P-channel Bypass</description>
+          <addressOffset>0x4c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pch_bypass</name>
+              <description>Bypass P-channel. 0: enable p-channel, 1: bypass p-channel</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pch_pstate</name>
+          <description>P-channel PSTATE</description>
+          <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pch_pstate</name>
+              <description>P-channel state set</description>
+              <bitRange>[4:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pch_timeout</name>
+          <description>P-channel Timeout Threshold</description>
+          <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pch_timeout</name>
+              <description>P-channel waiting device acknowledge timeout.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>lp_timeout</name>
+          <description>LP Cell Control Timeout Threshold</description>
+          <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>lp_timeout</name>
+              <description>LP Cell Control signal waiting carries acknowledge timeout.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hard_turn_on_power_mode</name>
+          <description>Hardware Turn-On Power Mode</description>
+          <addressOffset>0x5c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>systop_power_mode</name>
+              <description>SYSTOP turn-on power mode.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cpu_power_mode</name>
+              <description>CPU turn-on power mode.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gpua_power_mode</name>
+              <description>GPUA turn-on power mode.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vdec_power_mode</name>
+              <description>VDEC turn-on power mode.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vout_power_mode</name>
+              <description>VOUT turn-on power mode.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>isp_power_mode</name>
+              <description>ISP turn-on power mode.</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>venc_power_mode</name>
+              <description>VENC turn-on power mode.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>current_power_mode</name>
+          <description>Current Power Mode</description>
+          <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>systop_power_mode</name>
+              <description>SYSTOP turn-on power mode.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>cpu_power_mode</name>
+              <description>CPU turn-on power mode.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>gpua_power_mode</name>
+              <description>GPUA turn-on power mode.</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vdec_power_mode</name>
+              <description>VDEC turn-on power mode.</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>vout_power_mode</name>
+              <description>VOUT turn-on power mode.</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>isp_power_mode</name>
+              <description>ISP turn-on power mode.</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>venc_power_mode</name>
+              <description>VENC turn-on power mode.</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>current_seq_state</name>
+          <description>Current Sequence State</description>
+          <addressOffset>0x84</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>power_mode_cur</name>
+              <description>Current sequence state.</description>
+              <bitRange>[1:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>event_status</name>
+          <description>PMU Event Status</description>
+          <addressOffset>0x88</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>seq_done_event</name>
+              <description>Sequence complete.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>hw_req_event</name>
+              <description>Hardware encouragement request.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sw_fail_event</name>
+              <description>Software encouragement failure.</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>hw_fail_event</name>
+              <description>Hardware encouragement failure.</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>pch_fail_event</name>
+              <description>P-channel failure.</description>
+              <bitRange>[8:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>int_status</name>
+          <description>PMU Interrupt Status</description>
+          <addressOffset>0x8c</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>seq_done_event</name>
+              <description>Sequence complete.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>hw_req_event</name>
+              <description>Hardware encouragement request.</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>sw_fail_event</name>
+              <description>Software encouragement failure.</description>
+              <bitRange>[3:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>hw_fail_event</name>
+              <description>Hardware encouragement failure.</description>
+              <bitRange>[5:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>pch_fail_event</name>
+              <description>P-channel failure.</description>
+              <bitRange>[8:6]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>hw_event_crd</name>
+          <description>Hardware Event Record</description>
+          <addressOffset>0x90</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>hw_event_crd</name>
+              <description>Hardware Event Record.</description>
+              <bitRange>[7:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>encourage_type_crd</name>
+          <description>Hardware Event Type Record</description>
+          <addressOffset>0x94</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>encourage_type_crd</name>
+              <description>Hardware/Software encouragement type record. 0: Software, 1: Hardware.</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>pch_active</name>
+          <description>P-channel PACTIVE Status</description>
+          <addressOffset>0x98</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>pch_active</name>
+              <description>P-channel PACTIVE status.</description>
+              <bitRange>[10:0]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>starfive_jh7110_ispcrg_0</name>
+      <description>From starfive,jh7110-ispcrg, peripheral generator</description>
+      <baseAddress>0x19810000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
     </peripheral>
     <peripheral>
-      <name>starfive_jh7110_pcie_1</name>
-      <description>From starfive,jh7110-pcie,config peripheral generator</description>
-      <baseAddress>0x940000000</baseAddress>
+      <name>starfive_jh7110_voutcrg_0</name>
+      <description>From starfive,jh7110-voutcrg, peripheral generator</description>
+      <baseAddress>0x295C0000</baseAddress>
       <addressBlock>
         <offset>0</offset>
-        <size>0x10000000</size>
-        <usage>registers</usage>
-      </addressBlock>
-    </peripheral>
-    <peripheral>
-      <name>starfive_jh7110_pcie_2</name>
-      <description>From starfive,jh7110-pcie,reg peripheral generator</description>
-      <baseAddress>0x2C000000</baseAddress>
-      <addressBlock>
-        <offset>0</offset>
-        <size>0x1000000</size>
-        <usage>registers</usage>
-      </addressBlock>
-    </peripheral>
-    <peripheral>
-      <name>starfive_jh7110_pcie_3</name>
-      <description>From starfive,jh7110-pcie,config peripheral generator</description>
-      <baseAddress>0x9C0000000</baseAddress>
-      <addressBlock>
-        <offset>0</offset>
-        <size>0x10000000</size>
+        <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
     </peripheral>

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_0/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_1/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_2/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_3/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_4/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_5/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6.rs
@@ -1,0 +1,147 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+    pub ssp_cr0: SSP_CR0,
+    _reserved1: [u8; 0x02],
+    #[doc = "0x04 - SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+    pub ssp_cr1: SSP_CR1,
+    _reserved2: [u8; 0x02],
+    #[doc = "0x08 - SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+    pub ssp_dr: SSP_DR,
+    _reserved3: [u8; 0x02],
+    #[doc = "0x0c - SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+    pub ssp_sr: SSP_SR,
+    _reserved4: [u8; 0x02],
+    #[doc = "0x10 - SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+    pub ssp_cpsr: SSP_CPSR,
+    _reserved5: [u8; 0x02],
+    #[doc = "0x14 - The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+    pub ssp_imsc: SSP_IMSC,
+    _reserved6: [u8; 0x02],
+    #[doc = "0x18 - The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+    pub ssp_ris: SSP_RIS,
+    _reserved7: [u8; 0x02],
+    #[doc = "0x1c - The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+    pub ssp_mis: SSP_MIS,
+    _reserved8: [u8; 0x02],
+    #[doc = "0x20 - The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+    pub ssp_icr: SSP_ICR,
+    _reserved9: [u8; 0x02],
+    #[doc = "0x24 - The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+    pub ssp_dmacr: SSP_DMACR,
+    _reserved10: [u8; 0x0fba],
+    #[doc = "0xfe0 - The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id0: SSP_PERIPH_ID0,
+    _reserved11: [u8; 0x02],
+    #[doc = "0xfe4 - The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id1: SSP_PERIPH_ID1,
+    _reserved12: [u8; 0x02],
+    #[doc = "0xfe8 - The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id2: SSP_PERIPH_ID2,
+    _reserved13: [u8; 0x02],
+    #[doc = "0xfec - The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+    pub ssp_periph_id3: SSP_PERIPH_ID3,
+    _reserved14: [u8; 0x02],
+    #[doc = "0xff0 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id0: SSP_PCELL_ID0,
+    _reserved15: [u8; 0x02],
+    #[doc = "0xff4 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id1: SSP_PCELL_ID1,
+    _reserved16: [u8; 0x02],
+    #[doc = "0xff8 - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id2: SSP_PCELL_ID2,
+    _reserved17: [u8; 0x02],
+    #[doc = "0xffc - The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+    pub ssp_pcell_id3: SSP_PCELL_ID3,
+}
+#[doc = "ssp_cr0 (rw) register accessor: SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr0`]
+module"]
+pub type SSP_CR0 = crate::Reg<ssp_cr0::SSP_CR0_SPEC>;
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr0;
+#[doc = "ssp_cr1 (rw) register accessor: SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cr1`]
+module"]
+pub type SSP_CR1 = crate::Reg<ssp_cr1::SSP_CR1_SPEC>;
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP."]
+pub mod ssp_cr1;
+#[doc = "ssp_dr (rw) register accessor: SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dr`]
+module"]
+pub type SSP_DR = crate::Reg<ssp_dr::SSP_DR_SPEC>;
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer."]
+pub mod ssp_dr;
+#[doc = "ssp_sr (rw) register accessor: SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_sr`]
+module"]
+pub type SSP_SR = crate::Reg<ssp_sr::SSP_SR_SPEC>;
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status."]
+pub mod ssp_sr;
+#[doc = "ssp_cpsr (rw) register accessor: SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_cpsr`]
+module"]
+pub type SSP_CPSR = crate::Reg<ssp_cpsr::SSP_CPSR_SPEC>;
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero."]
+pub mod ssp_cpsr;
+#[doc = "ssp_imsc (rw) register accessor: The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_imsc`]
+module"]
+pub type SSP_IMSC = crate::Reg<ssp_imsc::SSP_IMSC_SPEC>;
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset."]
+pub mod ssp_imsc;
+#[doc = "ssp_ris (rw) register accessor: The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_ris`]
+module"]
+pub type SSP_RIS = crate::Reg<ssp_ris::SSP_RIS_SPEC>;
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect."]
+pub mod ssp_ris;
+#[doc = "ssp_mis (rw) register accessor: The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_mis`]
+module"]
+pub type SSP_MIS = crate::Reg<ssp_mis::SSP_MIS_SPEC>;
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect."]
+pub mod ssp_mis;
+#[doc = "ssp_icr (rw) register accessor: The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_icr`]
+module"]
+pub type SSP_ICR = crate::Reg<ssp_icr::SSP_ICR_SPEC>;
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect."]
+pub mod ssp_icr;
+#[doc = "ssp_dmacr (rw) register accessor: The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_dmacr`]
+module"]
+pub type SSP_DMACR = crate::Reg<ssp_dmacr::SSP_DMACR_SPEC>;
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset."]
+pub mod ssp_dmacr;
+#[doc = "ssp_periph_id0 (rw) register accessor: The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id0`]
+module"]
+pub type SSP_PERIPH_ID0 = crate::Reg<ssp_periph_id0::SSP_PERIPH_ID0_SPEC>;
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id0;
+#[doc = "ssp_periph_id1 (rw) register accessor: The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id1`]
+module"]
+pub type SSP_PERIPH_ID1 = crate::Reg<ssp_periph_id1::SSP_PERIPH_ID1_SPEC>;
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id1;
+#[doc = "ssp_periph_id2 (rw) register accessor: The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id2`]
+module"]
+pub type SSP_PERIPH_ID2 = crate::Reg<ssp_periph_id2::SSP_PERIPH_ID2_SPEC>;
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id2;
+#[doc = "ssp_periph_id3 (rw) register accessor: The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_periph_id3`]
+module"]
+pub type SSP_PERIPH_ID3 = crate::Reg<ssp_periph_id3::SSP_PERIPH_ID3_SPEC>;
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register."]
+pub mod ssp_periph_id3;
+#[doc = "ssp_pcell_id0 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id0`]
+module"]
+pub type SSP_PCELL_ID0 = crate::Reg<ssp_pcell_id0::SSP_PCELL_ID0_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id0;
+#[doc = "ssp_pcell_id1 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id1`]
+module"]
+pub type SSP_PCELL_ID1 = crate::Reg<ssp_pcell_id1::SSP_PCELL_ID1_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id1;
+#[doc = "ssp_pcell_id2 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id2`]
+module"]
+pub type SSP_PCELL_ID2 = crate::Reg<ssp_pcell_id2::SSP_PCELL_ID2_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id2;
+#[doc = "ssp_pcell_id3 (rw) register accessor: The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ssp_pcell_id3`]
+module"]
+pub type SSP_PCELL_ID3 = crate::Reg<ssp_pcell_id3::SSP_PCELL_ID3_SPEC>;
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D."]
+pub mod ssp_pcell_id3;

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cpsr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cpsr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_cpsr` reader"]
+pub type R = crate::R<SSP_CPSR_SPEC>;
+#[doc = "Register `ssp_cpsr` writer"]
+pub type W = crate::W<SSP_CPSR_SPEC>;
+#[doc = "Field `cpsdvsr` reader - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_R = crate::FieldReader;
+#[doc = "Field `cpsdvsr` writer - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+pub type CPSDVSR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    pub fn cpsdvsr(&self) -> CPSDVSR_R {
+        CPSDVSR_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Clock prescale divisor. Must be an even number from 2-254, depending on the frequency of SSPCLK. The least significant bit always returns zero on reads."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpsdvsr(&mut self) -> CPSDVSR_W<SSP_CPSR_SPEC, 0> {
+        CPSDVSR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCPSR is the clock prescale register and specifies the division factor by which the input SSPCLK must be internally divided before further use. The value programmed into this register must be an even number between \\[2:254\\]. The least significant bit of the programmed number is hard-coded to zero. If an odd number is written to this register, data read back from this register has the least significant bit as zero.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cpsr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cpsr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CPSR_SPEC;
+impl crate::RegisterSpec for SSP_CPSR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cpsr::R`](R) reader structure"]
+impl crate::Readable for SSP_CPSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cpsr::W`](W) writer structure"]
+impl crate::Writable for SSP_CPSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cr0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cr0.rs
@@ -1,0 +1,105 @@
+#[doc = "Register `ssp_cr0` reader"]
+pub type R = crate::R<SSP_CR0_SPEC>;
+#[doc = "Register `ssp_cr0` writer"]
+pub type W = crate::W<SSP_CR0_SPEC>;
+#[doc = "Field `dss` reader - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_R = crate::FieldReader;
+#[doc = "Field `dss` writer - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+pub type DSS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `frf` reader - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_R = crate::FieldReader;
+#[doc = "Field `frf` writer - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+pub type FRF_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `spo` reader - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_R = crate::BitReader;
+#[doc = "Field `spo` writer - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+pub type SPO_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sph` reader - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_R = crate::BitReader;
+#[doc = "Field `sph` writer - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+pub type SPH_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `scr` reader - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_R = crate::FieldReader;
+#[doc = "Field `scr` writer - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+pub type SCR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    pub fn dss(&self) -> DSS_R {
+        DSS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    pub fn frf(&self) -> FRF_R {
+        FRF_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn spo(&self) -> SPO_R {
+        SPO_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    pub fn sph(&self) -> SPH_R {
+        SPH_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    pub fn scr(&self) -> SCR_R {
+        SCR_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Data Size Select - 0000, 0001, 0010: Reserved, 0011: 4-bit data, 0100: 5-bit data, 6-bit data, 0110: 7-bit data, 0111: 8-bit data, 1000: 9-bit data, 1001: 10-bit data, 1010: 11-bit data, 1011: 12-bit data, 1100: 13-bit data, 1101: 14-bit data, 1110: 15-bit data, 1111: 16-bit data"]
+    #[inline(always)]
+    #[must_use]
+    pub fn dss(&mut self) -> DSS_W<SSP_CR0_SPEC, 0> {
+        DSS_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Frame format - 00: Motorola SPI frame format, 01: TI synchronous serial frame format, 10: National Microwire frame format, 11: Reserved"]
+    #[inline(always)]
+    #[must_use]
+    pub fn frf(&mut self) -> FRF_W<SSP_CR0_SPEC, 4> {
+        FRF_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT polarity, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn spo(&mut self) -> SPO_W<SSP_CR0_SPEC, 6> {
+        SPO_W::new(self)
+    }
+    #[doc = "Bit 6 - SSPCLKOUT phase, applicable to Motorola SPI frame format only."]
+    #[inline(always)]
+    #[must_use]
+    pub fn sph(&mut self) -> SPH_W<SSP_CR0_SPEC, 6> {
+        SPH_W::new(self)
+    }
+    #[doc = "Bits 8:15 - Serial clock rate. The value SCR is used to generate the transmit and receive bit rate of the PrimeCell SSP. The bit rate is: (F\\[sspclk\\]
+/ (CPSDVR * (1 + SCR))), where CPSDVSR is an even value from \\[2:254\\], programmed through the SSPCPSR register and SCR is a value from \\[0:255\\]"]
+    #[inline(always)]
+    #[must_use]
+    pub fn scr(&mut self) -> SCR_W<SSP_CR0_SPEC, 8> {
+        SCR_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR0 is control register 0 and contains five bit fields that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR0_SPEC;
+impl crate::RegisterSpec for SSP_CR0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr0::R`](R) reader structure"]
+impl crate::Readable for SSP_CR0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr0::W`](W) writer structure"]
+impl crate::Writable for SSP_CR0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cr1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_cr1.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_cr1` reader"]
+pub type R = crate::R<SSP_CR1_SPEC>;
+#[doc = "Register `ssp_cr1` writer"]
+pub type W = crate::W<SSP_CR1_SPEC>;
+#[doc = "Field `lbm` reader - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_R = crate::BitReader;
+#[doc = "Field `lbm` writer - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+pub type LBM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sse` reader - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_R = crate::BitReader;
+#[doc = "Field `sse` writer - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+pub type SSE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `ms` reader - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_R = crate::BitReader;
+#[doc = "Field `ms` writer - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+pub type MS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sod` reader - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_R = crate::BitReader;
+#[doc = "Field `sod` writer - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+pub type SOD_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    pub fn lbm(&self) -> LBM_R {
+        LBM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    pub fn sse(&self) -> SSE_R {
+        SSE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    pub fn ms(&self) -> MS_R {
+        MS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    pub fn sod(&self) -> SOD_R {
+        SOD_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Loop back mode - 0: Normal serial port operation enabled, 1: Output of transmit serial shifter is connected to input of receive serial shifter internally"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lbm(&mut self) -> LBM_W<SSP_CR1_SPEC, 0> {
+        LBM_W::new(self)
+    }
+    #[doc = "Bit 1 - Synchronous serial port enable - 0: SSP operation disabled, 1: SSP operation enabled"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sse(&mut self) -> SSE_W<SSP_CR1_SPEC, 1> {
+        SSE_W::new(self)
+    }
+    #[doc = "Bit 2 - Master or slave mode select. This bit can be modified only when the PrimeCell SSP is disabled, SSE=0 - 0: Device configured as master (default), 1: Device configured as slave"]
+    #[inline(always)]
+    #[must_use]
+    pub fn ms(&mut self) -> MS_W<SSP_CR1_SPEC, 2> {
+        MS_W::new(self)
+    }
+    #[doc = "Bit 3 - Slave-mode output disable. This bit is relevant only in the slave mode, MS=1. In multiple-slave systems, it is possible for an PrimeCell SSP master to broadcast a message to all slaves in the system while ensuring that only one slave drives data onto its serial output line. In such systems the RXD lines from multiple slaves could be tied together. To operate in such systems, the SOD bit can be set if the PrimeCell SSP slave is not supposed to drive the SSPTXD line - 0: SSP can drive the SSPTXD output in slave mode, 1: SSP must not drive the SSPTXD output in slave mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sod(&mut self) -> SOD_W<SSP_CR1_SPEC, 3> {
+        SOD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPCR1 is the control register 1 and contains four different bit fields, that control various functions within the PrimeCell SSP.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_cr1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_cr1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_CR1_SPEC;
+impl crate::RegisterSpec for SSP_CR1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_cr1::R`](R) reader structure"]
+impl crate::Readable for SSP_CR1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_cr1::W`](W) writer structure"]
+impl crate::Writable for SSP_CR1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_dmacr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_dmacr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_dmacr` reader"]
+pub type R = crate::R<SSP_DMACR_SPEC>;
+#[doc = "Register `ssp_dmacr` writer"]
+pub type W = crate::W<SSP_DMACR_SPEC>;
+#[doc = "Field `rxdmae` reader - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_R = crate::BitReader;
+#[doc = "Field `rxdmae` writer - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+pub type RXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txdmae` reader - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_R = crate::BitReader;
+#[doc = "Field `txdmae` writer - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+pub type TXDMAE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    pub fn rxdmae(&self) -> RXDMAE_R {
+        RXDMAE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    pub fn txdmae(&self) -> TXDMAE_R {
+        TXDMAE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive DMA Enable. If this bit is set to 1, DMA for the receive FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxdmae(&mut self) -> RXDMAE_W<SSP_DMACR_SPEC, 0> {
+        RXDMAE_W::new(self)
+    }
+    #[doc = "Bit 1 - Transmit DMA Enable. If this bit is set to 1, DMA for the transmit FIFO is enabled."]
+    #[inline(always)]
+    #[must_use]
+    pub fn txdmae(&mut self) -> TXDMAE_W<SSP_DMACR_SPEC, 1> {
+        TXDMAE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPDMACR register is the DMA control register. It is a RW register. All the bits are cleared to 0 on reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dmacr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dmacr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DMACR_SPEC;
+impl crate::RegisterSpec for SSP_DMACR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dmacr::R`](R) reader structure"]
+impl crate::Readable for SSP_DMACR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dmacr::W`](W) writer structure"]
+impl crate::Writable for SSP_DMACR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_dr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_dr.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `ssp_dr` reader"]
+pub type R = crate::R<SSP_DR_SPEC>;
+#[doc = "Register `ssp_dr` writer"]
+pub type W = crate::W<SSP_DR_SPEC>;
+#[doc = "Field `data` reader - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_R = crate::FieldReader<u16>;
+#[doc = "Field `data` writer - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+pub type DATA_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Transmit/Receive FIFO - Read: Receive FIFO, Write: Transmit FIFO. You must right-justify data when the PrimeCell SSP is programmed for a data size that is less than 16 bits. Unused bits at the top are ignored by transmit logic. The receive logic automatically right-justifies."]
+    #[inline(always)]
+    #[must_use]
+    pub fn data(&mut self) -> DATA_W<SSP_DR_SPEC, 0> {
+        DATA_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPDR is the data register and is 16-bits wide. When SSPDR is read, the entry in the receive FIFO, pointed to by the current FIFO read pointer, is accessed. As data values are removed by the PrimeCell SSP receive logic from the incoming data frame, they are placed into the entry in the receive FIFO, pointed to by the current FIFO write pointer. When SSPDR is written to, the entry in the transmit FIFO, pointed to by the write pointer, is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. It is loaded into the transmit serial shifter, then serially shifted out onto the SSPTXD pin at the programmed bit rate. When a data size of less than 16 bits is selected, the user must right-justify data written to the transmit FIFO. The transmit logic ignores the unused bits. Received data less than 16 bits is automatically right-justified in the receive buffer.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_dr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_dr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_DR_SPEC;
+impl crate::RegisterSpec for SSP_DR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_dr::R`](R) reader structure"]
+impl crate::Readable for SSP_DR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_dr::W`](W) writer structure"]
+impl crate::Writable for SSP_DR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_icr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_icr.rs
@@ -1,0 +1,56 @@
+#[doc = "Register `ssp_icr` reader"]
+pub type R = crate::R<SSP_ICR_SPEC>;
+#[doc = "Register `ssp_icr` writer"]
+pub type W = crate::W<SSP_ICR_SPEC>;
+#[doc = "Field `roric` reader - Clears the SSPRORINTR interrupt"]
+pub type RORIC_R = crate::BitReader;
+#[doc = "Field `roric` writer - Clears the SSPRORINTR interrupt"]
+pub type RORIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtic` reader - Clears the SSPRTINTR interrupt"]
+pub type RTIC_R = crate::BitReader;
+#[doc = "Field `rtic` writer - Clears the SSPRTINTR interrupt"]
+pub type RTIC_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn roric(&self) -> RORIC_R {
+        RORIC_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtic(&self) -> RTIC_R {
+        RTIC_R::new(((self.bits >> 1) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clears the SSPRORINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn roric(&mut self) -> RORIC_W<SSP_ICR_SPEC, 0> {
+        RORIC_W::new(self)
+    }
+    #[doc = "Bit 1 - Clears the SSPRTINTR interrupt"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtic(&mut self) -> RTIC_W<SSP_ICR_SPEC, 1> {
+        RTIC_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPICR register is the interrupt clear register and is write-only. On a write of 1, the corresponding interrupt is cleared. A write of 0 has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_icr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_icr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_ICR_SPEC;
+impl crate::RegisterSpec for SSP_ICR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_icr::R`](R) reader structure"]
+impl crate::Readable for SSP_ICR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_icr::W`](W) writer structure"]
+impl crate::Writable for SSP_ICR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_imsc.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_imsc.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ssp_imsc` reader"]
+pub type R = crate::R<SSP_IMSC_SPEC>;
+#[doc = "Register `ssp_imsc` writer"]
+pub type W = crate::W<SSP_IMSC_SPEC>;
+#[doc = "Field `rorim` reader - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_R = crate::BitReader;
+#[doc = "Field `rorim` writer - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+pub type RORIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rtim` reader - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_R = crate::BitReader;
+#[doc = "Field `rtim` writer - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+pub type RTIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `rxim` reader - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_R = crate::BitReader;
+#[doc = "Field `rxim` writer - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+pub type RXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `txim` reader - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_R = crate::BitReader;
+#[doc = "Field `txim` writer - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+pub type TXIM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rorim(&self) -> RORIM_R {
+        RORIM_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    pub fn rtim(&self) -> RTIM_R {
+        RTIM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn rxim(&self) -> RXIM_R {
+        RXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    pub fn txim(&self) -> TXIM_R {
+        TXIM_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Receive overrun interrupt mask - 0: Receive FIFO written to while full condition interrupt is masked, 1: Receive FIFO written to while full condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rorim(&mut self) -> RORIM_W<SSP_IMSC_SPEC, 0> {
+        RORIM_W::new(self)
+    }
+    #[doc = "Bit 1 - Receive timeout interrupt mask - 0: Receive FIFO not empty and no read prior to timeout period interrupt is masked, 1: Receive FIFO not empty and no read prior to timeout period interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rtim(&mut self) -> RTIM_W<SSP_IMSC_SPEC, 1> {
+        RTIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Receive FIFO interrupt mask - 0: Receive FIFO half full or less condition interrupt is masked, 1: Receive FIFO half full or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rxim(&mut self) -> RXIM_W<SSP_IMSC_SPEC, 2> {
+        RXIM_W::new(self)
+    }
+    #[doc = "Bit 2 - Transmit FIFO interrupt mask - 0: Transmit FIFO half empty or less condition interrupt is masked, 1: Transmit FIFO half empty or less condition interrupt is not masked"]
+    #[inline(always)]
+    #[must_use]
+    pub fn txim(&mut self) -> TXIM_W<SSP_IMSC_SPEC, 2> {
+        TXIM_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPIMSC register is the interrupt mask set or clear register. It is a RW register. On a read this register gives the current value of the mask on the relevant interrupt. A write of 1 to the particular bit sets the mask, enabling the interrupt to be read. A write of 0 clears the corresponding mask. All the bits are cleared to 0 when reset.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_imsc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_imsc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_IMSC_SPEC;
+impl crate::RegisterSpec for SSP_IMSC_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_imsc::R`](R) reader structure"]
+impl crate::Readable for SSP_IMSC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_imsc::W`](W) writer structure"]
+impl crate::Writable for SSP_IMSC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_mis.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_mis.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_mis` reader"]
+pub type R = crate::R<SSP_MIS_SPEC>;
+#[doc = "Register `ssp_mis` writer"]
+pub type W = crate::W<SSP_MIS_SPEC>;
+#[doc = "Field `rormis` reader - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+pub type RORMIS_R = crate::BitReader;
+#[doc = "Field `rtmis` reader - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+pub type RTMIS_R = crate::BitReader;
+#[doc = "Field `rxmis` reader - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+pub type RXMIS_R = crate::BitReader;
+#[doc = "Field `txmis` reader - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+pub type TXMIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rormis(&self) -> RORMIS_R {
+        RORMIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtmis(&self) -> RTMIS_R {
+        RTMIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxmis(&self) -> RXMIS_R {
+        RXMIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txmis(&self) -> TXMIS_R {
+        TXMIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPMIS register is the masked interrupt status register. It is a RO register. On a read this register gives the current masked status value of the corresponding interrupt. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_mis::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_mis::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_MIS_SPEC;
+impl crate::RegisterSpec for SSP_MIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_mis::R`](R) reader structure"]
+impl crate::Readable for SSP_MIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_mis::W`](W) writer structure"]
+impl crate::Writable for SSP_MIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id0` reader"]
+pub type R = crate::R<SSP_PCELL_ID0_SPEC>;
+#[doc = "Register `ssp_pcell_id0` writer"]
+pub type W = crate::W<SSP_PCELL_ID0_SPEC>;
+#[doc = "Field `ssp_pcell_id0` reader - The bits are read as 0xD"]
+pub type SSP_PCELL_ID0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xD"]
+    #[inline(always)]
+    pub fn ssp_pcell_id0(&self) -> SSP_PCELL_ID0_R {
+        SSP_PCELL_ID0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id1` reader"]
+pub type R = crate::R<SSP_PCELL_ID1_SPEC>;
+#[doc = "Register `ssp_pcell_id1` writer"]
+pub type W = crate::W<SSP_PCELL_ID1_SPEC>;
+#[doc = "Field `ssp_pcell_id1` reader - The bits are read as 0xF0"]
+pub type SSP_PCELL_ID1_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xF0"]
+    #[inline(always)]
+    pub fn ssp_pcell_id1(&self) -> SSP_PCELL_ID1_R {
+        SSP_PCELL_ID1_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id2` reader"]
+pub type R = crate::R<SSP_PCELL_ID2_SPEC>;
+#[doc = "Register `ssp_pcell_id2` writer"]
+pub type W = crate::W<SSP_PCELL_ID2_SPEC>;
+#[doc = "Field `ssp_pcell_id2` reader - The bits are read as 0x5"]
+pub type SSP_PCELL_ID2_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0x5"]
+    #[inline(always)]
+    pub fn ssp_pcell_id2(&self) -> SSP_PCELL_ID2_R {
+        SSP_PCELL_ID2_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_pcell_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_pcell_id3` reader"]
+pub type R = crate::R<SSP_PCELL_ID3_SPEC>;
+#[doc = "Register `ssp_pcell_id3` writer"]
+pub type W = crate::W<SSP_PCELL_ID3_SPEC>;
+#[doc = "Field `ssp_pcell_id3` reader - The bits are read as 0xB1"]
+pub type SSP_PCELL_ID3_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - The bits are read as 0xB1"]
+    #[inline(always)]
+    pub fn ssp_pcell_id3(&self) -> SSP_PCELL_ID3_R {
+        SSP_PCELL_ID3_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPCellID0-3 registers are four 8-bit wide registers, that span address locations 0xFF0-0xFFC. The registers can conceptually be treated as a 32-bit register. The register is used as a standard cross-peripheral identification system. The SSPPCellID register is set to 0xB105F00D.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_pcell_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_pcell_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PCELL_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PCELL_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_pcell_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PCELL_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_pcell_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PCELL_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id0.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id0` reader"]
+pub type R = crate::R<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Register `ssp_periph_id0` writer"]
+pub type W = crate::W<SSP_PERIPH_ID0_SPEC>;
+#[doc = "Field `part_number0` reader - These bits read back as 0x22"]
+pub type PART_NUMBER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x22"]
+    #[inline(always)]
+    pub fn part_number0(&self) -> PART_NUMBER0_R {
+        PART_NUMBER0_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID0 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID0_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID0_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id0::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id0::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id1.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id1.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id1` reader"]
+pub type R = crate::R<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Register `ssp_periph_id1` writer"]
+pub type W = crate::W<SSP_PERIPH_ID1_SPEC>;
+#[doc = "Field `part_number1` reader - These bits read back as 0x0"]
+pub type PART_NUMBER1_R = crate::FieldReader;
+#[doc = "Field `designer0` reader - These bits read back as 0x1"]
+pub type DESIGNER0_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x0"]
+    #[inline(always)]
+    pub fn part_number1(&self) -> PART_NUMBER1_R {
+        PART_NUMBER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits read back as 0x1"]
+    #[inline(always)]
+    pub fn designer0(&self) -> DESIGNER0_R {
+        DESIGNER0_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID1 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID1_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID1_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id1::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id1::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id2.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id2.rs
@@ -1,0 +1,40 @@
+#[doc = "Register `ssp_periph_id2` reader"]
+pub type R = crate::R<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Register `ssp_periph_id2` writer"]
+pub type W = crate::W<SSP_PERIPH_ID2_SPEC>;
+#[doc = "Field `designer1` reader - These bits read back as 0x4"]
+pub type DESIGNER1_R = crate::FieldReader;
+#[doc = "Field `revision` reader - These bits return the peripheral revision"]
+pub type REVISION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:3 - These bits read back as 0x4"]
+    #[inline(always)]
+    pub fn designer1(&self) -> DESIGNER1_R {
+        DESIGNER1_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - These bits return the peripheral revision"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID2 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID2_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID2_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id2::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id2::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id3.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_periph_id3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `ssp_periph_id3` reader"]
+pub type R = crate::R<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Register `ssp_periph_id3` writer"]
+pub type W = crate::W<SSP_PERIPH_ID3_SPEC>;
+#[doc = "Field `configuration` reader - These bits read back as 0x80"]
+pub type CONFIGURATION_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - These bits read back as 0x80"]
+    #[inline(always)]
+    pub fn configuration(&self) -> CONFIGURATION_R {
+        CONFIGURATION_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPPeriphID3 register is hard-coded and the fields within the register determine reset value. The SSPPeriphID0-3 registers are four 8-bit registers, that span address locations 0xFE0 to 0xFEC. The registers can conceptually be treated as a single 32-bit register.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_periph_id3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_periph_id3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_PERIPH_ID3_SPEC;
+impl crate::RegisterSpec for SSP_PERIPH_ID3_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_periph_id3::R`](R) reader structure"]
+impl crate::Readable for SSP_PERIPH_ID3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_periph_id3::W`](W) writer structure"]
+impl crate::Writable for SSP_PERIPH_ID3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_ris.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_ris.rs
@@ -1,0 +1,54 @@
+#[doc = "Register `ssp_ris` reader"]
+pub type R = crate::R<SSP_RIS_SPEC>;
+#[doc = "Register `ssp_ris` writer"]
+pub type W = crate::W<SSP_RIS_SPEC>;
+#[doc = "Field `rorris` reader - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+pub type RORRIS_R = crate::BitReader;
+#[doc = "Field `rtris` reader - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+pub type RTRIS_R = crate::BitReader;
+#[doc = "Field `rxris` reader - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+pub type RXRIS_R = crate::BitReader;
+#[doc = "Field `txris` reader - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+pub type TXRIS_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Gives the raw interrupt state, prior to masking, of the SSPRORINTR interrupt"]
+    #[inline(always)]
+    pub fn rorris(&self) -> RORRIS_R {
+        RORRIS_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Gives the raw interrupt state, prior to masking, of the SSPRTINTR interrupt"]
+    #[inline(always)]
+    pub fn rtris(&self) -> RTRIS_R {
+        RTRIS_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Gives the raw interrupt state, prior to masking, of the SSPRXINTR interrupt"]
+    #[inline(always)]
+    pub fn rxris(&self) -> RXRIS_R {
+        RXRIS_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Gives the raw interrupt state, prior to masking, of the SSPTXINTR interrupt"]
+    #[inline(always)]
+    pub fn txris(&self) -> TXRIS_R {
+        TXRIS_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "The SSPRIS register is the raw interrupt status register. It is a RO register. On a read this register gives the current raw status value of the corresponding interrupt prior to masking. A write has no effect.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_ris::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_ris::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_RIS_SPEC;
+impl crate::RegisterSpec for SSP_RIS_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_ris::R`](R) reader structure"]
+impl crate::Readable for SSP_RIS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_ris::W`](W) writer structure"]
+impl crate::Writable for SSP_RIS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_sr.rs
+++ b/jh7110-vf2-13b-pac/src/arm_pl022_6/ssp_sr.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `ssp_sr` reader"]
+pub type R = crate::R<SSP_SR_SPEC>;
+#[doc = "Register `ssp_sr` writer"]
+pub type W = crate::W<SSP_SR_SPEC>;
+#[doc = "Field `tfe` reader - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+pub type TFE_R = crate::BitReader;
+#[doc = "Field `tnf` reader - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+pub type TNF_R = crate::BitReader;
+#[doc = "Field `rne` reader - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+pub type RNE_R = crate::BitReader;
+#[doc = "Field `rff` reader - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+pub type RFF_R = crate::BitReader;
+#[doc = "Field `bsy` reader - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+pub type BSY_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Transmit FIFO empty, RO - 0: Transmit FIFO is not empty, 1: Transmit FIFO is empty."]
+    #[inline(always)]
+    pub fn tfe(&self) -> TFE_R {
+        TFE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Transmit FIFO not full, RO - 0: Transmit FIFO is full, 1: Transmit FIFO is not full."]
+    #[inline(always)]
+    pub fn tnf(&self) -> TNF_R {
+        TNF_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Receive FIFO not empty, RO - 0: Receive FIFO is empty, 1: Receive FIFO is not empty."]
+    #[inline(always)]
+    pub fn rne(&self) -> RNE_R {
+        RNE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - Receive FIFO full, RO - 0: Receive FIFO is not full, 1: Receive FIFO is full."]
+    #[inline(always)]
+    pub fn rff(&self) -> RFF_R {
+        RFF_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - PrimeCell SSP busy flag, RO - 0: SSP is idle, 1: SSP is currently transmitting and/or receiving a frame or the transmit FIFO is not empty."]
+    #[inline(always)]
+    pub fn bsy(&self) -> BSY_R {
+        BSY_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u16) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SSPSR is a RO status register that contains bits that indicate the FIFO fill status and the PrimeCell SSP busy status.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ssp_sr::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ssp_sr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SSP_SR_SPEC;
+impl crate::RegisterSpec for SSP_SR_SPEC {
+    type Ux = u16;
+}
+#[doc = "`read()` method returns [`ssp_sr::R`](R) reader structure"]
+impl crate::Readable for SSP_SR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ssp_sr::W`](W) writer structure"]
+impl crate::Writable for SSP_SR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/lib.rs
+++ b/jh7110-vf2-13b-pac/src/lib.rs
@@ -80,52 +80,6 @@ impl core::fmt::Debug for SIFIVE_CLINT0_0 {
 }
 #[doc = "From sifive,clint0, peripheral generator"]
 pub mod sifive_clint0_0;
-#[doc = "From sifive,plic0, peripheral generator"]
-pub struct SIFIVE_PLIC0_0 {
-    _marker: PhantomData<*const ()>,
-}
-unsafe impl Send for SIFIVE_PLIC0_0 {}
-impl SIFIVE_PLIC0_0 {
-    #[doc = r"Pointer to the register block"]
-    pub const PTR: *const sifive_plic0_0::RegisterBlock = 0x0c00_0000 as *const _;
-    #[doc = r"Return the pointer to the register block"]
-    #[inline(always)]
-    pub const fn ptr() -> *const sifive_plic0_0::RegisterBlock {
-        Self::PTR
-    }
-    #[doc = r" Steal an instance of this peripheral"]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r""]
-    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
-    #[doc = r" that may race with any existing instances, for example by only"]
-    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
-    #[doc = r" original peripheral and using critical sections to coordinate"]
-    #[doc = r" access between multiple new instances."]
-    #[doc = r""]
-    #[doc = r" Additionally, other software such as HALs may rely on only one"]
-    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
-    #[doc = r" no stolen instances are passed to such software."]
-    pub unsafe fn steal() -> Self {
-        Self {
-            _marker: PhantomData,
-        }
-    }
-}
-impl Deref for SIFIVE_PLIC0_0 {
-    type Target = sifive_plic0_0::RegisterBlock;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*Self::PTR }
-    }
-}
-impl core::fmt::Debug for SIFIVE_PLIC0_0 {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("SIFIVE_PLIC0_0").finish()
-    }
-}
-#[doc = "From sifive,plic0, peripheral generator"]
-pub mod sifive_plic0_0;
 #[doc = "From snps,designware-i2c, peripheral generator"]
 pub struct SNPS_DESIGNWARE_I2C_0 {
     _marker: PhantomData<*const ()>,
@@ -264,6 +218,144 @@ impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_2 {
 }
 #[doc = "From snps,designware-i2c, peripheral generator"]
 pub mod snps_designware_i2c_2;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_0 {}
+impl ARM_PL022_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_0::RegisterBlock = 0x1006_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_0 {
+    type Target = arm_pl022_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_0").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_0;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_1 {}
+impl ARM_PL022_1 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_1::RegisterBlock = 0x1007_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_1::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_1 {
+    type Target = arm_pl022_1::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_1 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_1").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_1;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_2 {}
+impl ARM_PL022_2 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_2::RegisterBlock = 0x1008_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_2::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_2 {
+    type Target = arm_pl022_2::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_2").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_2;
 #[doc = "From starfive,jh7110-stgcrg, peripheral generator"]
 pub struct STARFIVE_JH7110_STGCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -540,17 +632,17 @@ impl core::fmt::Debug for SNPS_DESIGNWARE_I2C_6 {
 }
 #[doc = "From snps,designware-i2c, peripheral generator"]
 pub mod snps_designware_i2c_6;
-#[doc = "From starfive,jh7110-pwm, peripheral generator"]
-pub struct STARFIVE_JH7110_PWM_0 {
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_3 {
     _marker: PhantomData<*const ()>,
 }
-unsafe impl Send for STARFIVE_JH7110_PWM_0 {}
-impl STARFIVE_JH7110_PWM_0 {
+unsafe impl Send for ARM_PL022_3 {}
+impl ARM_PL022_3 {
     #[doc = r"Pointer to the register block"]
-    pub const PTR: *const starfive_jh7110_pwm_0::RegisterBlock = 0x120d_0000 as *const _;
+    pub const PTR: *const arm_pl022_3::RegisterBlock = 0x1207_0000 as *const _;
     #[doc = r"Return the pointer to the register block"]
     #[inline(always)]
-    pub const fn ptr() -> *const starfive_jh7110_pwm_0::RegisterBlock {
+    pub const fn ptr() -> *const arm_pl022_3::RegisterBlock {
         Self::PTR
     }
     #[doc = r" Steal an instance of this peripheral"]
@@ -572,20 +664,158 @@ impl STARFIVE_JH7110_PWM_0 {
         }
     }
 }
-impl Deref for STARFIVE_JH7110_PWM_0 {
-    type Target = starfive_jh7110_pwm_0::RegisterBlock;
+impl Deref for ARM_PL022_3 {
+    type Target = arm_pl022_3::RegisterBlock;
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
         unsafe { &*Self::PTR }
     }
 }
-impl core::fmt::Debug for STARFIVE_JH7110_PWM_0 {
+impl core::fmt::Debug for ARM_PL022_3 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("STARFIVE_JH7110_PWM_0").finish()
+        f.debug_struct("ARM_PL022_3").finish()
     }
 }
-#[doc = "From starfive,jh7110-pwm, peripheral generator"]
-pub mod starfive_jh7110_pwm_0;
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_3;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_4 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_4 {}
+impl ARM_PL022_4 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_4::RegisterBlock = 0x1208_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_4::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_4 {
+    type Target = arm_pl022_4::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_4 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_4").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_4;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_5 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_5 {}
+impl ARM_PL022_5 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_5::RegisterBlock = 0x1209_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_5::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_5 {
+    type Target = arm_pl022_5::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_5 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_5").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_5;
+#[doc = "From arm,pl022, peripheral generator"]
+pub struct ARM_PL022_6 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ARM_PL022_6 {}
+impl ARM_PL022_6 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const arm_pl022_6::RegisterBlock = 0x120a_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const arm_pl022_6::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for ARM_PL022_6 {
+    type Target = arm_pl022_6::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for ARM_PL022_6 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("ARM_PL022_6").finish()
+    }
+}
+#[doc = "From arm,pl022, peripheral generator"]
+pub mod arm_pl022_6;
 #[doc = "From starfive,jh7110-syscrg, peripheral generator"]
 pub struct STARFIVE_JH7110_SYSCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -724,6 +954,52 @@ impl core::fmt::Debug for STARFIVE_JH7110_SYS_PINCTRL_0 {
 }
 #[doc = "From starfive,jh7110-sys-pinctrl, peripheral generator"]
 pub mod starfive_jh7110_sys_pinctrl_0;
+#[doc = "From starfive,jh7110-trng, peripheral generator"]
+pub struct STARFIVE_JH7110_TRNG_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for STARFIVE_JH7110_TRNG_0 {}
+impl STARFIVE_JH7110_TRNG_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const starfive_jh7110_trng_0::RegisterBlock = 0x1600_c000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const starfive_jh7110_trng_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for STARFIVE_JH7110_TRNG_0 {
+    type Target = starfive_jh7110_trng_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for STARFIVE_JH7110_TRNG_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("STARFIVE_JH7110_TRNG_0").finish()
+    }
+}
+#[doc = "From starfive,jh7110-trng, peripheral generator"]
+pub mod starfive_jh7110_trng_0;
 #[doc = "From starfive,jh7110-aoncrg, peripheral generator"]
 pub struct STARFIVE_JH7110_AONCRG_0 {
     _marker: PhantomData<*const ()>,
@@ -862,6 +1138,52 @@ impl core::fmt::Debug for STARFIVE_JH7110_AON_PINCTRL_0 {
 }
 #[doc = "From starfive,jh7110-aon-pinctrl, peripheral generator"]
 pub mod starfive_jh7110_aon_pinctrl_0;
+#[doc = "From starfive,jh7110-pmu, peripheral generator"]
+pub struct STARFIVE_JH7110_PMU_0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for STARFIVE_JH7110_PMU_0 {}
+impl STARFIVE_JH7110_PMU_0 {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const starfive_jh7110_pmu_0::RegisterBlock = 0x1703_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const starfive_jh7110_pmu_0::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for STARFIVE_JH7110_PMU_0 {
+    type Target = starfive_jh7110_pmu_0::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for STARFIVE_JH7110_PMU_0 {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("STARFIVE_JH7110_PMU_0").finish()
+    }
+}
+#[doc = "From starfive,jh7110-pmu, peripheral generator"]
+pub mod starfive_jh7110_pmu_0;
 #[no_mangle]
 static mut DEVICE_PERIPHERALS: bool = false;
 #[doc = r" All the peripherals."]
@@ -869,14 +1191,18 @@ static mut DEVICE_PERIPHERALS: bool = false;
 pub struct Peripherals {
     #[doc = "SIFIVE_CLINT0_0"]
     pub SIFIVE_CLINT0_0: SIFIVE_CLINT0_0,
-    #[doc = "SIFIVE_PLIC0_0"]
-    pub SIFIVE_PLIC0_0: SIFIVE_PLIC0_0,
     #[doc = "SNPS_DESIGNWARE_I2C_0"]
     pub SNPS_DESIGNWARE_I2C_0: SNPS_DESIGNWARE_I2C_0,
     #[doc = "SNPS_DESIGNWARE_I2C_1"]
     pub SNPS_DESIGNWARE_I2C_1: SNPS_DESIGNWARE_I2C_1,
     #[doc = "SNPS_DESIGNWARE_I2C_2"]
     pub SNPS_DESIGNWARE_I2C_2: SNPS_DESIGNWARE_I2C_2,
+    #[doc = "ARM_PL022_0"]
+    pub ARM_PL022_0: ARM_PL022_0,
+    #[doc = "ARM_PL022_1"]
+    pub ARM_PL022_1: ARM_PL022_1,
+    #[doc = "ARM_PL022_2"]
+    pub ARM_PL022_2: ARM_PL022_2,
     #[doc = "STARFIVE_JH7110_STGCRG_0"]
     pub STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0,
     #[doc = "STARFIVE_JH7110_STG_SYSCON_0"]
@@ -889,20 +1215,30 @@ pub struct Peripherals {
     pub SNPS_DESIGNWARE_I2C_5: SNPS_DESIGNWARE_I2C_5,
     #[doc = "SNPS_DESIGNWARE_I2C_6"]
     pub SNPS_DESIGNWARE_I2C_6: SNPS_DESIGNWARE_I2C_6,
-    #[doc = "STARFIVE_JH7110_PWM_0"]
-    pub STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0,
+    #[doc = "ARM_PL022_3"]
+    pub ARM_PL022_3: ARM_PL022_3,
+    #[doc = "ARM_PL022_4"]
+    pub ARM_PL022_4: ARM_PL022_4,
+    #[doc = "ARM_PL022_5"]
+    pub ARM_PL022_5: ARM_PL022_5,
+    #[doc = "ARM_PL022_6"]
+    pub ARM_PL022_6: ARM_PL022_6,
     #[doc = "STARFIVE_JH7110_SYSCRG_0"]
     pub STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0,
     #[doc = "STARFIVE_JH7110_SYS_SYSCON_0"]
     pub STARFIVE_JH7110_SYS_SYSCON_0: STARFIVE_JH7110_SYS_SYSCON_0,
     #[doc = "STARFIVE_JH7110_SYS_PINCTRL_0"]
     pub STARFIVE_JH7110_SYS_PINCTRL_0: STARFIVE_JH7110_SYS_PINCTRL_0,
+    #[doc = "STARFIVE_JH7110_TRNG_0"]
+    pub STARFIVE_JH7110_TRNG_0: STARFIVE_JH7110_TRNG_0,
     #[doc = "STARFIVE_JH7110_AONCRG_0"]
     pub STARFIVE_JH7110_AONCRG_0: STARFIVE_JH7110_AONCRG_0,
     #[doc = "STARFIVE_JH7110_AON_SYSCON_0"]
     pub STARFIVE_JH7110_AON_SYSCON_0: STARFIVE_JH7110_AON_SYSCON_0,
     #[doc = "STARFIVE_JH7110_AON_PINCTRL_0"]
     pub STARFIVE_JH7110_AON_PINCTRL_0: STARFIVE_JH7110_AON_PINCTRL_0,
+    #[doc = "STARFIVE_JH7110_PMU_0"]
+    pub STARFIVE_JH7110_PMU_0: STARFIVE_JH7110_PMU_0,
 }
 impl Peripherals {
     #[doc = r" Returns all the peripherals *once*."]
@@ -928,9 +1264,6 @@ impl Peripherals {
             SIFIVE_CLINT0_0: SIFIVE_CLINT0_0 {
                 _marker: PhantomData,
             },
-            SIFIVE_PLIC0_0: SIFIVE_PLIC0_0 {
-                _marker: PhantomData,
-            },
             SNPS_DESIGNWARE_I2C_0: SNPS_DESIGNWARE_I2C_0 {
                 _marker: PhantomData,
             },
@@ -938,6 +1271,15 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             SNPS_DESIGNWARE_I2C_2: SNPS_DESIGNWARE_I2C_2 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_0: ARM_PL022_0 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_1: ARM_PL022_1 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_2: ARM_PL022_2 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_STGCRG_0: STARFIVE_JH7110_STGCRG_0 {
@@ -958,7 +1300,16 @@ impl Peripherals {
             SNPS_DESIGNWARE_I2C_6: SNPS_DESIGNWARE_I2C_6 {
                 _marker: PhantomData,
             },
-            STARFIVE_JH7110_PWM_0: STARFIVE_JH7110_PWM_0 {
+            ARM_PL022_3: ARM_PL022_3 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_4: ARM_PL022_4 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_5: ARM_PL022_5 {
+                _marker: PhantomData,
+            },
+            ARM_PL022_6: ARM_PL022_6 {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_SYSCRG_0: STARFIVE_JH7110_SYSCRG_0 {
@@ -970,6 +1321,9 @@ impl Peripherals {
             STARFIVE_JH7110_SYS_PINCTRL_0: STARFIVE_JH7110_SYS_PINCTRL_0 {
                 _marker: PhantomData,
             },
+            STARFIVE_JH7110_TRNG_0: STARFIVE_JH7110_TRNG_0 {
+                _marker: PhantomData,
+            },
             STARFIVE_JH7110_AONCRG_0: STARFIVE_JH7110_AONCRG_0 {
                 _marker: PhantomData,
             },
@@ -977,6 +1331,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             STARFIVE_JH7110_AON_PINCTRL_0: STARFIVE_JH7110_AON_PINCTRL_0 {
+                _marker: PhantomData,
+            },
+            STARFIVE_JH7110_PMU_0: STARFIVE_JH7110_PMU_0 {
                 _marker: PhantomData,
             },
         }

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0.rs
@@ -1,0 +1,159 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    _reserved0: [u8; 0x04],
+    #[doc = "0x04 - Hardware Event Turn-On Mask"]
+    pub hard_event_turn_on_mask: HARD_EVENT_TURN_ON_MASK,
+    _reserved1: [u8; 0x04],
+    #[doc = "0x0c - Software Turn-On Power Mode"]
+    pub soft_turn_on_power_mode: SOFT_TURN_ON_POWER_MODE,
+    #[doc = "0x10 - Software Turn-Off Power Mode"]
+    pub soft_turn_off_power_mode: SOFT_TURN_OFF_POWER_MODE,
+    #[doc = "0x14 - Threshold Sequence Timeout"]
+    pub timeout_seq_thd: TIMEOUT_SEQ_THD,
+    #[doc = "0x18 - Powerdomain Cascade 0"]
+    pub pdc0: PDC0,
+    #[doc = "0x1c - Powerdomain Cascade 1"]
+    pub pdc1: PDC1,
+    #[doc = "0x20 - Powerdomain Cascade 2"]
+    pub pdc2: PDC2,
+    _reserved7: [u8; 0x20],
+    #[doc = "0x44 - Software Encouragement"]
+    pub sw_encourage: SW_ENCOURAGE,
+    #[doc = "0x48 - TIMER Interrupt Mask"]
+    pub tim: TIM,
+    #[doc = "0x4c - P-channel Bypass"]
+    pub pch_bypass: PCH_BYPASS,
+    #[doc = "0x50 - P-channel PSTATE"]
+    pub pch_pstate: PCH_PSTATE,
+    #[doc = "0x54 - P-channel Timeout Threshold"]
+    pub pch_timeout: PCH_TIMEOUT,
+    #[doc = "0x58 - LP Cell Control Timeout Threshold"]
+    pub lp_timeout: LP_TIMEOUT,
+    #[doc = "0x5c - Hardware Turn-On Power Mode"]
+    pub hard_turn_on_power_mode: HARD_TURN_ON_POWER_MODE,
+    _reserved14: [u8; 0x20],
+    #[doc = "0x80 - Current Power Mode"]
+    pub current_power_mode: CURRENT_POWER_MODE,
+    #[doc = "0x84 - Current Sequence State"]
+    pub current_seq_state: CURRENT_SEQ_STATE,
+    #[doc = "0x88 - PMU Event Status"]
+    pub event_status: EVENT_STATUS,
+    #[doc = "0x8c - PMU Interrupt Status"]
+    pub int_status: INT_STATUS,
+    #[doc = "0x90 - Hardware Event Record"]
+    pub hw_event_crd: HW_EVENT_CRD,
+    #[doc = "0x94 - Hardware Event Type Record"]
+    pub encourage_type_crd: ENCOURAGE_TYPE_CRD,
+    #[doc = "0x98 - P-channel PACTIVE Status"]
+    pub pch_active: PCH_ACTIVE,
+}
+#[doc = "hard_event_turn_on_mask (rw) register accessor: Hardware Event Turn-On Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hard_event_turn_on_mask::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hard_event_turn_on_mask::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hard_event_turn_on_mask`]
+module"]
+pub type HARD_EVENT_TURN_ON_MASK =
+    crate::Reg<hard_event_turn_on_mask::HARD_EVENT_TURN_ON_MASK_SPEC>;
+#[doc = "Hardware Event Turn-On Mask"]
+pub mod hard_event_turn_on_mask;
+#[doc = "soft_turn_on_power_mode (rw) register accessor: Software Turn-On Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_turn_on_power_mode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_turn_on_power_mode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`soft_turn_on_power_mode`]
+module"]
+pub type SOFT_TURN_ON_POWER_MODE =
+    crate::Reg<soft_turn_on_power_mode::SOFT_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Software Turn-On Power Mode"]
+pub mod soft_turn_on_power_mode;
+#[doc = "soft_turn_off_power_mode (rw) register accessor: Software Turn-Off Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_turn_off_power_mode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_turn_off_power_mode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`soft_turn_off_power_mode`]
+module"]
+pub type SOFT_TURN_OFF_POWER_MODE =
+    crate::Reg<soft_turn_off_power_mode::SOFT_TURN_OFF_POWER_MODE_SPEC>;
+#[doc = "Software Turn-Off Power Mode"]
+pub mod soft_turn_off_power_mode;
+#[doc = "timeout_seq_thd (rw) register accessor: Threshold Sequence Timeout\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`timeout_seq_thd::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`timeout_seq_thd::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`timeout_seq_thd`]
+module"]
+pub type TIMEOUT_SEQ_THD = crate::Reg<timeout_seq_thd::TIMEOUT_SEQ_THD_SPEC>;
+#[doc = "Threshold Sequence Timeout"]
+pub mod timeout_seq_thd;
+#[doc = "pdc0 (rw) register accessor: Powerdomain Cascade 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pdc0`]
+module"]
+pub type PDC0 = crate::Reg<pdc0::PDC0_SPEC>;
+#[doc = "Powerdomain Cascade 0"]
+pub mod pdc0;
+#[doc = "pdc1 (rw) register accessor: Powerdomain Cascade 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pdc1`]
+module"]
+pub type PDC1 = crate::Reg<pdc1::PDC1_SPEC>;
+#[doc = "Powerdomain Cascade 1"]
+pub mod pdc1;
+#[doc = "pdc2 (rw) register accessor: Powerdomain Cascade 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pdc2`]
+module"]
+pub type PDC2 = crate::Reg<pdc2::PDC2_SPEC>;
+#[doc = "Powerdomain Cascade 2"]
+pub mod pdc2;
+#[doc = "sw_encourage (rw) register accessor: Software Encouragement\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`sw_encourage`]
+module"]
+pub type SW_ENCOURAGE = crate::Reg<sw_encourage::SW_ENCOURAGE_SPEC>;
+#[doc = "Software Encouragement"]
+pub mod sw_encourage;
+#[doc = "tim (rw) register accessor: TIMER Interrupt Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`tim`]
+module"]
+pub type TIM = crate::Reg<tim::TIM_SPEC>;
+#[doc = "TIMER Interrupt Mask"]
+pub mod tim;
+#[doc = "pch_bypass (rw) register accessor: P-channel Bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_bypass`]
+module"]
+pub type PCH_BYPASS = crate::Reg<pch_bypass::PCH_BYPASS_SPEC>;
+#[doc = "P-channel Bypass"]
+pub mod pch_bypass;
+#[doc = "pch_pstate (rw) register accessor: P-channel PSTATE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_pstate::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_pstate::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_pstate`]
+module"]
+pub type PCH_PSTATE = crate::Reg<pch_pstate::PCH_PSTATE_SPEC>;
+#[doc = "P-channel PSTATE"]
+pub mod pch_pstate;
+#[doc = "pch_timeout (rw) register accessor: P-channel Timeout Threshold\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_timeout::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_timeout::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_timeout`]
+module"]
+pub type PCH_TIMEOUT = crate::Reg<pch_timeout::PCH_TIMEOUT_SPEC>;
+#[doc = "P-channel Timeout Threshold"]
+pub mod pch_timeout;
+#[doc = "lp_timeout (rw) register accessor: LP Cell Control Timeout Threshold\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_timeout::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_timeout::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`lp_timeout`]
+module"]
+pub type LP_TIMEOUT = crate::Reg<lp_timeout::LP_TIMEOUT_SPEC>;
+#[doc = "LP Cell Control Timeout Threshold"]
+pub mod lp_timeout;
+#[doc = "hard_turn_on_power_mode (rw) register accessor: Hardware Turn-On Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hard_turn_on_power_mode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hard_turn_on_power_mode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hard_turn_on_power_mode`]
+module"]
+pub type HARD_TURN_ON_POWER_MODE =
+    crate::Reg<hard_turn_on_power_mode::HARD_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Hardware Turn-On Power Mode"]
+pub mod hard_turn_on_power_mode;
+#[doc = "current_power_mode (rw) register accessor: Current Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`current_power_mode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`current_power_mode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`current_power_mode`]
+module"]
+pub type CURRENT_POWER_MODE = crate::Reg<current_power_mode::CURRENT_POWER_MODE_SPEC>;
+#[doc = "Current Power Mode"]
+pub mod current_power_mode;
+#[doc = "current_seq_state (rw) register accessor: Current Sequence State\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`current_seq_state::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`current_seq_state::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`current_seq_state`]
+module"]
+pub type CURRENT_SEQ_STATE = crate::Reg<current_seq_state::CURRENT_SEQ_STATE_SPEC>;
+#[doc = "Current Sequence State"]
+pub mod current_seq_state;
+#[doc = "event_status (rw) register accessor: PMU Event Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`event_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`event_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`event_status`]
+module"]
+pub type EVENT_STATUS = crate::Reg<event_status::EVENT_STATUS_SPEC>;
+#[doc = "PMU Event Status"]
+pub mod event_status;
+#[doc = "int_status (rw) register accessor: PMU Interrupt Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`int_status`]
+module"]
+pub type INT_STATUS = crate::Reg<int_status::INT_STATUS_SPEC>;
+#[doc = "PMU Interrupt Status"]
+pub mod int_status;
+#[doc = "hw_event_crd (rw) register accessor: Hardware Event Record\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hw_event_crd::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hw_event_crd::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`hw_event_crd`]
+module"]
+pub type HW_EVENT_CRD = crate::Reg<hw_event_crd::HW_EVENT_CRD_SPEC>;
+#[doc = "Hardware Event Record"]
+pub mod hw_event_crd;
+#[doc = "encourage_type_crd (rw) register accessor: Hardware Event Type Record\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`encourage_type_crd::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`encourage_type_crd::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`encourage_type_crd`]
+module"]
+pub type ENCOURAGE_TYPE_CRD = crate::Reg<encourage_type_crd::ENCOURAGE_TYPE_CRD_SPEC>;
+#[doc = "Hardware Event Type Record"]
+pub mod encourage_type_crd;
+#[doc = "pch_active (rw) register accessor: P-channel PACTIVE Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_active::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_active::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`pch_active`]
+module"]
+pub type PCH_ACTIVE = crate::Reg<pch_active::PCH_ACTIVE_SPEC>;
+#[doc = "P-channel PACTIVE Status"]
+pub mod pch_active;

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/current_power_mode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/current_power_mode.rs
@@ -1,0 +1,131 @@
+#[doc = "Register `current_power_mode` reader"]
+pub type R = crate::R<CURRENT_POWER_MODE_SPEC>;
+#[doc = "Register `current_power_mode` writer"]
+pub type W = crate::W<CURRENT_POWER_MODE_SPEC>;
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cpu_power_mode` reader - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `cpu_power_mode` writer - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vout_power_mode` reader - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vout_power_mode` writer - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `isp_power_mode` reader - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `isp_power_mode` writer - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `venc_power_mode` reader - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `venc_power_mode` writer - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
+        SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
+        CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
+        GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
+        VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
+        VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
+        ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
+        VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 0> {
+        SYSTOP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 1> {
+        CPU_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 2> {
+        GPUA_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 3> {
+        VDEC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 4> {
+        VOUT_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 5> {
+        ISP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<CURRENT_POWER_MODE_SPEC, 6> {
+        VENC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Current Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`current_power_mode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`current_power_mode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CURRENT_POWER_MODE_SPEC;
+impl crate::RegisterSpec for CURRENT_POWER_MODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`current_power_mode::R`](R) reader structure"]
+impl crate::Readable for CURRENT_POWER_MODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`current_power_mode::W`](W) writer structure"]
+impl crate::Writable for CURRENT_POWER_MODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/current_seq_state.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/current_seq_state.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `current_seq_state` reader"]
+pub type R = crate::R<CURRENT_SEQ_STATE_SPEC>;
+#[doc = "Register `current_seq_state` writer"]
+pub type W = crate::W<CURRENT_SEQ_STATE_SPEC>;
+#[doc = "Field `power_mode_cur` reader - Current sequence state."]
+pub type POWER_MODE_CUR_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:1 - Current sequence state."]
+    #[inline(always)]
+    pub fn power_mode_cur(&self) -> POWER_MODE_CUR_R {
+        POWER_MODE_CUR_R::new((self.bits & 3) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Current Sequence State\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`current_seq_state::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`current_seq_state::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CURRENT_SEQ_STATE_SPEC;
+impl crate::RegisterSpec for CURRENT_SEQ_STATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`current_seq_state::R`](R) reader structure"]
+impl crate::Readable for CURRENT_SEQ_STATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`current_seq_state::W`](W) writer structure"]
+impl crate::Writable for CURRENT_SEQ_STATE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/encourage_type_crd.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/encourage_type_crd.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `encourage_type_crd` reader"]
+pub type R = crate::R<ENCOURAGE_TYPE_CRD_SPEC>;
+#[doc = "Register `encourage_type_crd` writer"]
+pub type W = crate::W<ENCOURAGE_TYPE_CRD_SPEC>;
+#[doc = "Field `encourage_type_crd` reader - Hardware/Software encouragement type record. 0: Software, 1: Hardware."]
+pub type ENCOURAGE_TYPE_CRD_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - Hardware/Software encouragement type record. 0: Software, 1: Hardware."]
+    #[inline(always)]
+    pub fn encourage_type_crd(&self) -> ENCOURAGE_TYPE_CRD_R {
+        ENCOURAGE_TYPE_CRD_R::new((self.bits & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Hardware Event Type Record\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`encourage_type_crd::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`encourage_type_crd::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ENCOURAGE_TYPE_CRD_SPEC;
+impl crate::RegisterSpec for ENCOURAGE_TYPE_CRD_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`encourage_type_crd::R`](R) reader structure"]
+impl crate::Readable for ENCOURAGE_TYPE_CRD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`encourage_type_crd::W`](W) writer structure"]
+impl crate::Writable for ENCOURAGE_TYPE_CRD_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/event_status.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/event_status.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `event_status` reader"]
+pub type R = crate::R<EVENT_STATUS_SPEC>;
+#[doc = "Register `event_status` writer"]
+pub type W = crate::W<EVENT_STATUS_SPEC>;
+#[doc = "Field `seq_done_event` reader - Sequence complete."]
+pub type SEQ_DONE_EVENT_R = crate::BitReader;
+#[doc = "Field `hw_req_event` reader - Hardware encouragement request."]
+pub type HW_REQ_EVENT_R = crate::BitReader;
+#[doc = "Field `sw_fail_event` reader - Software encouragement failure."]
+pub type SW_FAIL_EVENT_R = crate::FieldReader;
+#[doc = "Field `hw_fail_event` reader - Hardware encouragement failure."]
+pub type HW_FAIL_EVENT_R = crate::FieldReader;
+#[doc = "Field `pch_fail_event` reader - P-channel failure."]
+pub type PCH_FAIL_EVENT_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - Sequence complete."]
+    #[inline(always)]
+    pub fn seq_done_event(&self) -> SEQ_DONE_EVENT_R {
+        SEQ_DONE_EVENT_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Hardware encouragement request."]
+    #[inline(always)]
+    pub fn hw_req_event(&self) -> HW_REQ_EVENT_R {
+        HW_REQ_EVENT_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:3 - Software encouragement failure."]
+    #[inline(always)]
+    pub fn sw_fail_event(&self) -> SW_FAIL_EVENT_R {
+        SW_FAIL_EVENT_R::new(((self.bits >> 2) & 3) as u8)
+    }
+    #[doc = "Bits 4:5 - Hardware encouragement failure."]
+    #[inline(always)]
+    pub fn hw_fail_event(&self) -> HW_FAIL_EVENT_R {
+        HW_FAIL_EVENT_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bits 6:8 - P-channel failure."]
+    #[inline(always)]
+    pub fn pch_fail_event(&self) -> PCH_FAIL_EVENT_R {
+        PCH_FAIL_EVENT_R::new(((self.bits >> 6) & 7) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PMU Event Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`event_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`event_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct EVENT_STATUS_SPEC;
+impl crate::RegisterSpec for EVENT_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`event_status::R`](R) reader structure"]
+impl crate::Readable for EVENT_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`event_status::W`](W) writer structure"]
+impl crate::Writable for EVENT_STATUS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hard_event_turn_on_mask.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hard_event_turn_on_mask.rs
@@ -1,0 +1,162 @@
+#[doc = "Register `hard_event_turn_on_mask` reader"]
+pub type R = crate::R<HARD_EVENT_TURN_ON_MASK_SPEC>;
+#[doc = "Register `hard_event_turn_on_mask` writer"]
+pub type W = crate::W<HARD_EVENT_TURN_ON_MASK_SPEC>;
+#[doc = "Field `hard_event_0_on_mask` reader - RTC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_0_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_0_on_mask` writer - RTC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_0_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_1_on_mask` reader - GMAC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_1_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_1_on_mask` writer - GMAC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_1_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_2_on_mask` reader - RFU, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_2_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_2_on_mask` writer - RFU, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_2_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_3_on_mask` reader - RGPIO0 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_3_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_3_on_mask` writer - RGPIO0 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_3_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_4_on_mask` reader - RGPIO1 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_4_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_4_on_mask` writer - RGPIO1 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_4_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_5_on_mask` reader - RGPIO2 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_5_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_5_on_mask` writer - RGPIO2 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_5_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_6_on_mask` reader - RGPIO3 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_6_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_6_on_mask` writer - RGPIO3 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_6_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hard_event_7_on_mask` reader - GPU event, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_7_ON_MASK_R = crate::BitReader;
+#[doc = "Field `hard_event_7_on_mask` writer - GPU event, 1: mask hardware event, 0: enable hardware event"]
+pub type HARD_EVENT_7_ON_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - RTC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_0_on_mask(&self) -> HARD_EVENT_0_ON_MASK_R {
+        HARD_EVENT_0_ON_MASK_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - GMAC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_1_on_mask(&self) -> HARD_EVENT_1_ON_MASK_R {
+        HARD_EVENT_1_ON_MASK_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - RFU, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_2_on_mask(&self) -> HARD_EVENT_2_ON_MASK_R {
+        HARD_EVENT_2_ON_MASK_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - RGPIO0 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_3_on_mask(&self) -> HARD_EVENT_3_ON_MASK_R {
+        HARD_EVENT_3_ON_MASK_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - RGPIO1 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_4_on_mask(&self) -> HARD_EVENT_4_ON_MASK_R {
+        HARD_EVENT_4_ON_MASK_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - RGPIO2 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_5_on_mask(&self) -> HARD_EVENT_5_ON_MASK_R {
+        HARD_EVENT_5_ON_MASK_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - RGPIO3 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_6_on_mask(&self) -> HARD_EVENT_6_ON_MASK_R {
+        HARD_EVENT_6_ON_MASK_R::new(((self.bits >> 6) & 1) != 0)
+    }
+    #[doc = "Bit 7 - GPU event, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    pub fn hard_event_7_on_mask(&self) -> HARD_EVENT_7_ON_MASK_R {
+        HARD_EVENT_7_ON_MASK_R::new(((self.bits >> 7) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - RTC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_0_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_0_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 0> {
+        HARD_EVENT_0_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 1 - GMAC event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_1_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_1_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 1> {
+        HARD_EVENT_1_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 2 - RFU, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_2_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_2_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 2> {
+        HARD_EVENT_2_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 3 - RGPIO0 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_3_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_3_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 3> {
+        HARD_EVENT_3_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 4 - RGPIO1 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_4_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_4_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 4> {
+        HARD_EVENT_4_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 5 - RGPIO2 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_5_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_5_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 5> {
+        HARD_EVENT_5_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 6 - RGPIO3 event encourage turn-on sequence, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_6_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_6_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 6> {
+        HARD_EVENT_6_ON_MASK_W::new(self)
+    }
+    #[doc = "Bit 7 - GPU event, 1: mask hardware event, 0: enable hardware event"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hard_event_7_on_mask(
+        &mut self,
+    ) -> HARD_EVENT_7_ON_MASK_W<HARD_EVENT_TURN_ON_MASK_SPEC, 7> {
+        HARD_EVENT_7_ON_MASK_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Hardware Event Turn-On Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hard_event_turn_on_mask::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hard_event_turn_on_mask::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HARD_EVENT_TURN_ON_MASK_SPEC;
+impl crate::RegisterSpec for HARD_EVENT_TURN_ON_MASK_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hard_event_turn_on_mask::R`](R) reader structure"]
+impl crate::Readable for HARD_EVENT_TURN_ON_MASK_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hard_event_turn_on_mask::W`](W) writer structure"]
+impl crate::Writable for HARD_EVENT_TURN_ON_MASK_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hard_turn_on_power_mode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hard_turn_on_power_mode.rs
@@ -1,0 +1,131 @@
+#[doc = "Register `hard_turn_on_power_mode` reader"]
+pub type R = crate::R<HARD_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Register `hard_turn_on_power_mode` writer"]
+pub type W = crate::W<HARD_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cpu_power_mode` reader - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `cpu_power_mode` writer - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vout_power_mode` reader - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vout_power_mode` writer - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `isp_power_mode` reader - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `isp_power_mode` writer - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `venc_power_mode` reader - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `venc_power_mode` writer - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
+        SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
+        CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
+        GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
+        VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
+        VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
+        ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
+        VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 0> {
+        SYSTOP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 1> {
+        CPU_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 2> {
+        GPUA_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 3> {
+        VDEC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 4> {
+        VOUT_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 5> {
+        ISP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<HARD_TURN_ON_POWER_MODE_SPEC, 6> {
+        VENC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Hardware Turn-On Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hard_turn_on_power_mode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hard_turn_on_power_mode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HARD_TURN_ON_POWER_MODE_SPEC;
+impl crate::RegisterSpec for HARD_TURN_ON_POWER_MODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hard_turn_on_power_mode::R`](R) reader structure"]
+impl crate::Readable for HARD_TURN_ON_POWER_MODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hard_turn_on_power_mode::W`](W) writer structure"]
+impl crate::Writable for HARD_TURN_ON_POWER_MODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hw_event_crd.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/hw_event_crd.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `hw_event_crd` reader"]
+pub type R = crate::R<HW_EVENT_CRD_SPEC>;
+#[doc = "Register `hw_event_crd` writer"]
+pub type W = crate::W<HW_EVENT_CRD_SPEC>;
+#[doc = "Field `hw_event_crd` reader - Hardware Event Record."]
+pub type HW_EVENT_CRD_R = crate::FieldReader;
+impl R {
+    #[doc = "Bits 0:7 - Hardware Event Record."]
+    #[inline(always)]
+    pub fn hw_event_crd(&self) -> HW_EVENT_CRD_R {
+        HW_EVENT_CRD_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Hardware Event Record\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`hw_event_crd::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`hw_event_crd::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct HW_EVENT_CRD_SPEC;
+impl crate::RegisterSpec for HW_EVENT_CRD_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`hw_event_crd::R`](R) reader structure"]
+impl crate::Readable for HW_EVENT_CRD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`hw_event_crd::W`](W) writer structure"]
+impl crate::Writable for HW_EVENT_CRD_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/int_status.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/int_status.rs
@@ -1,0 +1,61 @@
+#[doc = "Register `int_status` reader"]
+pub type R = crate::R<INT_STATUS_SPEC>;
+#[doc = "Register `int_status` writer"]
+pub type W = crate::W<INT_STATUS_SPEC>;
+#[doc = "Field `seq_done_event` reader - Sequence complete."]
+pub type SEQ_DONE_EVENT_R = crate::BitReader;
+#[doc = "Field `hw_req_event` reader - Hardware encouragement request."]
+pub type HW_REQ_EVENT_R = crate::BitReader;
+#[doc = "Field `sw_fail_event` reader - Software encouragement failure."]
+pub type SW_FAIL_EVENT_R = crate::FieldReader;
+#[doc = "Field `hw_fail_event` reader - Hardware encouragement failure."]
+pub type HW_FAIL_EVENT_R = crate::FieldReader;
+#[doc = "Field `pch_fail_event` reader - P-channel failure."]
+pub type PCH_FAIL_EVENT_R = crate::FieldReader;
+impl R {
+    #[doc = "Bit 0 - Sequence complete."]
+    #[inline(always)]
+    pub fn seq_done_event(&self) -> SEQ_DONE_EVENT_R {
+        SEQ_DONE_EVENT_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Hardware encouragement request."]
+    #[inline(always)]
+    pub fn hw_req_event(&self) -> HW_REQ_EVENT_R {
+        HW_REQ_EVENT_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:3 - Software encouragement failure."]
+    #[inline(always)]
+    pub fn sw_fail_event(&self) -> SW_FAIL_EVENT_R {
+        SW_FAIL_EVENT_R::new(((self.bits >> 2) & 3) as u8)
+    }
+    #[doc = "Bits 4:5 - Hardware encouragement failure."]
+    #[inline(always)]
+    pub fn hw_fail_event(&self) -> HW_FAIL_EVENT_R {
+        HW_FAIL_EVENT_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bits 6:8 - P-channel failure."]
+    #[inline(always)]
+    pub fn pch_fail_event(&self) -> PCH_FAIL_EVENT_R {
+        PCH_FAIL_EVENT_R::new(((self.bits >> 6) & 7) as u8)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "PMU Interrupt Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`int_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`int_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct INT_STATUS_SPEC;
+impl crate::RegisterSpec for INT_STATUS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`int_status::R`](R) reader structure"]
+impl crate::Readable for INT_STATUS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`int_status::W`](W) writer structure"]
+impl crate::Writable for INT_STATUS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/lp_timeout.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/lp_timeout.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `lp_timeout` reader"]
+pub type R = crate::R<LP_TIMEOUT_SPEC>;
+#[doc = "Register `lp_timeout` writer"]
+pub type W = crate::W<LP_TIMEOUT_SPEC>;
+#[doc = "Field `lp_timeout` reader - LP Cell Control signal waiting carries acknowledge timeout."]
+pub type LP_TIMEOUT_R = crate::FieldReader;
+#[doc = "Field `lp_timeout` writer - LP Cell Control signal waiting carries acknowledge timeout."]
+pub type LP_TIMEOUT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - LP Cell Control signal waiting carries acknowledge timeout."]
+    #[inline(always)]
+    pub fn lp_timeout(&self) -> LP_TIMEOUT_R {
+        LP_TIMEOUT_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - LP Cell Control signal waiting carries acknowledge timeout."]
+    #[inline(always)]
+    #[must_use]
+    pub fn lp_timeout(&mut self) -> LP_TIMEOUT_W<LP_TIMEOUT_SPEC, 0> {
+        LP_TIMEOUT_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "LP Cell Control Timeout Threshold\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`lp_timeout::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`lp_timeout::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct LP_TIMEOUT_SPEC;
+impl crate::RegisterSpec for LP_TIMEOUT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`lp_timeout::R`](R) reader structure"]
+impl crate::Readable for LP_TIMEOUT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`lp_timeout::W`](W) writer structure"]
+impl crate::Writable for LP_TIMEOUT_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_active.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_active.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `pch_active` reader"]
+pub type R = crate::R<PCH_ACTIVE_SPEC>;
+#[doc = "Register `pch_active` writer"]
+pub type W = crate::W<PCH_ACTIVE_SPEC>;
+#[doc = "Field `pch_active` reader - P-channel PACTIVE status."]
+pub type PCH_ACTIVE_R = crate::FieldReader<u16>;
+impl R {
+    #[doc = "Bits 0:10 - P-channel PACTIVE status."]
+    #[inline(always)]
+    pub fn pch_active(&self) -> PCH_ACTIVE_R {
+        PCH_ACTIVE_R::new((self.bits & 0x07ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "P-channel PACTIVE Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_active::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_active::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PCH_ACTIVE_SPEC;
+impl crate::RegisterSpec for PCH_ACTIVE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pch_active::R`](R) reader structure"]
+impl crate::Readable for PCH_ACTIVE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pch_active::W`](W) writer structure"]
+impl crate::Writable for PCH_ACTIVE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_bypass.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_bypass.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `pch_bypass` reader"]
+pub type R = crate::R<PCH_BYPASS_SPEC>;
+#[doc = "Register `pch_bypass` writer"]
+pub type W = crate::W<PCH_BYPASS_SPEC>;
+#[doc = "Field `pch_bypass` reader - Bypass P-channel. 0: enable p-channel, 1: bypass p-channel"]
+pub type PCH_BYPASS_R = crate::BitReader;
+#[doc = "Field `pch_bypass` writer - Bypass P-channel. 0: enable p-channel, 1: bypass p-channel"]
+pub type PCH_BYPASS_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Bypass P-channel. 0: enable p-channel, 1: bypass p-channel"]
+    #[inline(always)]
+    pub fn pch_bypass(&self) -> PCH_BYPASS_R {
+        PCH_BYPASS_R::new((self.bits & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Bypass P-channel. 0: enable p-channel, 1: bypass p-channel"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pch_bypass(&mut self) -> PCH_BYPASS_W<PCH_BYPASS_SPEC, 0> {
+        PCH_BYPASS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "P-channel Bypass\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_bypass::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_bypass::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PCH_BYPASS_SPEC;
+impl crate::RegisterSpec for PCH_BYPASS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pch_bypass::R`](R) reader structure"]
+impl crate::Readable for PCH_BYPASS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pch_bypass::W`](W) writer structure"]
+impl crate::Writable for PCH_BYPASS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_pstate.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_pstate.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `pch_pstate` reader"]
+pub type R = crate::R<PCH_PSTATE_SPEC>;
+#[doc = "Register `pch_pstate` writer"]
+pub type W = crate::W<PCH_PSTATE_SPEC>;
+#[doc = "Field `pch_pstate` reader - P-channel state set"]
+pub type PCH_PSTATE_R = crate::FieldReader;
+#[doc = "Field `pch_pstate` writer - P-channel state set"]
+pub type PCH_PSTATE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+impl R {
+    #[doc = "Bits 0:4 - P-channel state set"]
+    #[inline(always)]
+    pub fn pch_pstate(&self) -> PCH_PSTATE_R {
+        PCH_PSTATE_R::new((self.bits & 0x1f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - P-channel state set"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pch_pstate(&mut self) -> PCH_PSTATE_W<PCH_PSTATE_SPEC, 0> {
+        PCH_PSTATE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "P-channel PSTATE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_pstate::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_pstate::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PCH_PSTATE_SPEC;
+impl crate::RegisterSpec for PCH_PSTATE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pch_pstate::R`](R) reader structure"]
+impl crate::Readable for PCH_PSTATE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pch_pstate::W`](W) writer structure"]
+impl crate::Writable for PCH_PSTATE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_timeout.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pch_timeout.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `pch_timeout` reader"]
+pub type R = crate::R<PCH_TIMEOUT_SPEC>;
+#[doc = "Register `pch_timeout` writer"]
+pub type W = crate::W<PCH_TIMEOUT_SPEC>;
+#[doc = "Field `pch_timeout` reader - P-channel waiting device acknowledge timeout."]
+pub type PCH_TIMEOUT_R = crate::FieldReader;
+#[doc = "Field `pch_timeout` writer - P-channel waiting device acknowledge timeout."]
+pub type PCH_TIMEOUT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - P-channel waiting device acknowledge timeout."]
+    #[inline(always)]
+    pub fn pch_timeout(&self) -> PCH_TIMEOUT_R {
+        PCH_TIMEOUT_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - P-channel waiting device acknowledge timeout."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pch_timeout(&mut self) -> PCH_TIMEOUT_W<PCH_TIMEOUT_SPEC, 0> {
+        PCH_TIMEOUT_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "P-channel Timeout Threshold\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pch_timeout::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pch_timeout::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PCH_TIMEOUT_SPEC;
+impl crate::RegisterSpec for PCH_TIMEOUT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pch_timeout::R`](R) reader structure"]
+impl crate::Readable for PCH_TIMEOUT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pch_timeout::W`](W) writer structure"]
+impl crate::Writable for PCH_TIMEOUT_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc0.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc0.rs
@@ -1,0 +1,116 @@
+#[doc = "Register `pdc0` reader"]
+pub type R = crate::R<PDC0_SPEC>;
+#[doc = "Register `pdc0` writer"]
+pub type W = crate::W<PDC0_SPEC>;
+#[doc = "Field `pd0_off_cas` reader - Power domain 0 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD0_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd0_off_cas` writer - Power domain 0 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD0_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd0_on_cas` reader - Power domain 0 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD0_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd0_on_cas` writer - Power domain 0 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD0_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd1_off_cas` reader - Power domain 1 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD1_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd1_off_cas` writer - Power domain 1 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD1_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd1_on_cas` reader - Power domain 1 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD1_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd1_on_cas` writer - Power domain 1 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD1_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd2_off_cas` reader - Power domain 2 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD2_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd2_off_cas` writer - Power domain 2 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD2_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd2_on_cas` reader - Power domain 2 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD2_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd2_on_cas` writer - Power domain 2 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD2_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+impl R {
+    #[doc = "Bits 0:4 - Power domain 0 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd0_off_cas(&self) -> PD0_OFF_CAS_R {
+        PD0_OFF_CAS_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:9 - Power domain 0 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd0_on_cas(&self) -> PD0_ON_CAS_R {
+        PD0_ON_CAS_R::new(((self.bits >> 5) & 0x1f) as u8)
+    }
+    #[doc = "Bits 10:14 - Power domain 1 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd1_off_cas(&self) -> PD1_OFF_CAS_R {
+        PD1_OFF_CAS_R::new(((self.bits >> 10) & 0x1f) as u8)
+    }
+    #[doc = "Bits 15:19 - Power domain 1 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd1_on_cas(&self) -> PD1_ON_CAS_R {
+        PD1_ON_CAS_R::new(((self.bits >> 15) & 0x1f) as u8)
+    }
+    #[doc = "Bits 20:24 - Power domain 2 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd2_off_cas(&self) -> PD2_OFF_CAS_R {
+        PD2_OFF_CAS_R::new(((self.bits >> 20) & 0x1f) as u8)
+    }
+    #[doc = "Bits 25:29 - Power domain 2 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd2_on_cas(&self) -> PD2_ON_CAS_R {
+        PD2_ON_CAS_R::new(((self.bits >> 25) & 0x1f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Power domain 0 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd0_off_cas(&mut self) -> PD0_OFF_CAS_W<PDC0_SPEC, 0> {
+        PD0_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 5:9 - Power domain 0 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd0_on_cas(&mut self) -> PD0_ON_CAS_W<PDC0_SPEC, 5> {
+        PD0_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 10:14 - Power domain 1 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd1_off_cas(&mut self) -> PD1_OFF_CAS_W<PDC0_SPEC, 10> {
+        PD1_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 15:19 - Power domain 1 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd1_on_cas(&mut self) -> PD1_ON_CAS_W<PDC0_SPEC, 15> {
+        PD1_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 20:24 - Power domain 2 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd2_off_cas(&mut self) -> PD2_OFF_CAS_W<PDC0_SPEC, 20> {
+        PD2_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 25:29 - Power domain 2 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd2_on_cas(&mut self) -> PD2_ON_CAS_W<PDC0_SPEC, 25> {
+        PD2_ON_CAS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Powerdomain Cascade 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PDC0_SPEC;
+impl crate::RegisterSpec for PDC0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pdc0::R`](R) reader structure"]
+impl crate::Readable for PDC0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pdc0::W`](W) writer structure"]
+impl crate::Writable for PDC0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc1.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc1.rs
@@ -1,0 +1,116 @@
+#[doc = "Register `pdc1` reader"]
+pub type R = crate::R<PDC1_SPEC>;
+#[doc = "Register `pdc1` writer"]
+pub type W = crate::W<PDC1_SPEC>;
+#[doc = "Field `pd3_off_cas` reader - Power domain 3 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD3_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd3_off_cas` writer - Power domain 3 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD3_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd3_on_cas` reader - Power domain 3 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD3_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd3_on_cas` writer - Power domain 3 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD3_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd4_off_cas` reader - Power domain 4 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD4_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd4_off_cas` writer - Power domain 4 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD4_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd4_on_cas` reader - Power domain 4 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD4_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd4_on_cas` writer - Power domain 4 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD4_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd5_off_cas` reader - Power domain 5 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD5_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd5_off_cas` writer - Power domain 5 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD5_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd5_on_cas` reader - Power domain 5 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD5_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd5_on_cas` writer - Power domain 5 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD5_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+impl R {
+    #[doc = "Bits 0:4 - Power domain 3 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd3_off_cas(&self) -> PD3_OFF_CAS_R {
+        PD3_OFF_CAS_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:9 - Power domain 3 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd3_on_cas(&self) -> PD3_ON_CAS_R {
+        PD3_ON_CAS_R::new(((self.bits >> 5) & 0x1f) as u8)
+    }
+    #[doc = "Bits 10:14 - Power domain 4 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd4_off_cas(&self) -> PD4_OFF_CAS_R {
+        PD4_OFF_CAS_R::new(((self.bits >> 10) & 0x1f) as u8)
+    }
+    #[doc = "Bits 15:19 - Power domain 4 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd4_on_cas(&self) -> PD4_ON_CAS_R {
+        PD4_ON_CAS_R::new(((self.bits >> 15) & 0x1f) as u8)
+    }
+    #[doc = "Bits 20:24 - Power domain 5 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd5_off_cas(&self) -> PD5_OFF_CAS_R {
+        PD5_OFF_CAS_R::new(((self.bits >> 20) & 0x1f) as u8)
+    }
+    #[doc = "Bits 25:29 - Power domain 5 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd5_on_cas(&self) -> PD5_ON_CAS_R {
+        PD5_ON_CAS_R::new(((self.bits >> 25) & 0x1f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Power domain 3 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd3_off_cas(&mut self) -> PD3_OFF_CAS_W<PDC1_SPEC, 0> {
+        PD3_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 5:9 - Power domain 3 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd3_on_cas(&mut self) -> PD3_ON_CAS_W<PDC1_SPEC, 5> {
+        PD3_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 10:14 - Power domain 4 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd4_off_cas(&mut self) -> PD4_OFF_CAS_W<PDC1_SPEC, 10> {
+        PD4_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 15:19 - Power domain 4 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd4_on_cas(&mut self) -> PD4_ON_CAS_W<PDC1_SPEC, 15> {
+        PD4_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 20:24 - Power domain 5 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd5_off_cas(&mut self) -> PD5_OFF_CAS_W<PDC1_SPEC, 20> {
+        PD5_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 25:29 - Power domain 5 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd5_on_cas(&mut self) -> PD5_ON_CAS_W<PDC1_SPEC, 25> {
+        PD5_ON_CAS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Powerdomain Cascade 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PDC1_SPEC;
+impl crate::RegisterSpec for PDC1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pdc1::R`](R) reader structure"]
+impl crate::Readable for PDC1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pdc1::W`](W) writer structure"]
+impl crate::Writable for PDC1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc2.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/pdc2.rs
@@ -1,0 +1,116 @@
+#[doc = "Register `pdc2` reader"]
+pub type R = crate::R<PDC2_SPEC>;
+#[doc = "Register `pdc2` writer"]
+pub type W = crate::W<PDC2_SPEC>;
+#[doc = "Field `pd6_off_cas` reader - Power domain 6 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD6_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd6_off_cas` writer - Power domain 6 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD6_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd6_on_cas` reader - Power domain 6 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD6_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd6_on_cas` writer - Power domain 6 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD6_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd7_off_cas` reader - Power domain 7 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD7_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd7_off_cas` writer - Power domain 7 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD7_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd7_on_cas` reader - Power domain 7 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD7_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd7_on_cas` writer - Power domain 7 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD7_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd8_off_cas` reader - Power domain 8 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD8_OFF_CAS_R = crate::FieldReader;
+#[doc = "Field `pd8_off_cas` writer - Power domain 8 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD8_OFF_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+#[doc = "Field `pd8_on_cas` reader - Power domain 8 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD8_ON_CAS_R = crate::FieldReader;
+#[doc = "Field `pd8_on_cas` writer - Power domain 8 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+pub type PD8_ON_CAS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 5, O>;
+impl R {
+    #[doc = "Bits 0:4 - Power domain 6 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd6_off_cas(&self) -> PD6_OFF_CAS_R {
+        PD6_OFF_CAS_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:9 - Power domain 6 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd6_on_cas(&self) -> PD6_ON_CAS_R {
+        PD6_ON_CAS_R::new(((self.bits >> 5) & 0x1f) as u8)
+    }
+    #[doc = "Bits 10:14 - Power domain 7 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd7_off_cas(&self) -> PD7_OFF_CAS_R {
+        PD7_OFF_CAS_R::new(((self.bits >> 10) & 0x1f) as u8)
+    }
+    #[doc = "Bits 15:19 - Power domain 7 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd7_on_cas(&self) -> PD7_ON_CAS_R {
+        PD7_ON_CAS_R::new(((self.bits >> 15) & 0x1f) as u8)
+    }
+    #[doc = "Bits 20:24 - Power domain 8 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd8_off_cas(&self) -> PD8_OFF_CAS_R {
+        PD8_OFF_CAS_R::new(((self.bits >> 20) & 0x1f) as u8)
+    }
+    #[doc = "Bits 25:29 - Power domain 8 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    pub fn pd8_on_cas(&self) -> PD8_ON_CAS_R {
+        PD8_ON_CAS_R::new(((self.bits >> 25) & 0x1f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Power domain 6 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd6_off_cas(&mut self) -> PD6_OFF_CAS_W<PDC2_SPEC, 0> {
+        PD6_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 5:9 - Power domain 6 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd6_on_cas(&mut self) -> PD6_ON_CAS_W<PDC2_SPEC, 5> {
+        PD6_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 10:14 - Power domain 7 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd7_off_cas(&mut self) -> PD7_OFF_CAS_W<PDC2_SPEC, 10> {
+        PD7_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 15:19 - Power domain 7 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd7_on_cas(&mut self) -> PD7_ON_CAS_W<PDC2_SPEC, 15> {
+        PD7_ON_CAS_W::new(self)
+    }
+    #[doc = "Bits 20:24 - Power domain 8 turn-off cascade. The register value indicates the power-off sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd8_off_cas(&mut self) -> PD8_OFF_CAS_W<PDC2_SPEC, 20> {
+        PD8_OFF_CAS_W::new(self)
+    }
+    #[doc = "Bits 25:29 - Power domain 8 turn-on cascade. The register value indicates the power-on sequence of this domain. 0 means the highest priority. System only accepts value from 0 to 7, any other value is invalid."]
+    #[inline(always)]
+    #[must_use]
+    pub fn pd8_on_cas(&mut self) -> PD8_ON_CAS_W<PDC2_SPEC, 25> {
+        PD8_ON_CAS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Powerdomain Cascade 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pdc2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pdc2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct PDC2_SPEC;
+impl crate::RegisterSpec for PDC2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`pdc2::R`](R) reader structure"]
+impl crate::Readable for PDC2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`pdc2::W`](W) writer structure"]
+impl crate::Writable for PDC2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/soft_turn_off_power_mode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/soft_turn_off_power_mode.rs
@@ -1,0 +1,131 @@
+#[doc = "Register `soft_turn_off_power_mode` reader"]
+pub type R = crate::R<SOFT_TURN_OFF_POWER_MODE_SPEC>;
+#[doc = "Register `soft_turn_off_power_mode` writer"]
+pub type W = crate::W<SOFT_TURN_OFF_POWER_MODE_SPEC>;
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-off power mode."]
+pub type SYSTOP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-off power mode."]
+pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cpu_power_mode` reader - CPU turn-off power mode."]
+pub type CPU_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `cpu_power_mode` writer - CPU turn-off power mode."]
+pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-off power mode."]
+pub type GPUA_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-off power mode."]
+pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-off power mode."]
+pub type VDEC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-off power mode."]
+pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vout_power_mode` reader - VOUT turn-off power mode."]
+pub type VOUT_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vout_power_mode` writer - VOUT turn-off power mode."]
+pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `isp_power_mode` reader - ISP turn-off power mode."]
+pub type ISP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `isp_power_mode` writer - ISP turn-off power mode."]
+pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `venc_power_mode` reader - VENC turn-off power mode."]
+pub type VENC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `venc_power_mode` writer - VENC turn-off power mode."]
+pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - SYSTOP turn-off power mode."]
+    #[inline(always)]
+    pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
+        SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - CPU turn-off power mode."]
+    #[inline(always)]
+    pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
+        CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - GPUA turn-off power mode."]
+    #[inline(always)]
+    pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
+        GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - VDEC turn-off power mode."]
+    #[inline(always)]
+    pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
+        VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - VOUT turn-off power mode."]
+    #[inline(always)]
+    pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
+        VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - ISP turn-off power mode."]
+    #[inline(always)]
+    pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
+        ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - VENC turn-off power mode."]
+    #[inline(always)]
+    pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
+        VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - SYSTOP turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 0> {
+        SYSTOP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 1 - CPU turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 1> {
+        CPU_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 2 - GPUA turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 2> {
+        GPUA_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 3 - VDEC turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 3> {
+        VDEC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 4 - VOUT turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 4> {
+        VOUT_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 5 - ISP turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 5> {
+        ISP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 6 - VENC turn-off power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<SOFT_TURN_OFF_POWER_MODE_SPEC, 6> {
+        VENC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Software Turn-Off Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_turn_off_power_mode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_turn_off_power_mode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SOFT_TURN_OFF_POWER_MODE_SPEC;
+impl crate::RegisterSpec for SOFT_TURN_OFF_POWER_MODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`soft_turn_off_power_mode::R`](R) reader structure"]
+impl crate::Readable for SOFT_TURN_OFF_POWER_MODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`soft_turn_off_power_mode::W`](W) writer structure"]
+impl crate::Writable for SOFT_TURN_OFF_POWER_MODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/soft_turn_on_power_mode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/soft_turn_on_power_mode.rs
@@ -1,0 +1,131 @@
+#[doc = "Register `soft_turn_on_power_mode` reader"]
+pub type R = crate::R<SOFT_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Register `soft_turn_on_power_mode` writer"]
+pub type W = crate::W<SOFT_TURN_ON_POWER_MODE_SPEC>;
+#[doc = "Field `systop_power_mode` reader - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `systop_power_mode` writer - SYSTOP turn-on power mode."]
+pub type SYSTOP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `cpu_power_mode` reader - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `cpu_power_mode` writer - CPU turn-on power mode."]
+pub type CPU_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `gpua_power_mode` reader - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `gpua_power_mode` writer - GPUA turn-on power mode."]
+pub type GPUA_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vdec_power_mode` reader - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vdec_power_mode` writer - VDEC turn-on power mode."]
+pub type VDEC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `vout_power_mode` reader - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `vout_power_mode` writer - VOUT turn-on power mode."]
+pub type VOUT_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `isp_power_mode` reader - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `isp_power_mode` writer - ISP turn-on power mode."]
+pub type ISP_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `venc_power_mode` reader - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_R = crate::BitReader;
+#[doc = "Field `venc_power_mode` writer - VENC turn-on power mode."]
+pub type VENC_POWER_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    pub fn systop_power_mode(&self) -> SYSTOP_POWER_MODE_R {
+        SYSTOP_POWER_MODE_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    pub fn cpu_power_mode(&self) -> CPU_POWER_MODE_R {
+        CPU_POWER_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    pub fn gpua_power_mode(&self) -> GPUA_POWER_MODE_R {
+        GPUA_POWER_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    pub fn vdec_power_mode(&self) -> VDEC_POWER_MODE_R {
+        VDEC_POWER_MODE_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    pub fn vout_power_mode(&self) -> VOUT_POWER_MODE_R {
+        VOUT_POWER_MODE_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    pub fn isp_power_mode(&self) -> ISP_POWER_MODE_R {
+        ISP_POWER_MODE_R::new(((self.bits >> 5) & 1) != 0)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    pub fn venc_power_mode(&self) -> VENC_POWER_MODE_R {
+        VENC_POWER_MODE_R::new(((self.bits >> 6) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - SYSTOP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn systop_power_mode(&mut self) -> SYSTOP_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 0> {
+        SYSTOP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 1 - CPU turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn cpu_power_mode(&mut self) -> CPU_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 1> {
+        CPU_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 2 - GPUA turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn gpua_power_mode(&mut self) -> GPUA_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 2> {
+        GPUA_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 3 - VDEC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vdec_power_mode(&mut self) -> VDEC_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 3> {
+        VDEC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 4 - VOUT turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn vout_power_mode(&mut self) -> VOUT_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 4> {
+        VOUT_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 5 - ISP turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn isp_power_mode(&mut self) -> ISP_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 5> {
+        ISP_POWER_MODE_W::new(self)
+    }
+    #[doc = "Bit 6 - VENC turn-on power mode."]
+    #[inline(always)]
+    #[must_use]
+    pub fn venc_power_mode(&mut self) -> VENC_POWER_MODE_W<SOFT_TURN_ON_POWER_MODE_SPEC, 6> {
+        VENC_POWER_MODE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Software Turn-On Power Mode\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_turn_on_power_mode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_turn_on_power_mode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SOFT_TURN_ON_POWER_MODE_SPEC;
+impl crate::RegisterSpec for SOFT_TURN_ON_POWER_MODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`soft_turn_on_power_mode::R`](R) reader structure"]
+impl crate::Readable for SOFT_TURN_ON_POWER_MODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`soft_turn_on_power_mode::W`](W) writer structure"]
+impl crate::Writable for SOFT_TURN_ON_POWER_MODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/sw_encourage.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/sw_encourage.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `sw_encourage` reader"]
+pub type R = crate::R<SW_ENCOURAGE_SPEC>;
+#[doc = "Register `sw_encourage` writer"]
+pub type W = crate::W<SW_ENCOURAGE_SPEC>;
+#[doc = "Field `sw_encourage` reader - Software Encouragement"]
+pub type SW_ENCOURAGE_R = crate::FieldReader;
+#[doc = "Field `sw_encourage` writer - Software Encouragement"]
+pub type SW_ENCOURAGE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+impl R {
+    #[doc = "Bits 0:7 - Software Encouragement"]
+    #[inline(always)]
+    pub fn sw_encourage(&self) -> SW_ENCOURAGE_R {
+        SW_ENCOURAGE_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Software Encouragement"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sw_encourage(&mut self) -> SW_ENCOURAGE_W<SW_ENCOURAGE_SPEC, 0> {
+        SW_ENCOURAGE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Software Encouragement\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sw_encourage::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sw_encourage::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SW_ENCOURAGE_SPEC;
+impl crate::RegisterSpec for SW_ENCOURAGE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`sw_encourage::R`](R) reader structure"]
+impl crate::Readable for SW_ENCOURAGE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`sw_encourage::W`](W) writer structure"]
+impl crate::Writable for SW_ENCOURAGE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/tim.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/tim.rs
@@ -1,0 +1,101 @@
+#[doc = "Register `tim` reader"]
+pub type R = crate::R<TIM_SPEC>;
+#[doc = "Register `tim` writer"]
+pub type W = crate::W<TIM_SPEC>;
+#[doc = "Field `seq_done_mask` reader - Mask the sequence complete event. 0: mask, 1: unmask"]
+pub type SEQ_DONE_MASK_R = crate::BitReader;
+#[doc = "Field `seq_done_mask` writer - Mask the sequence complete event. 0: mask, 1: unmask"]
+pub type SEQ_DONE_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `hw_req_mask` reader - Mask the hardware encouragement request. 0: mask, 1: unmask"]
+pub type HW_REQ_MASK_R = crate::BitReader;
+#[doc = "Field `hw_req_mask` writer - Mask the hardware encouragement request. 0: mask, 1: unmask"]
+pub type HW_REQ_MASK_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `sw_fail_mask` reader - Mask the software encouragement failure event. 0: mask, 1: unmask"]
+pub type SW_FAIL_MASK_R = crate::FieldReader;
+#[doc = "Field `sw_fail_mask` writer - Mask the software encouragement failure event. 0: mask, 1: unmask"]
+pub type SW_FAIL_MASK_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `hw_fail_mask` reader - Mask the hardware encouragement failure event. 0: mask, 1: unmask"]
+pub type HW_FAIL_MASK_R = crate::FieldReader;
+#[doc = "Field `hw_fail_mask` writer - Mask the hardware encouragement failure event. 0: mask, 1: unmask"]
+pub type HW_FAIL_MASK_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 2, O>;
+#[doc = "Field `pch_fail_mask` reader - Mask the P-channel encouragement failure event. 0: mask, 1: unmask"]
+pub type PCH_FAIL_MASK_R = crate::FieldReader;
+#[doc = "Field `pch_fail_mask` writer - Mask the P-channel encouragement failure event. 0: mask, 1: unmask"]
+pub type PCH_FAIL_MASK_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 3, O>;
+impl R {
+    #[doc = "Bit 0 - Mask the sequence complete event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    pub fn seq_done_mask(&self) -> SEQ_DONE_MASK_R {
+        SEQ_DONE_MASK_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Mask the hardware encouragement request. 0: mask, 1: unmask"]
+    #[inline(always)]
+    pub fn hw_req_mask(&self) -> HW_REQ_MASK_R {
+        HW_REQ_MASK_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bits 2:3 - Mask the software encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    pub fn sw_fail_mask(&self) -> SW_FAIL_MASK_R {
+        SW_FAIL_MASK_R::new(((self.bits >> 2) & 3) as u8)
+    }
+    #[doc = "Bits 4:5 - Mask the hardware encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    pub fn hw_fail_mask(&self) -> HW_FAIL_MASK_R {
+        HW_FAIL_MASK_R::new(((self.bits >> 4) & 3) as u8)
+    }
+    #[doc = "Bits 6:8 - Mask the P-channel encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    pub fn pch_fail_mask(&self) -> PCH_FAIL_MASK_R {
+        PCH_FAIL_MASK_R::new(((self.bits >> 6) & 7) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Mask the sequence complete event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    #[must_use]
+    pub fn seq_done_mask(&mut self) -> SEQ_DONE_MASK_W<TIM_SPEC, 0> {
+        SEQ_DONE_MASK_W::new(self)
+    }
+    #[doc = "Bit 1 - Mask the hardware encouragement request. 0: mask, 1: unmask"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hw_req_mask(&mut self) -> HW_REQ_MASK_W<TIM_SPEC, 1> {
+        HW_REQ_MASK_W::new(self)
+    }
+    #[doc = "Bits 2:3 - Mask the software encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    #[must_use]
+    pub fn sw_fail_mask(&mut self) -> SW_FAIL_MASK_W<TIM_SPEC, 2> {
+        SW_FAIL_MASK_W::new(self)
+    }
+    #[doc = "Bits 4:5 - Mask the hardware encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    #[must_use]
+    pub fn hw_fail_mask(&mut self) -> HW_FAIL_MASK_W<TIM_SPEC, 4> {
+        HW_FAIL_MASK_W::new(self)
+    }
+    #[doc = "Bits 6:8 - Mask the P-channel encouragement failure event. 0: mask, 1: unmask"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pch_fail_mask(&mut self) -> PCH_FAIL_MASK_W<TIM_SPEC, 6> {
+        PCH_FAIL_MASK_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TIMER Interrupt Mask\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`tim::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TIM_SPEC;
+impl crate::RegisterSpec for TIM_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`tim::R`](R) reader structure"]
+impl crate::Readable for TIM_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`tim::W`](W) writer structure"]
+impl crate::Writable for TIM_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/timeout_seq_thd.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_pmu_0/timeout_seq_thd.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `timeout_seq_thd` reader"]
+pub type R = crate::R<TIMEOUT_SEQ_THD_SPEC>;
+#[doc = "Register `timeout_seq_thd` writer"]
+pub type W = crate::W<TIMEOUT_SEQ_THD_SPEC>;
+#[doc = "Field `timeout_seq_thd` reader - Threshold Sequence Timeout"]
+pub type TIMEOUT_SEQ_THD_R = crate::FieldReader<u16>;
+#[doc = "Field `timeout_seq_thd` writer - Threshold Sequence Timeout"]
+pub type TIMEOUT_SEQ_THD_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Threshold Sequence Timeout"]
+    #[inline(always)]
+    pub fn timeout_seq_thd(&self) -> TIMEOUT_SEQ_THD_R {
+        TIMEOUT_SEQ_THD_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Threshold Sequence Timeout"]
+    #[inline(always)]
+    #[must_use]
+    pub fn timeout_seq_thd(&mut self) -> TIMEOUT_SEQ_THD_W<TIMEOUT_SEQ_THD_SPEC, 0> {
+        TIMEOUT_SEQ_THD_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Threshold Sequence Timeout\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`timeout_seq_thd::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`timeout_seq_thd::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct TIMEOUT_SEQ_THD_SPEC;
+impl crate::RegisterSpec for TIMEOUT_SEQ_THD_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`timeout_seq_thd::R`](R) reader structure"]
+impl crate::Readable for TIMEOUT_SEQ_THD_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`timeout_seq_thd::W`](W) writer structure"]
+impl crate::Writable for TIMEOUT_SEQ_THD_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0.rs
@@ -1,0 +1,118 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - TRNG CTRL Register"]
+    pub ctrl: CTRL,
+    #[doc = "0x04 - TRNG STAT Register"]
+    pub stat: STAT,
+    #[doc = "0x08 - TRNG MODE Register"]
+    pub mode: MODE,
+    #[doc = "0x0c - TRNG SMODE Register"]
+    pub smode: SMODE,
+    #[doc = "0x10 - TRNG Interrupt Enable Register"]
+    pub ie: IE,
+    #[doc = "0x14 - TRNG Interrupt Status Register"]
+    pub istat: ISTAT,
+    _reserved6: [u8; 0x08],
+    #[doc = "0x20 - TRNG RAND 0 Status Register"]
+    pub rand0: RAND0,
+    #[doc = "0x24 - TRNG RAND 1 Status Register"]
+    pub rand1: RAND1,
+    #[doc = "0x28 - TRNG RAND 2 Status Register"]
+    pub rand2: RAND2,
+    #[doc = "0x2c - TRNG RAND 3 Status Register"]
+    pub rand3: RAND3,
+    #[doc = "0x30 - TRNG RAND 4 Status Register"]
+    pub rand4: RAND4,
+    #[doc = "0x34 - TRNG RAND 5 Status Register"]
+    pub rand5: RAND5,
+    #[doc = "0x38 - TRNG RAND 6 Status Register"]
+    pub rand6: RAND6,
+    #[doc = "0x3c - TRNG RAND 7 Status Register"]
+    pub rand7: RAND7,
+    _reserved14: [u8; 0x20],
+    #[doc = "0x60 - Auto-reseeding after random number requests by host reaches specified counter: 0 - disable counter, other - reload value for internal counter"]
+    pub auto_rqsts: AUTO_RQSTS,
+    #[doc = "0x64 - Auto-reseeding after specified timer countdowns to 0: 0 - disable timer, other - reload value for internal timer"]
+    pub auto_age: AUTO_AGE,
+}
+#[doc = "ctrl (rw) register accessor: TRNG CTRL Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ctrl`]
+module"]
+pub type CTRL = crate::Reg<ctrl::CTRL_SPEC>;
+#[doc = "TRNG CTRL Register"]
+pub mod ctrl;
+#[doc = "stat (rw) register accessor: TRNG STAT Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stat::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`stat`]
+module"]
+pub type STAT = crate::Reg<stat::STAT_SPEC>;
+#[doc = "TRNG STAT Register"]
+pub mod stat;
+#[doc = "mode (rw) register accessor: TRNG MODE Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`mode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`mode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mode`]
+module"]
+pub type MODE = crate::Reg<mode::MODE_SPEC>;
+#[doc = "TRNG MODE Register"]
+pub mod mode;
+#[doc = "smode (rw) register accessor: TRNG SMODE Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`smode::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`smode::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`smode`]
+module"]
+pub type SMODE = crate::Reg<smode::SMODE_SPEC>;
+#[doc = "TRNG SMODE Register"]
+pub mod smode;
+#[doc = "ie (rw) register accessor: TRNG Interrupt Enable Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ie::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ie::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`ie`]
+module"]
+pub type IE = crate::Reg<ie::IE_SPEC>;
+#[doc = "TRNG Interrupt Enable Register"]
+pub mod ie;
+#[doc = "istat (rw) register accessor: TRNG Interrupt Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`istat::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`istat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`istat`]
+module"]
+pub type ISTAT = crate::Reg<istat::ISTAT_SPEC>;
+#[doc = "TRNG Interrupt Status Register"]
+pub mod istat;
+#[doc = "rand0 (rw) register accessor: TRNG RAND 0 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand0`]
+module"]
+pub type RAND0 = crate::Reg<rand0::RAND0_SPEC>;
+#[doc = "TRNG RAND 0 Status Register"]
+pub mod rand0;
+#[doc = "rand1 (rw) register accessor: TRNG RAND 1 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand1`]
+module"]
+pub type RAND1 = crate::Reg<rand1::RAND1_SPEC>;
+#[doc = "TRNG RAND 1 Status Register"]
+pub mod rand1;
+#[doc = "rand2 (rw) register accessor: TRNG RAND 2 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand2`]
+module"]
+pub type RAND2 = crate::Reg<rand2::RAND2_SPEC>;
+#[doc = "TRNG RAND 2 Status Register"]
+pub mod rand2;
+#[doc = "rand3 (rw) register accessor: TRNG RAND 3 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand3`]
+module"]
+pub type RAND3 = crate::Reg<rand3::RAND3_SPEC>;
+#[doc = "TRNG RAND 3 Status Register"]
+pub mod rand3;
+#[doc = "rand4 (rw) register accessor: TRNG RAND 4 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand4`]
+module"]
+pub type RAND4 = crate::Reg<rand4::RAND4_SPEC>;
+#[doc = "TRNG RAND 4 Status Register"]
+pub mod rand4;
+#[doc = "rand5 (rw) register accessor: TRNG RAND 5 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand5`]
+module"]
+pub type RAND5 = crate::Reg<rand5::RAND5_SPEC>;
+#[doc = "TRNG RAND 5 Status Register"]
+pub mod rand5;
+#[doc = "rand6 (rw) register accessor: TRNG RAND 6 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand6::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand6`]
+module"]
+pub type RAND6 = crate::Reg<rand6::RAND6_SPEC>;
+#[doc = "TRNG RAND 6 Status Register"]
+pub mod rand6;
+#[doc = "rand7 (rw) register accessor: TRNG RAND 7 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand7::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`rand7`]
+module"]
+pub type RAND7 = crate::Reg<rand7::RAND7_SPEC>;
+#[doc = "TRNG RAND 7 Status Register"]
+pub mod rand7;
+#[doc = "auto_rqsts (rw) register accessor: Auto-reseeding after random number requests by host reaches specified counter: 0 - disable counter, other - reload value for internal counter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`auto_rqsts::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`auto_rqsts::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`auto_rqsts`]
+module"]
+pub type AUTO_RQSTS = crate::Reg<auto_rqsts::AUTO_RQSTS_SPEC>;
+#[doc = "Auto-reseeding after random number requests by host reaches specified counter: 0 - disable counter, other - reload value for internal counter"]
+pub mod auto_rqsts;
+#[doc = "auto_age (rw) register accessor: Auto-reseeding after specified timer countdowns to 0: 0 - disable timer, other - reload value for internal timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`auto_age::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`auto_age::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`auto_age`]
+module"]
+pub type AUTO_AGE = crate::Reg<auto_age::AUTO_AGE_SPEC>;
+#[doc = "Auto-reseeding after specified timer countdowns to 0: 0 - disable timer, other - reload value for internal timer"]
+pub mod auto_age;

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/auto_age.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/auto_age.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `auto_age` reader"]
+pub type R = crate::R<AUTO_AGE_SPEC>;
+#[doc = "Register `auto_age` writer"]
+pub type W = crate::W<AUTO_AGE_SPEC>;
+#[doc = "Field `age` reader - Countdown value for auto-reseed timer"]
+pub type AGE_R = crate::FieldReader<u32>;
+#[doc = "Field `age` writer - Countdown value for auto-reseed timer"]
+pub type AGE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Countdown value for auto-reseed timer"]
+    #[inline(always)]
+    pub fn age(&self) -> AGE_R {
+        AGE_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Countdown value for auto-reseed timer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn age(&mut self) -> AGE_W<AUTO_AGE_SPEC, 0> {
+        AGE_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Auto-reseeding after specified timer countdowns to 0: 0 - disable timer, other - reload value for internal timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`auto_age::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`auto_age::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct AUTO_AGE_SPEC;
+impl crate::RegisterSpec for AUTO_AGE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`auto_age::R`](R) reader structure"]
+impl crate::Readable for AUTO_AGE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`auto_age::W`](W) writer structure"]
+impl crate::Writable for AUTO_AGE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/auto_rqsts.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/auto_rqsts.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `auto_rqsts` reader"]
+pub type R = crate::R<AUTO_RQSTS_SPEC>;
+#[doc = "Register `auto_rqsts` writer"]
+pub type W = crate::W<AUTO_RQSTS_SPEC>;
+#[doc = "Field `rqsts` reader - Threshold number of reseed requests for auto-reseed counter"]
+pub type RQSTS_R = crate::FieldReader<u32>;
+#[doc = "Field `rqsts` writer - Threshold number of reseed requests for auto-reseed counter"]
+pub type RQSTS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Threshold number of reseed requests for auto-reseed counter"]
+    #[inline(always)]
+    pub fn rqsts(&self) -> RQSTS_R {
+        RQSTS_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Threshold number of reseed requests for auto-reseed counter"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rqsts(&mut self) -> RQSTS_W<AUTO_RQSTS_SPEC, 0> {
+        RQSTS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Auto-reseeding after random number requests by host reaches specified counter: 0 - disable counter, other - reload value for internal counter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`auto_rqsts::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`auto_rqsts::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct AUTO_RQSTS_SPEC;
+impl crate::RegisterSpec for AUTO_RQSTS_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`auto_rqsts::R`](R) reader structure"]
+impl crate::Readable for AUTO_RQSTS_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`auto_rqsts::W`](W) writer structure"]
+impl crate::Writable for AUTO_RQSTS_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/ctrl.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/ctrl.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `ctrl` reader"]
+pub type R = crate::R<CTRL_SPEC>;
+#[doc = "Register `ctrl` writer"]
+pub type W = crate::W<CTRL_SPEC>;
+#[doc = "Field `exec_nop` reader - Execute a NOP instruction"]
+pub type EXEC_NOP_R = crate::BitReader;
+#[doc = "Field `exec_nop` writer - Execute a NOP instruction"]
+pub type EXEC_NOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `gene_randnum` reader - Generate a random number"]
+pub type GENE_RANDNUM_R = crate::BitReader;
+#[doc = "Field `gene_randnum` writer - Generate a random number"]
+pub type GENE_RANDNUM_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `exec_randreseed` reader - Reseed the TRNG from noise sources"]
+pub type EXEC_RANDRESEED_R = crate::BitReader;
+#[doc = "Field `exec_randreseed` writer - Reseed the TRNG from noise sources"]
+pub type EXEC_RANDRESEED_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - Execute a NOP instruction"]
+    #[inline(always)]
+    pub fn exec_nop(&self) -> EXEC_NOP_R {
+        EXEC_NOP_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Generate a random number"]
+    #[inline(always)]
+    pub fn gene_randnum(&self) -> GENE_RANDNUM_R {
+        GENE_RANDNUM_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 2 - Reseed the TRNG from noise sources"]
+    #[inline(always)]
+    pub fn exec_randreseed(&self) -> EXEC_RANDRESEED_R {
+        EXEC_RANDRESEED_R::new(((self.bits >> 2) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Execute a NOP instruction"]
+    #[inline(always)]
+    #[must_use]
+    pub fn exec_nop(&mut self) -> EXEC_NOP_W<CTRL_SPEC, 0> {
+        EXEC_NOP_W::new(self)
+    }
+    #[doc = "Bit 1 - Generate a random number"]
+    #[inline(always)]
+    #[must_use]
+    pub fn gene_randnum(&mut self) -> GENE_RANDNUM_W<CTRL_SPEC, 1> {
+        GENE_RANDNUM_W::new(self)
+    }
+    #[doc = "Bit 2 - Reseed the TRNG from noise sources"]
+    #[inline(always)]
+    #[must_use]
+    pub fn exec_randreseed(&mut self) -> EXEC_RANDRESEED_W<CTRL_SPEC, 2> {
+        EXEC_RANDRESEED_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG CTRL Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ctrl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ctrl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CTRL_SPEC;
+impl crate::RegisterSpec for CTRL_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ctrl::R`](R) reader structure"]
+impl crate::Readable for CTRL_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ctrl::W`](W) writer structure"]
+impl crate::Writable for CTRL_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/ie.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/ie.rs
@@ -1,0 +1,86 @@
+#[doc = "Register `ie` reader"]
+pub type R = crate::R<IE_SPEC>;
+#[doc = "Register `ie` writer"]
+pub type W = crate::W<IE_SPEC>;
+#[doc = "Field `rand_rdy_en` reader - RAND Ready Enable"]
+pub type RAND_RDY_EN_R = crate::BitReader;
+#[doc = "Field `rand_rdy_en` writer - RAND Ready Enable"]
+pub type RAND_RDY_EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `seed_done_en` reader - Seed Done Enable"]
+pub type SEED_DONE_EN_R = crate::BitReader;
+#[doc = "Field `seed_done_en` writer - Seed Done Enable"]
+pub type SEED_DONE_EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `lfsr_lockup_en` reader - LFSR Lockup Enable"]
+pub type LFSR_LOCKUP_EN_R = crate::BitReader;
+#[doc = "Field `lfsr_lockup_en` writer - LFSR Lockup Enable"]
+pub type LFSR_LOCKUP_EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `glbl_en` reader - Global Enable"]
+pub type GLBL_EN_R = crate::BitReader;
+#[doc = "Field `glbl_en` writer - Global Enable"]
+pub type GLBL_EN_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 0 - RAND Ready Enable"]
+    #[inline(always)]
+    pub fn rand_rdy_en(&self) -> RAND_RDY_EN_R {
+        RAND_RDY_EN_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Seed Done Enable"]
+    #[inline(always)]
+    pub fn seed_done_en(&self) -> SEED_DONE_EN_R {
+        SEED_DONE_EN_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 4 - LFSR Lockup Enable"]
+    #[inline(always)]
+    pub fn lfsr_lockup_en(&self) -> LFSR_LOCKUP_EN_R {
+        LFSR_LOCKUP_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+    #[doc = "Bit 31 - Global Enable"]
+    #[inline(always)]
+    pub fn glbl_en(&self) -> GLBL_EN_R {
+        GLBL_EN_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - RAND Ready Enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn rand_rdy_en(&mut self) -> RAND_RDY_EN_W<IE_SPEC, 0> {
+        RAND_RDY_EN_W::new(self)
+    }
+    #[doc = "Bit 1 - Seed Done Enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn seed_done_en(&mut self) -> SEED_DONE_EN_W<IE_SPEC, 1> {
+        SEED_DONE_EN_W::new(self)
+    }
+    #[doc = "Bit 4 - LFSR Lockup Enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn lfsr_lockup_en(&mut self) -> LFSR_LOCKUP_EN_W<IE_SPEC, 4> {
+        LFSR_LOCKUP_EN_W::new(self)
+    }
+    #[doc = "Bit 31 - Global Enable"]
+    #[inline(always)]
+    #[must_use]
+    pub fn glbl_en(&mut self) -> GLBL_EN_W<IE_SPEC, 31> {
+        GLBL_EN_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG Interrupt Enable Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ie::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ie::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct IE_SPEC;
+impl crate::RegisterSpec for IE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ie::R`](R) reader structure"]
+impl crate::Readable for IE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ie::W`](W) writer structure"]
+impl crate::Writable for IE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/istat.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/istat.rs
@@ -1,0 +1,47 @@
+#[doc = "Register `istat` reader"]
+pub type R = crate::R<ISTAT_SPEC>;
+#[doc = "Register `istat` writer"]
+pub type W = crate::W<ISTAT_SPEC>;
+#[doc = "Field `rand_rdy` reader - RAND Ready Enable"]
+pub type RAND_RDY_R = crate::BitReader;
+#[doc = "Field `seed_done` reader - Seed Done Enable"]
+pub type SEED_DONE_R = crate::BitReader;
+#[doc = "Field `lfsr_lockup_en` reader - LFSR Lockup Enable"]
+pub type LFSR_LOCKUP_EN_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 0 - RAND Ready Enable"]
+    #[inline(always)]
+    pub fn rand_rdy(&self) -> RAND_RDY_R {
+        RAND_RDY_R::new((self.bits & 1) != 0)
+    }
+    #[doc = "Bit 1 - Seed Done Enable"]
+    #[inline(always)]
+    pub fn seed_done(&self) -> SEED_DONE_R {
+        SEED_DONE_R::new(((self.bits >> 1) & 1) != 0)
+    }
+    #[doc = "Bit 4 - LFSR Lockup Enable"]
+    #[inline(always)]
+    pub fn lfsr_lockup_en(&self) -> LFSR_LOCKUP_EN_R {
+        LFSR_LOCKUP_EN_R::new(((self.bits >> 4) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG Interrupt Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`istat::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`istat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct ISTAT_SPEC;
+impl crate::RegisterSpec for ISTAT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`istat::R`](R) reader structure"]
+impl crate::Readable for ISTAT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`istat::W`](W) writer structure"]
+impl crate::Writable for ISTAT_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/mode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/mode.rs
@@ -1,0 +1,41 @@
+#[doc = "Register `mode` reader"]
+pub type R = crate::R<MODE_SPEC>;
+#[doc = "Register `mode` writer"]
+pub type W = crate::W<MODE_SPEC>;
+#[doc = "Field `r256` reader - 256-bit operation mode: 0 - 128-bit mode, 1 - 256-bit mode"]
+pub type R256_R = crate::BitReader;
+#[doc = "Field `r256` writer - 256-bit operation mode: 0 - 128-bit mode, 1 - 256-bit mode"]
+pub type R256_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+impl R {
+    #[doc = "Bit 3 - 256-bit operation mode: 0 - 128-bit mode, 1 - 256-bit mode"]
+    #[inline(always)]
+    pub fn r256(&self) -> R256_R {
+        R256_R::new(((self.bits >> 3) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 3 - 256-bit operation mode: 0 - 128-bit mode, 1 - 256-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn r256(&mut self) -> R256_W<MODE_SPEC, 3> {
+        R256_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG MODE Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`mode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`mode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct MODE_SPEC;
+impl crate::RegisterSpec for MODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`mode::R`](R) reader structure"]
+impl crate::Readable for MODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`mode::W`](W) writer structure"]
+impl crate::Writable for MODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand0.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand0.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand0` reader"]
+pub type R = crate::R<RAND0_SPEC>;
+#[doc = "Register `rand0` writer"]
+pub type W = crate::W<RAND0_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 0 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND0_SPEC;
+impl crate::RegisterSpec for RAND0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand0::R`](R) reader structure"]
+impl crate::Readable for RAND0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand0::W`](W) writer structure"]
+impl crate::Writable for RAND0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand1.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand1.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand1` reader"]
+pub type R = crate::R<RAND1_SPEC>;
+#[doc = "Register `rand1` writer"]
+pub type W = crate::W<RAND1_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 1 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND1_SPEC;
+impl crate::RegisterSpec for RAND1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand1::R`](R) reader structure"]
+impl crate::Readable for RAND1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand1::W`](W) writer structure"]
+impl crate::Writable for RAND1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand2.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand2.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand2` reader"]
+pub type R = crate::R<RAND2_SPEC>;
+#[doc = "Register `rand2` writer"]
+pub type W = crate::W<RAND2_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 2 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND2_SPEC;
+impl crate::RegisterSpec for RAND2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand2::R`](R) reader structure"]
+impl crate::Readable for RAND2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand2::W`](W) writer structure"]
+impl crate::Writable for RAND2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand3.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand3.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand3` reader"]
+pub type R = crate::R<RAND3_SPEC>;
+#[doc = "Register `rand3` writer"]
+pub type W = crate::W<RAND3_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 3 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND3_SPEC;
+impl crate::RegisterSpec for RAND3_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand3::R`](R) reader structure"]
+impl crate::Readable for RAND3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand3::W`](W) writer structure"]
+impl crate::Writable for RAND3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand4.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand4.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand4` reader"]
+pub type R = crate::R<RAND4_SPEC>;
+#[doc = "Register `rand4` writer"]
+pub type W = crate::W<RAND4_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 4 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND4_SPEC;
+impl crate::RegisterSpec for RAND4_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand4::R`](R) reader structure"]
+impl crate::Readable for RAND4_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand4::W`](W) writer structure"]
+impl crate::Writable for RAND4_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand5.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand5.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand5` reader"]
+pub type R = crate::R<RAND5_SPEC>;
+#[doc = "Register `rand5` writer"]
+pub type W = crate::W<RAND5_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 5 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND5_SPEC;
+impl crate::RegisterSpec for RAND5_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand5::R`](R) reader structure"]
+impl crate::Readable for RAND5_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand5::W`](W) writer structure"]
+impl crate::Writable for RAND5_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand6.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand6.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand6` reader"]
+pub type R = crate::R<RAND6_SPEC>;
+#[doc = "Register `rand6` writer"]
+pub type W = crate::W<RAND6_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 6 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand6::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND6_SPEC;
+impl crate::RegisterSpec for RAND6_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand6::R`](R) reader structure"]
+impl crate::Readable for RAND6_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand6::W`](W) writer structure"]
+impl crate::Writable for RAND6_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand7.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/rand7.rs
@@ -1,0 +1,33 @@
+#[doc = "Register `rand7` reader"]
+pub type R = crate::R<RAND7_SPEC>;
+#[doc = "Register `rand7` writer"]
+pub type W = crate::W<RAND7_SPEC>;
+#[doc = "Field `rand` reader - Random number bits"]
+pub type RAND_R = crate::FieldReader<u32>;
+impl R {
+    #[doc = "Bits 0:31 - Random number bits"]
+    #[inline(always)]
+    pub fn rand(&self) -> RAND_R {
+        RAND_R::new(self.bits)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG RAND 7 Status Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`rand7::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`rand7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct RAND7_SPEC;
+impl crate::RegisterSpec for RAND7_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`rand7::R`](R) reader structure"]
+impl crate::Readable for RAND7_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`rand7::W`](W) writer structure"]
+impl crate::Writable for RAND7_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/smode.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/smode.rs
@@ -1,0 +1,71 @@
+#[doc = "Register `smode` reader"]
+pub type R = crate::R<SMODE_SPEC>;
+#[doc = "Register `smode` writer"]
+pub type W = crate::W<SMODE_SPEC>;
+#[doc = "Field `nonce_mode` reader - Nonce operation mode"]
+pub type NONCE_MODE_R = crate::BitReader;
+#[doc = "Field `nonce_mode` writer - Nonce operation mode"]
+pub type NONCE_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `mission_mode` reader - Mission operation mode"]
+pub type MISSION_MODE_R = crate::BitReader;
+#[doc = "Field `mission_mode` writer - Mission operation mode"]
+pub type MISSION_MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `max_rejects` reader - TRNG Maximum Rejects"]
+pub type MAX_REJECTS_R = crate::FieldReader<u16>;
+#[doc = "Field `max_rejects` writer - TRNG Maximum Rejects"]
+pub type MAX_REJECTS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 16, O, u16>;
+impl R {
+    #[doc = "Bit 2 - Nonce operation mode"]
+    #[inline(always)]
+    pub fn nonce_mode(&self) -> NONCE_MODE_R {
+        NONCE_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 8 - Mission operation mode"]
+    #[inline(always)]
+    pub fn mission_mode(&self) -> MISSION_MODE_R {
+        MISSION_MODE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bits 16:31 - TRNG Maximum Rejects"]
+    #[inline(always)]
+    pub fn max_rejects(&self) -> MAX_REJECTS_R {
+        MAX_REJECTS_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bit 2 - Nonce operation mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn nonce_mode(&mut self) -> NONCE_MODE_W<SMODE_SPEC, 2> {
+        NONCE_MODE_W::new(self)
+    }
+    #[doc = "Bit 8 - Mission operation mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mission_mode(&mut self) -> MISSION_MODE_W<SMODE_SPEC, 8> {
+        MISSION_MODE_W::new(self)
+    }
+    #[doc = "Bits 16:31 - TRNG Maximum Rejects"]
+    #[inline(always)]
+    #[must_use]
+    pub fn max_rejects(&mut self) -> MAX_REJECTS_W<SMODE_SPEC, 16> {
+        MAX_REJECTS_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG SMODE Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`smode::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`smode::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SMODE_SPEC;
+impl crate::RegisterSpec for SMODE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`smode::R`](R) reader structure"]
+impl crate::Readable for SMODE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`smode::W`](W) writer structure"]
+impl crate::Writable for SMODE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/stat.rs
+++ b/jh7110-vf2-13b-pac/src/starfive_jh7110_trng_0/stat.rs
@@ -1,0 +1,131 @@
+#[doc = "Register `stat` reader"]
+pub type R = crate::R<STAT_SPEC>;
+#[doc = "Register `stat` writer"]
+pub type W = crate::W<STAT_SPEC>;
+#[doc = "Field `nonce_mode` reader - TRNG Nonce operating mode"]
+pub type NONCE_MODE_R = crate::BitReader;
+#[doc = "Field `r256` reader - TRNG 256-bit random number operating mode"]
+pub type R256_R = crate::BitReader;
+#[doc = "Field `mission_mode` reader - TRNG Mission Mode operating mode"]
+pub type MISSION_MODE_R = crate::BitReader;
+#[doc = "Field `seeded` reader - TRNG Seeded operating mode"]
+pub type SEEDED_R = crate::BitReader;
+#[doc = "Field `last_reseed0` reader - TRNG Last Reseed 0 status"]
+pub type LAST_RESEED0_R = crate::BitReader;
+#[doc = "Field `last_reseed1` reader - TRNG Last Reseed 1 status"]
+pub type LAST_RESEED1_R = crate::BitReader;
+#[doc = "Field `last_reseed2` reader - TRNG Last Reseed 2 status"]
+pub type LAST_RESEED2_R = crate::BitReader;
+#[doc = "Field `last_reseed3` reader - TRNG Last Reseed 3 status"]
+pub type LAST_RESEED3_R = crate::BitReader;
+#[doc = "Field `last_reseed4` reader - TRNG Last Reseed 4 status"]
+pub type LAST_RESEED4_R = crate::BitReader;
+#[doc = "Field `last_reseed5` reader - TRNG Last Reseed 5 status"]
+pub type LAST_RESEED5_R = crate::BitReader;
+#[doc = "Field `last_reseed6` reader - TRNG Last Reseed 6 status"]
+pub type LAST_RESEED6_R = crate::BitReader;
+#[doc = "Field `last_reseed7` reader - TRNG Last Reseed 7 status"]
+pub type LAST_RESEED7_R = crate::BitReader;
+#[doc = "Field `srvc_rqst` reader - TRNG Service Request"]
+pub type SRVC_RQST_R = crate::BitReader;
+#[doc = "Field `rand_generating` reader - TRNG Random Number Generating Status"]
+pub type RAND_GENERATING_R = crate::BitReader;
+#[doc = "Field `rand_seeding` reader - TRNG Random Number Seeding Status"]
+pub type RAND_SEEDING_R = crate::BitReader;
+impl R {
+    #[doc = "Bit 2 - TRNG Nonce operating mode"]
+    #[inline(always)]
+    pub fn nonce_mode(&self) -> NONCE_MODE_R {
+        NONCE_MODE_R::new(((self.bits >> 2) & 1) != 0)
+    }
+    #[doc = "Bit 3 - TRNG 256-bit random number operating mode"]
+    #[inline(always)]
+    pub fn r256(&self) -> R256_R {
+        R256_R::new(((self.bits >> 3) & 1) != 0)
+    }
+    #[doc = "Bit 8 - TRNG Mission Mode operating mode"]
+    #[inline(always)]
+    pub fn mission_mode(&self) -> MISSION_MODE_R {
+        MISSION_MODE_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - TRNG Seeded operating mode"]
+    #[inline(always)]
+    pub fn seeded(&self) -> SEEDED_R {
+        SEEDED_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 16 - TRNG Last Reseed 0 status"]
+    #[inline(always)]
+    pub fn last_reseed0(&self) -> LAST_RESEED0_R {
+        LAST_RESEED0_R::new(((self.bits >> 16) & 1) != 0)
+    }
+    #[doc = "Bit 17 - TRNG Last Reseed 1 status"]
+    #[inline(always)]
+    pub fn last_reseed1(&self) -> LAST_RESEED1_R {
+        LAST_RESEED1_R::new(((self.bits >> 17) & 1) != 0)
+    }
+    #[doc = "Bit 18 - TRNG Last Reseed 2 status"]
+    #[inline(always)]
+    pub fn last_reseed2(&self) -> LAST_RESEED2_R {
+        LAST_RESEED2_R::new(((self.bits >> 18) & 1) != 0)
+    }
+    #[doc = "Bit 19 - TRNG Last Reseed 3 status"]
+    #[inline(always)]
+    pub fn last_reseed3(&self) -> LAST_RESEED3_R {
+        LAST_RESEED3_R::new(((self.bits >> 19) & 1) != 0)
+    }
+    #[doc = "Bit 20 - TRNG Last Reseed 4 status"]
+    #[inline(always)]
+    pub fn last_reseed4(&self) -> LAST_RESEED4_R {
+        LAST_RESEED4_R::new(((self.bits >> 20) & 1) != 0)
+    }
+    #[doc = "Bit 21 - TRNG Last Reseed 5 status"]
+    #[inline(always)]
+    pub fn last_reseed5(&self) -> LAST_RESEED5_R {
+        LAST_RESEED5_R::new(((self.bits >> 21) & 1) != 0)
+    }
+    #[doc = "Bit 22 - TRNG Last Reseed 6 status"]
+    #[inline(always)]
+    pub fn last_reseed6(&self) -> LAST_RESEED6_R {
+        LAST_RESEED6_R::new(((self.bits >> 22) & 1) != 0)
+    }
+    #[doc = "Bit 23 - TRNG Last Reseed 7 status"]
+    #[inline(always)]
+    pub fn last_reseed7(&self) -> LAST_RESEED7_R {
+        LAST_RESEED7_R::new(((self.bits >> 23) & 1) != 0)
+    }
+    #[doc = "Bit 27 - TRNG Service Request"]
+    #[inline(always)]
+    pub fn srvc_rqst(&self) -> SRVC_RQST_R {
+        SRVC_RQST_R::new(((self.bits >> 27) & 1) != 0)
+    }
+    #[doc = "Bit 30 - TRNG Random Number Generating Status"]
+    #[inline(always)]
+    pub fn rand_generating(&self) -> RAND_GENERATING_R {
+        RAND_GENERATING_R::new(((self.bits >> 30) & 1) != 0)
+    }
+    #[doc = "Bit 31 - TRNG Random Number Seeding Status"]
+    #[inline(always)]
+    pub fn rand_seeding(&self) -> RAND_SEEDING_R {
+        RAND_SEEDING_R::new(((self.bits >> 31) & 1) != 0)
+    }
+}
+impl W {
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "TRNG STAT Register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stat::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct STAT_SPEC;
+impl crate::RegisterSpec for STAT_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`stat::R`](R) reader structure"]
+impl crate::Readable for STAT_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`stat::W`](W) writer structure"]
+impl crate::Writable for STAT_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}


### PR DESCRIPTION
Adds the ARM PL022 SPI device register definitions.

Modifies the `jh7110-vf2-13b` DTS file based on the upstream Linux DTS files.