### PR TITLE
fixup: qspi: register naming and description

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -17370,27 +17370,27 @@
           </fields>
         </register>
         <register>
-          <name>reg_size</name>
-          <description>Cadence QSPI Register Size</description>
+          <name>size</name>
+          <description>Cadence QSPI Size Configuration</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
           <fields>
             <field>
               <name>address</name>
-              <description>Register Size Address</description>
+              <description>Address Size in Bytes</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>page</name>
-              <description>Read Capture Delay Value</description>
+              <description>Page Size in Bytes</description>
               <bitRange>[15:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>block</name>
-              <description>Read Capture Block Number</description>
+              <description>Block Size in Bytes</description>
               <bitRange>[21:16]</bitRange>
               <access>read-write</access>
             </field>

--- a/jh7110-vf2-12a-pac/src/qspi.rs
+++ b/jh7110-vf2-12a-pac/src/qspi.rs
@@ -11,8 +11,8 @@ pub struct RegisterBlock {
     pub delay: DELAY,
     #[doc = "0x10 - Cadence QSPI Read Capture"]
     pub read_capture: READ_CAPTURE,
-    #[doc = "0x14 - Cadence QSPI Register Size"]
-    pub reg_size: REG_SIZE,
+    #[doc = "0x14 - Cadence QSPI Size Configuration"]
+    pub size: SIZE,
     #[doc = "0x18 - Cadence QSPI SRAM Partition Size"]
     pub sram_partition: SRAM_PARTITION,
     #[doc = "0x1c - Cadence QSPI Indirect Trigger Address"]
@@ -95,11 +95,11 @@ module"]
 pub type READ_CAPTURE = crate::Reg<read_capture::READ_CAPTURE_SPEC>;
 #[doc = "Cadence QSPI Read Capture"]
 pub mod read_capture;
-#[doc = "reg_size (rw) register accessor: Cadence QSPI Register Size\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`reg_size::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`reg_size::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`reg_size`]
+#[doc = "size (rw) register accessor: Cadence QSPI Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`size::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`size::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`size`]
 module"]
-pub type REG_SIZE = crate::Reg<reg_size::REG_SIZE_SPEC>;
-#[doc = "Cadence QSPI Register Size"]
-pub mod reg_size;
+pub type SIZE = crate::Reg<size::SIZE_SPEC>;
+#[doc = "Cadence QSPI Size Configuration"]
+pub mod size;
 #[doc = "sram_partition (rw) register accessor: Cadence QSPI SRAM Partition Size\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sram_partition::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sram_partition::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`sram_partition`]
 module"]
 pub type SRAM_PARTITION = crate::Reg<sram_partition::SRAM_PARTITION_SPEC>;

--- a/jh7110-vf2-12a-pac/src/qspi/size.rs
+++ b/jh7110-vf2-12a-pac/src/qspi/size.rs
@@ -1,0 +1,75 @@
+#[doc = "Register `size` reader"]
+pub type R = crate::R<SIZE_SPEC>;
+#[doc = "Register `size` writer"]
+pub type W = crate::W<SIZE_SPEC>;
+#[doc = "Field `address` reader - Address Size in Bytes"]
+pub type ADDRESS_R = crate::FieldReader;
+#[doc = "Field `address` writer - Address Size in Bytes"]
+pub type ADDRESS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `page` reader - Page Size in Bytes"]
+pub type PAGE_R = crate::FieldReader<u16>;
+#[doc = "Field `page` writer - Page Size in Bytes"]
+pub type PAGE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 12, O, u16>;
+#[doc = "Field `block` reader - Block Size in Bytes"]
+pub type BLOCK_R = crate::FieldReader;
+#[doc = "Field `block` writer - Block Size in Bytes"]
+pub type BLOCK_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
+impl R {
+    #[doc = "Bits 0:3 - Address Size in Bytes"]
+    #[inline(always)]
+    pub fn address(&self) -> ADDRESS_R {
+        ADDRESS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:15 - Page Size in Bytes"]
+    #[inline(always)]
+    pub fn page(&self) -> PAGE_R {
+        PAGE_R::new(((self.bits >> 4) & 0x0fff) as u16)
+    }
+    #[doc = "Bits 16:21 - Block Size in Bytes"]
+    #[inline(always)]
+    pub fn block(&self) -> BLOCK_R {
+        BLOCK_R::new(((self.bits >> 16) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Address Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address(&mut self) -> ADDRESS_W<SIZE_SPEC, 0> {
+        ADDRESS_W::new(self)
+    }
+    #[doc = "Bits 4:15 - Page Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn page(&mut self) -> PAGE_W<SIZE_SPEC, 4> {
+        PAGE_W::new(self)
+    }
+    #[doc = "Bits 16:21 - Block Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn block(&mut self) -> BLOCK_W<SIZE_SPEC, 16> {
+        BLOCK_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Cadence QSPI Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`size::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`size::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SIZE_SPEC;
+impl crate::RegisterSpec for SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`size::R`](R) reader structure"]
+impl crate::Readable for SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`size::W`](W) writer structure"]
+impl crate::Writable for SIZE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets size to value 0"]
+impl crate::Resettable for SIZE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -17380,27 +17380,27 @@
           </fields>
         </register>
         <register>
-          <name>reg_size</name>
-          <description>Cadence QSPI Register Size</description>
+          <name>size</name>
+          <description>Cadence QSPI Size Configuration</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
           <fields>
             <field>
               <name>address</name>
-              <description>Register Size Address</description>
+              <description>Address Size in Bytes</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>page</name>
-              <description>Read Capture Delay Value</description>
+              <description>Page Size in Bytes</description>
               <bitRange>[15:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
               <name>block</name>
-              <description>Read Capture Block Number</description>
+              <description>Block Size in Bytes</description>
               <bitRange>[21:16]</bitRange>
               <access>read-write</access>
             </field>

--- a/jh7110-vf2-13b-pac/src/qspi.rs
+++ b/jh7110-vf2-13b-pac/src/qspi.rs
@@ -11,8 +11,8 @@ pub struct RegisterBlock {
     pub delay: DELAY,
     #[doc = "0x10 - Cadence QSPI Read Capture"]
     pub read_capture: READ_CAPTURE,
-    #[doc = "0x14 - Cadence QSPI Register Size"]
-    pub reg_size: REG_SIZE,
+    #[doc = "0x14 - Cadence QSPI Size Configuration"]
+    pub size: SIZE,
     #[doc = "0x18 - Cadence QSPI SRAM Partition Size"]
     pub sram_partition: SRAM_PARTITION,
     #[doc = "0x1c - Cadence QSPI Indirect Trigger Address"]
@@ -95,11 +95,11 @@ module"]
 pub type READ_CAPTURE = crate::Reg<read_capture::READ_CAPTURE_SPEC>;
 #[doc = "Cadence QSPI Read Capture"]
 pub mod read_capture;
-#[doc = "reg_size (rw) register accessor: Cadence QSPI Register Size\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`reg_size::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`reg_size::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`reg_size`]
+#[doc = "size (rw) register accessor: Cadence QSPI Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`size::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`size::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`size`]
 module"]
-pub type REG_SIZE = crate::Reg<reg_size::REG_SIZE_SPEC>;
-#[doc = "Cadence QSPI Register Size"]
-pub mod reg_size;
+pub type SIZE = crate::Reg<size::SIZE_SPEC>;
+#[doc = "Cadence QSPI Size Configuration"]
+pub mod size;
 #[doc = "sram_partition (rw) register accessor: Cadence QSPI SRAM Partition Size\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sram_partition::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sram_partition::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`sram_partition`]
 module"]
 pub type SRAM_PARTITION = crate::Reg<sram_partition::SRAM_PARTITION_SPEC>;

--- a/jh7110-vf2-13b-pac/src/qspi/size.rs
+++ b/jh7110-vf2-13b-pac/src/qspi/size.rs
@@ -1,0 +1,75 @@
+#[doc = "Register `size` reader"]
+pub type R = crate::R<SIZE_SPEC>;
+#[doc = "Register `size` writer"]
+pub type W = crate::W<SIZE_SPEC>;
+#[doc = "Field `address` reader - Address Size in Bytes"]
+pub type ADDRESS_R = crate::FieldReader;
+#[doc = "Field `address` writer - Address Size in Bytes"]
+pub type ADDRESS_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 4, O>;
+#[doc = "Field `page` reader - Page Size in Bytes"]
+pub type PAGE_R = crate::FieldReader<u16>;
+#[doc = "Field `page` writer - Page Size in Bytes"]
+pub type PAGE_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 12, O, u16>;
+#[doc = "Field `block` reader - Block Size in Bytes"]
+pub type BLOCK_R = crate::FieldReader;
+#[doc = "Field `block` writer - Block Size in Bytes"]
+pub type BLOCK_W<'a, REG, const O: u8> = crate::FieldWriter<'a, REG, 6, O>;
+impl R {
+    #[doc = "Bits 0:3 - Address Size in Bytes"]
+    #[inline(always)]
+    pub fn address(&self) -> ADDRESS_R {
+        ADDRESS_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:15 - Page Size in Bytes"]
+    #[inline(always)]
+    pub fn page(&self) -> PAGE_R {
+        PAGE_R::new(((self.bits >> 4) & 0x0fff) as u16)
+    }
+    #[doc = "Bits 16:21 - Block Size in Bytes"]
+    #[inline(always)]
+    pub fn block(&self) -> BLOCK_R {
+        BLOCK_R::new(((self.bits >> 16) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Address Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn address(&mut self) -> ADDRESS_W<SIZE_SPEC, 0> {
+        ADDRESS_W::new(self)
+    }
+    #[doc = "Bits 4:15 - Page Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn page(&mut self) -> PAGE_W<SIZE_SPEC, 4> {
+        PAGE_W::new(self)
+    }
+    #[doc = "Bits 16:21 - Block Size in Bytes"]
+    #[inline(always)]
+    #[must_use]
+    pub fn block(&mut self) -> BLOCK_W<SIZE_SPEC, 16> {
+        BLOCK_W::new(self)
+    }
+    #[doc = "Writes raw bits to the register."]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Cadence QSPI Size Configuration\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`size::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`size::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SIZE_SPEC;
+impl crate::RegisterSpec for SIZE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`size::R`](R) reader structure"]
+impl crate::Readable for SIZE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`size::W`](W) writer structure"]
+impl crate::Writable for SIZE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets size to value 0"]
+impl crate::Resettable for SIZE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}


### PR DESCRIPTION
Fixes some copy-paste errors for the `size` register bitfield, and changes `reg_size` to `size`.