### PR TITLE
fixup: stg_syscon: STG register name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,7 @@ members = [
 
 [features]
 visionfive2-12a = ["jh7110-vf2-12a-pac"]
+visionfive2-12a-rt = ["jh7110-vf2-12a-pac/rt"]
 visionfive2-13b = ["jh7110-vf2-13b-pac"]
+visionfive2-13b-rt = ["jh7110-vf2-13b-pac/rt"]
 all = ["visionfive2-12a", "visionfive2-13b"]

--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -13687,7 +13687,7 @@
           </fields>
         </register>
         <register>
-          <name>stg_syscfg_l54</name>
+          <name>stg_syscfg_154</name>
           <description>STG SYSCONSAIF SYSCFG 616</description>
           <addressOffset>0x268</addressOffset>
           <size>32</size>

--- a/jh7110-vf2-12a-pac/src/stg_syscon.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon.rs
@@ -155,7 +155,7 @@ pub struct RegisterBlock {
     stg_syscfg_151: STG_SYSCFG_151,
     stg_syscfg_152: STG_SYSCFG_152,
     stg_syscfg_153: STG_SYSCFG_153,
-    stg_syscfg_l54: STG_SYSCFG_L54,
+    stg_syscfg_154: STG_SYSCFG_154,
     stg_syscfg_155: STG_SYSCFG_155,
     stg_syscfg_156: STG_SYSCFG_156,
     stg_syscfg_157: STG_SYSCFG_157,
@@ -1009,8 +1009,8 @@ impl RegisterBlock {
     }
     #[doc = "0x268 - STG SYSCONSAIF SYSCFG 616"]
     #[inline(always)]
-    pub const fn stg_syscfg_l54(&self) -> &STG_SYSCFG_L54 {
-        &self.stg_syscfg_l54
+    pub const fn stg_syscfg_154(&self) -> &STG_SYSCFG_154 {
+        &self.stg_syscfg_154
     }
     #[doc = "0x26c - STG SYSCONSAIF SYSCFG 620"]
     #[inline(always)]
@@ -2178,11 +2178,11 @@ module"]
 pub type STG_SYSCFG_153 = crate::Reg<stg_syscfg_153::STG_SYSCFG_153_SPEC>;
 #[doc = "STG SYSCONSAIF SYSCFG 612"]
 pub mod stg_syscfg_153;
-#[doc = "stg_syscfg_l54 (rw) register accessor: STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_l54::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_l54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_l54`]
+#[doc = "stg_syscfg_154 (rw) register accessor: STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_154::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_154::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_154`]
 module"]
-pub type STG_SYSCFG_L54 = crate::Reg<stg_syscfg_l54::STG_SYSCFG_L54_SPEC>;
+pub type STG_SYSCFG_154 = crate::Reg<stg_syscfg_154::STG_SYSCFG_154_SPEC>;
 #[doc = "STG SYSCONSAIF SYSCFG 616"]
-pub mod stg_syscfg_l54;
+pub mod stg_syscfg_154;
 #[doc = "stg_syscfg_155 (rw) register accessor: STG SYSCONSAIF SYSCFG 620\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_155::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_155::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_155`]
 module"]
 pub type STG_SYSCFG_155 = crate::Reg<stg_syscfg_155::STG_SYSCFG_155_SPEC>;

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_154.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_154.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `stg_syscfg_l54` reader"]
-pub type R = crate::R<STG_SYSCFG_L54_SPEC>;
-#[doc = "Register `stg_syscfg_l54` writer"]
-pub type W = crate::W<STG_SYSCFG_L54_SPEC>;
+#[doc = "Register `stg_syscfg_154` reader"]
+pub type R = crate::R<STG_SYSCFG_154_SPEC>;
+#[doc = "Register `stg_syscfg_154` writer"]
+pub type W = crate::W<STG_SYSCFG_154_SPEC>;
 #[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` reader - u1_plda_pcie_axi4_slv0_awuser_40_32"]
 pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
 #[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` writer - u1_plda_pcie_axi4_slv0_awuser_40_32"]
@@ -26,7 +26,7 @@ impl W {
     #[must_use]
     pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_L54_SPEC> {
+    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
         U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -40,19 +40,19 @@ impl W {
         self
     }
 }
-#[doc = "STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_l54::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_l54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct STG_SYSCFG_L54_SPEC;
-impl crate::RegisterSpec for STG_SYSCFG_L54_SPEC {
+#[doc = "STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_154::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_154::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct STG_SYSCFG_154_SPEC;
+impl crate::RegisterSpec for STG_SYSCFG_154_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`stg_syscfg_l54::R`](R) reader structure"]
-impl crate::Readable for STG_SYSCFG_L54_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`stg_syscfg_l54::W`](W) writer structure"]
-impl crate::Writable for STG_SYSCFG_L54_SPEC {
+#[doc = "`read()` method returns [`stg_syscfg_154::R`](R) reader structure"]
+impl crate::Readable for STG_SYSCFG_154_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`stg_syscfg_154::W`](W) writer structure"]
+impl crate::Writable for STG_SYSCFG_154_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets stg_syscfg_l54 to value 0"]
-impl crate::Resettable for STG_SYSCFG_L54_SPEC {
+#[doc = "`reset()` method sets stg_syscfg_154 to value 0"]
+impl crate::Resettable for STG_SYSCFG_154_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -13687,7 +13687,7 @@
           </fields>
         </register>
         <register>
-          <name>stg_syscfg_l54</name>
+          <name>stg_syscfg_154</name>
           <description>STG SYSCONSAIF SYSCFG 616</description>
           <addressOffset>0x268</addressOffset>
           <size>32</size>

--- a/jh7110-vf2-13b-pac/src/stg_syscon.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon.rs
@@ -155,7 +155,7 @@ pub struct RegisterBlock {
     stg_syscfg_151: STG_SYSCFG_151,
     stg_syscfg_152: STG_SYSCFG_152,
     stg_syscfg_153: STG_SYSCFG_153,
-    stg_syscfg_l54: STG_SYSCFG_L54,
+    stg_syscfg_154: STG_SYSCFG_154,
     stg_syscfg_155: STG_SYSCFG_155,
     stg_syscfg_156: STG_SYSCFG_156,
     stg_syscfg_157: STG_SYSCFG_157,
@@ -1009,8 +1009,8 @@ impl RegisterBlock {
     }
     #[doc = "0x268 - STG SYSCONSAIF SYSCFG 616"]
     #[inline(always)]
-    pub const fn stg_syscfg_l54(&self) -> &STG_SYSCFG_L54 {
-        &self.stg_syscfg_l54
+    pub const fn stg_syscfg_154(&self) -> &STG_SYSCFG_154 {
+        &self.stg_syscfg_154
     }
     #[doc = "0x26c - STG SYSCONSAIF SYSCFG 620"]
     #[inline(always)]
@@ -2178,11 +2178,11 @@ module"]
 pub type STG_SYSCFG_153 = crate::Reg<stg_syscfg_153::STG_SYSCFG_153_SPEC>;
 #[doc = "STG SYSCONSAIF SYSCFG 612"]
 pub mod stg_syscfg_153;
-#[doc = "stg_syscfg_l54 (rw) register accessor: STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_l54::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_l54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_l54`]
+#[doc = "stg_syscfg_154 (rw) register accessor: STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_154::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_154::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_154`]
 module"]
-pub type STG_SYSCFG_L54 = crate::Reg<stg_syscfg_l54::STG_SYSCFG_L54_SPEC>;
+pub type STG_SYSCFG_154 = crate::Reg<stg_syscfg_154::STG_SYSCFG_154_SPEC>;
 #[doc = "STG SYSCONSAIF SYSCFG 616"]
-pub mod stg_syscfg_l54;
+pub mod stg_syscfg_154;
 #[doc = "stg_syscfg_155 (rw) register accessor: STG SYSCONSAIF SYSCFG 620\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_155::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_155::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stg_syscfg_155`]
 module"]
 pub type STG_SYSCFG_155 = crate::Reg<stg_syscfg_155::STG_SYSCFG_155_SPEC>;

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_154.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_154.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `stg_syscfg_l54` reader"]
-pub type R = crate::R<STG_SYSCFG_L54_SPEC>;
-#[doc = "Register `stg_syscfg_l54` writer"]
-pub type W = crate::W<STG_SYSCFG_L54_SPEC>;
+#[doc = "Register `stg_syscfg_154` reader"]
+pub type R = crate::R<STG_SYSCFG_154_SPEC>;
+#[doc = "Register `stg_syscfg_154` writer"]
+pub type W = crate::W<STG_SYSCFG_154_SPEC>;
 #[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` reader - u1_plda_pcie_axi4_slv0_awuser_40_32"]
 pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
 #[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` writer - u1_plda_pcie_axi4_slv0_awuser_40_32"]
@@ -26,7 +26,7 @@ impl W {
     #[must_use]
     pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_L54_SPEC> {
+    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
         U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -40,19 +40,19 @@ impl W {
         self
     }
 }
-#[doc = "STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_l54::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_l54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct STG_SYSCFG_L54_SPEC;
-impl crate::RegisterSpec for STG_SYSCFG_L54_SPEC {
+#[doc = "STG SYSCONSAIF SYSCFG 616\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stg_syscfg_154::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stg_syscfg_154::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct STG_SYSCFG_154_SPEC;
+impl crate::RegisterSpec for STG_SYSCFG_154_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`stg_syscfg_l54::R`](R) reader structure"]
-impl crate::Readable for STG_SYSCFG_L54_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`stg_syscfg_l54::W`](W) writer structure"]
-impl crate::Writable for STG_SYSCFG_L54_SPEC {
+#[doc = "`read()` method returns [`stg_syscfg_154::R`](R) reader structure"]
+impl crate::Readable for STG_SYSCFG_154_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`stg_syscfg_154::W`](W) writer structure"]
+impl crate::Writable for STG_SYSCFG_154_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets stg_syscfg_l54 to value 0"]
-impl crate::Resettable for STG_SYSCFG_L54_SPEC {
+#[doc = "`reset()` method sets stg_syscfg_154 to value 0"]
+impl crate::Resettable for STG_SYSCFG_154_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }


### PR DESCRIPTION
Typo in `stg_syscfg_154`.