### PR TITLE
fixup: i2c: add `DATA_CMD` fields

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -308,6 +308,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -1354,6 +1372,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -2397,6 +2433,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -10058,6 +10112,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -11101,6 +11173,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -12150,6 +12240,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -13193,6 +13301,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_0/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_1/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_2/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_3/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_4/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_5/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/data_cmd.rs
+++ b/jh7110-vf2-12a-pac/src/snps_designware_i2c_6/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -308,6 +308,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -1354,6 +1372,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -2397,6 +2433,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -10058,6 +10112,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -11104,6 +11176,24 @@
               <access>read-write</access>
             </field>
             <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
               <name>first_data_byte</name>
               <description>Data Command First Data Byte - 0: False, 1: True</description>
               <bitRange>[11:11]</bitRange>
@@ -12147,6 +12237,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
@@ -13203,6 +13311,24 @@
               <name>dat</name>
               <description>Data Command Data Byte</description>
               <bitRange>[7:0]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>read</name>
+              <description>Data Command READ Bit - 0: Write, 1: Read</description>
+              <bitRange>[8:8]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>stop</name>
+              <description>Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte</description>
+              <bitRange>[9:9]</bitRange>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>restart</name>
+              <description>Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer</description>
+              <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_0/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_1/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_2/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_3/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_4/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_5/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/data_cmd.rs
+++ b/jh7110-vf2-13b-pac/src/snps_designware_i2c_6/data_cmd.rs
@@ -6,6 +6,18 @@ pub type W = crate::W<DATA_CMD_SPEC>;
 pub type DAT_R = crate::FieldReader;
 #[doc = "Field `dat` writer - Data Command Data Byte"]
 pub type DAT_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 8, O>;
+#[doc = "Field `read` reader - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_R = crate::BitReader;
+#[doc = "Field `read` writer - Data Command READ Bit - 0: Write, 1: Read"]
+pub type READ_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `stop` reader - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_R = crate::BitReader;
+#[doc = "Field `stop` writer - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+pub type STOP_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
+#[doc = "Field `restart` reader - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_R = crate::BitReader;
+#[doc = "Field `restart` writer - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+pub type RESTART_W<'a, REG, const O: u8> = crate::BitWriter<'a, REG, O>;
 #[doc = "Field `first_data_byte` reader - Data Command First Data Byte - 0: False, 1: True"]
 pub type FIRST_DATA_BYTE_R = crate::BitReader;
 #[doc = "Field `first_data_byte` writer - Data Command First Data Byte - 0: False, 1: True"]
@@ -15,6 +27,21 @@ impl R {
     #[inline(always)]
     pub fn dat(&self) -> DAT_R {
         DAT_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    pub fn read(&self) -> READ_R {
+        READ_R::new(((self.bits >> 8) & 1) != 0)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 9) & 1) != 0)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]
@@ -28,6 +55,24 @@ impl W {
     #[must_use]
     pub fn dat(&mut self) -> DAT_W<DATA_CMD_SPEC, 0> {
         DAT_W::new(self)
+    }
+    #[doc = "Bit 8 - Data Command READ Bit - 0: Write, 1: Read"]
+    #[inline(always)]
+    #[must_use]
+    pub fn read(&mut self) -> READ_W<DATA_CMD_SPEC, 8> {
+        READ_W::new(self)
+    }
+    #[doc = "Bit 9 - Data Command STOP Bit - 0: Non-terminal DATA command byte, 1: Terminal DATA command byte"]
+    #[inline(always)]
+    #[must_use]
+    pub fn stop(&mut self) -> STOP_W<DATA_CMD_SPEC, 9> {
+        STOP_W::new(self)
+    }
+    #[doc = "Bit 10 - Data Command RESTART Bit - 0: Do not restart the transfer, 1: Restart the transfer"]
+    #[inline(always)]
+    #[must_use]
+    pub fn restart(&mut self) -> RESTART_W<DATA_CMD_SPEC, 10> {
+        RESTART_W::new(self)
     }
     #[doc = "Bit 11 - Data Command First Data Byte - 0: False, 1: True"]
     #[inline(always)]


### PR DESCRIPTION
Adds `DATA_CMD` register fields not explicitly listed in the Linux driver header. Fields are implicitly defined in the `i2c-designware-master.c` implementation function `i2c_dw_xfer_msg`.