### PR TITLE
fixup: i2c: better field definition - `TAR` and `SAR`

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -256,8 +256,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -270,9 +282,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -1284,8 +1302,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -1298,9 +1328,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -2312,8 +2348,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -2326,9 +2374,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -9952,8 +10006,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -9966,9 +10032,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -10980,8 +11052,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -10994,9 +11078,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -12008,8 +12098,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -12022,9 +12124,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -13036,8 +13144,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -13050,9 +13170,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/sar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/tar.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -256,8 +256,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -270,9 +282,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -1284,8 +1302,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -1298,9 +1328,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -2312,8 +2348,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -2326,9 +2374,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -9952,8 +10006,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -9966,9 +10032,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -10980,8 +11052,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -10994,9 +11078,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -12008,8 +12098,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -12022,9 +12124,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>
@@ -13046,8 +13154,20 @@
           <size>32</size>
           <fields>
             <field>
-              <name>master_10bit</name>
-              <description>If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers.</description>
+              <name>address_7bit</name>
+              <description>Target address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Target address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>mode</name>
+              <description>Target addressing mode - 0: 7-bit, 1: 10-bit</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
@@ -13060,9 +13180,15 @@
           <size>32</size>
           <fields>
             <field>
-              <name>sar</name>
-              <description>sar</description>
-              <bitRange>[31:0]</bitRange>
+              <name>address_7bit</name>
+              <description>Slave address, 7-bit mode</description>
+              <bitRange>[6:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>address_10bit</name>
+              <description>Slave address, 10-bit mode</description>
+              <bitRange>[9:0]</bitRange>
               <access>read-write</access>
             </field>
           </fields>

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/sar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/sar.rs
@@ -2,23 +2,38 @@
 pub type R = crate::R<SAR_SPEC>;
 #[doc = "Register `sar` writer"]
 pub type W = crate::W<SAR_SPEC>;
-#[doc = "Field `sar` reader - sar"]
-pub type SAR_R = crate::FieldReader<u32>;
-#[doc = "Field `sar` writer - sar"]
-pub type SAR_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 32, O, u32>;
+#[doc = "Field `address_7bit` reader - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Slave address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Slave address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
 impl R {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
-    pub fn sar(&self) -> SAR_R {
-        SAR_R::new(self.bits)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - sar"]
+    #[doc = "Bits 0:6 - Slave address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn sar(&mut self) -> SAR_W<SAR_SPEC, 0> {
-        SAR_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<SAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Slave address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<SAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/tar.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/tar.rs
@@ -2,23 +2,53 @@
 pub type R = crate::R<TAR_SPEC>;
 #[doc = "Register `tar` writer"]
 pub type W = crate::W<TAR_SPEC>;
-#[doc = "Field `master_10bit` reader - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_R = crate::BitReader;
-#[doc = "Field `master_10bit` writer - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
-pub type MASTER_10BIT_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `address_7bit` reader - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_R = crate::FieldReader;
+#[doc = "Field `address_7bit` writer - Target address, 7-bit mode"]
+pub type ADDRESS_7BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 7, O>;
+#[doc = "Field `address_10bit` reader - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_R = crate::FieldReader<u16>;
+#[doc = "Field `address_10bit` writer - Target address, 10-bit mode"]
+pub type ADDRESS_10BIT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 10, O, u16>;
+#[doc = "Field `mode` reader - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_R = crate::BitReader;
+#[doc = "Field `mode` writer - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+pub type MODE_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 impl R {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
-    pub fn master_10bit(&self) -> MASTER_10BIT_R {
-        MASTER_10BIT_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn address_7bit(&self) -> ADDRESS_7BIT_R {
+        ADDRESS_7BIT_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    pub fn address_10bit(&self) -> ADDRESS_10BIT_R {
+        ADDRESS_10BIT_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 12) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 12 - If I2C_DYNAMIC_TAR_UPDATE is set, the 10-bit addressing mode has to be enabled via bit 12 of TAR register. We set it always as I2C_DYNAMIC_TAR_UPDATE can't be detected from registers."]
+    #[doc = "Bits 0:6 - Target address, 7-bit mode"]
     #[inline(always)]
     #[must_use]
-    pub fn master_10bit(&mut self) -> MASTER_10BIT_W<TAR_SPEC, 12> {
-        MASTER_10BIT_W::new(self)
+    pub fn address_7bit(&mut self) -> ADDRESS_7BIT_W<TAR_SPEC, 0> {
+        ADDRESS_7BIT_W::new(self)
+    }
+    #[doc = "Bits 0:9 - Target address, 10-bit mode"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address_10bit(&mut self) -> ADDRESS_10BIT_W<TAR_SPEC, 0> {
+        ADDRESS_10BIT_W::new(self)
+    }
+    #[doc = "Bit 12 - Target addressing mode - 0: 7-bit, 1: 10-bit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn mode(&mut self) -> MODE_W<TAR_SPEC, 12> {
+        MODE_W::new(self)
     }
     #[doc = "Writes raw bits to the register."]
     #[inline(always)]


### PR DESCRIPTION
Better field definitions for `TAR` and `SAR` register bitfields.

Enables accessor functions for target and slave addresses that are 7-bit and 10-bit specific.