### PR TITLE
fixup: plic: add fields for reset value

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -125,881 +125,2616 @@
           <name>priority_1</name>
           <description>PRIORITY Register for interrupt id 1</description>
           <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_2</name>
           <description>PRIORITY Register for interrupt id 2</description>
           <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_3</name>
           <description>PRIORITY Register for interrupt id 3</description>
           <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_4</name>
           <description>PRIORITY Register for interrupt id 4</description>
           <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_5</name>
           <description>PRIORITY Register for interrupt id 5</description>
           <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_6</name>
           <description>PRIORITY Register for interrupt id 6</description>
           <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_7</name>
           <description>PRIORITY Register for interrupt id 7</description>
           <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_8</name>
           <description>PRIORITY Register for interrupt id 8</description>
           <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_9</name>
           <description>PRIORITY Register for interrupt id 9</description>
           <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_10</name>
           <description>PRIORITY Register for interrupt id 10</description>
           <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_11</name>
           <description>PRIORITY Register for interrupt id 11</description>
           <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_12</name>
           <description>PRIORITY Register for interrupt id 12</description>
           <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_13</name>
           <description>PRIORITY Register for interrupt id 13</description>
           <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_14</name>
           <description>PRIORITY Register for interrupt id 14</description>
           <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_15</name>
           <description>PRIORITY Register for interrupt id 15</description>
           <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_16</name>
           <description>PRIORITY Register for interrupt id 16</description>
           <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_17</name>
           <description>PRIORITY Register for interrupt id 17</description>
           <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_18</name>
           <description>PRIORITY Register for interrupt id 18</description>
           <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_19</name>
           <description>PRIORITY Register for interrupt id 19</description>
           <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_20</name>
           <description>PRIORITY Register for interrupt id 20</description>
           <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_21</name>
           <description>PRIORITY Register for interrupt id 21</description>
           <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_22</name>
           <description>PRIORITY Register for interrupt id 22</description>
           <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_23</name>
           <description>PRIORITY Register for interrupt id 23</description>
           <addressOffset>0x5C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_24</name>
           <description>PRIORITY Register for interrupt id 24</description>
           <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_25</name>
           <description>PRIORITY Register for interrupt id 25</description>
           <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_26</name>
           <description>PRIORITY Register for interrupt id 26</description>
           <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_27</name>
           <description>PRIORITY Register for interrupt id 27</description>
           <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_28</name>
           <description>PRIORITY Register for interrupt id 28</description>
           <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_29</name>
           <description>PRIORITY Register for interrupt id 29</description>
           <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_30</name>
           <description>PRIORITY Register for interrupt id 30</description>
           <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_31</name>
           <description>PRIORITY Register for interrupt id 31</description>
           <addressOffset>0x7C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_32</name>
           <description>PRIORITY Register for interrupt id 32</description>
           <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_33</name>
           <description>PRIORITY Register for interrupt id 33</description>
           <addressOffset>0x84</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_34</name>
           <description>PRIORITY Register for interrupt id 34</description>
           <addressOffset>0x88</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_35</name>
           <description>PRIORITY Register for interrupt id 35</description>
           <addressOffset>0x8C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_36</name>
           <description>PRIORITY Register for interrupt id 36</description>
           <addressOffset>0x90</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_37</name>
           <description>PRIORITY Register for interrupt id 37</description>
           <addressOffset>0x94</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_38</name>
           <description>PRIORITY Register for interrupt id 38</description>
           <addressOffset>0x98</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_39</name>
           <description>PRIORITY Register for interrupt id 39</description>
           <addressOffset>0x9C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_40</name>
           <description>PRIORITY Register for interrupt id 40</description>
           <addressOffset>0xA0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_41</name>
           <description>PRIORITY Register for interrupt id 41</description>
           <addressOffset>0xA4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_42</name>
           <description>PRIORITY Register for interrupt id 42</description>
           <addressOffset>0xA8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_43</name>
           <description>PRIORITY Register for interrupt id 43</description>
           <addressOffset>0xAC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_44</name>
           <description>PRIORITY Register for interrupt id 44</description>
           <addressOffset>0xB0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_45</name>
           <description>PRIORITY Register for interrupt id 45</description>
           <addressOffset>0xB4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_46</name>
           <description>PRIORITY Register for interrupt id 46</description>
           <addressOffset>0xB8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_47</name>
           <description>PRIORITY Register for interrupt id 47</description>
           <addressOffset>0xBC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_48</name>
           <description>PRIORITY Register for interrupt id 48</description>
           <addressOffset>0xC0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_49</name>
           <description>PRIORITY Register for interrupt id 49</description>
           <addressOffset>0xC4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_50</name>
           <description>PRIORITY Register for interrupt id 50</description>
           <addressOffset>0xC8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_51</name>
           <description>PRIORITY Register for interrupt id 51</description>
           <addressOffset>0xCC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_52</name>
           <description>PRIORITY Register for interrupt id 52</description>
           <addressOffset>0xD0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_53</name>
           <description>PRIORITY Register for interrupt id 53</description>
           <addressOffset>0xD4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_54</name>
           <description>PRIORITY Register for interrupt id 54</description>
           <addressOffset>0xD8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_55</name>
           <description>PRIORITY Register for interrupt id 55</description>
           <addressOffset>0xDC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_56</name>
           <description>PRIORITY Register for interrupt id 56</description>
           <addressOffset>0xE0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_57</name>
           <description>PRIORITY Register for interrupt id 57</description>
           <addressOffset>0xE4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_58</name>
           <description>PRIORITY Register for interrupt id 58</description>
           <addressOffset>0xE8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_59</name>
           <description>PRIORITY Register for interrupt id 59</description>
           <addressOffset>0xEC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_60</name>
           <description>PRIORITY Register for interrupt id 60</description>
           <addressOffset>0xF0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_61</name>
           <description>PRIORITY Register for interrupt id 61</description>
           <addressOffset>0xF4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_62</name>
           <description>PRIORITY Register for interrupt id 62</description>
           <addressOffset>0xF8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_63</name>
           <description>PRIORITY Register for interrupt id 63</description>
           <addressOffset>0xFC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_64</name>
           <description>PRIORITY Register for interrupt id 64</description>
           <addressOffset>0x100</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_65</name>
           <description>PRIORITY Register for interrupt id 65</description>
           <addressOffset>0x104</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_66</name>
           <description>PRIORITY Register for interrupt id 66</description>
           <addressOffset>0x108</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_67</name>
           <description>PRIORITY Register for interrupt id 67</description>
           <addressOffset>0x10C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_68</name>
           <description>PRIORITY Register for interrupt id 68</description>
           <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_69</name>
           <description>PRIORITY Register for interrupt id 69</description>
           <addressOffset>0x114</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_70</name>
           <description>PRIORITY Register for interrupt id 70</description>
           <addressOffset>0x118</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_71</name>
           <description>PRIORITY Register for interrupt id 71</description>
           <addressOffset>0x11C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_72</name>
           <description>PRIORITY Register for interrupt id 72</description>
           <addressOffset>0x120</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_73</name>
           <description>PRIORITY Register for interrupt id 73</description>
           <addressOffset>0x124</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_74</name>
           <description>PRIORITY Register for interrupt id 74</description>
           <addressOffset>0x128</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_75</name>
           <description>PRIORITY Register for interrupt id 75</description>
           <addressOffset>0x12C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_76</name>
           <description>PRIORITY Register for interrupt id 76</description>
           <addressOffset>0x130</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_77</name>
           <description>PRIORITY Register for interrupt id 77</description>
           <addressOffset>0x134</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_78</name>
           <description>PRIORITY Register for interrupt id 78</description>
           <addressOffset>0x138</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_79</name>
           <description>PRIORITY Register for interrupt id 79</description>
           <addressOffset>0x13C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_80</name>
           <description>PRIORITY Register for interrupt id 80</description>
           <addressOffset>0x140</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_81</name>
           <description>PRIORITY Register for interrupt id 81</description>
           <addressOffset>0x144</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_82</name>
           <description>PRIORITY Register for interrupt id 82</description>
           <addressOffset>0x148</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_83</name>
           <description>PRIORITY Register for interrupt id 83</description>
           <addressOffset>0x14C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_84</name>
           <description>PRIORITY Register for interrupt id 84</description>
           <addressOffset>0x150</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_85</name>
           <description>PRIORITY Register for interrupt id 85</description>
           <addressOffset>0x154</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_86</name>
           <description>PRIORITY Register for interrupt id 86</description>
           <addressOffset>0x158</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_87</name>
           <description>PRIORITY Register for interrupt id 87</description>
           <addressOffset>0x15C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_88</name>
           <description>PRIORITY Register for interrupt id 88</description>
           <addressOffset>0x160</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_89</name>
           <description>PRIORITY Register for interrupt id 89</description>
           <addressOffset>0x164</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_90</name>
           <description>PRIORITY Register for interrupt id 90</description>
           <addressOffset>0x168</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_91</name>
           <description>PRIORITY Register for interrupt id 91</description>
           <addressOffset>0x16C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_92</name>
           <description>PRIORITY Register for interrupt id 92</description>
           <addressOffset>0x170</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_93</name>
           <description>PRIORITY Register for interrupt id 93</description>
           <addressOffset>0x174</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_94</name>
           <description>PRIORITY Register for interrupt id 94</description>
           <addressOffset>0x178</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_95</name>
           <description>PRIORITY Register for interrupt id 95</description>
           <addressOffset>0x17C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_96</name>
           <description>PRIORITY Register for interrupt id 96</description>
           <addressOffset>0x180</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_97</name>
           <description>PRIORITY Register for interrupt id 97</description>
           <addressOffset>0x184</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_98</name>
           <description>PRIORITY Register for interrupt id 98</description>
           <addressOffset>0x188</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_99</name>
           <description>PRIORITY Register for interrupt id 99</description>
           <addressOffset>0x18C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_100</name>
           <description>PRIORITY Register for interrupt id 100</description>
           <addressOffset>0x190</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_101</name>
           <description>PRIORITY Register for interrupt id 101</description>
           <addressOffset>0x194</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_102</name>
           <description>PRIORITY Register for interrupt id 102</description>
           <addressOffset>0x198</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_103</name>
           <description>PRIORITY Register for interrupt id 103</description>
           <addressOffset>0x19C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_104</name>
           <description>PRIORITY Register for interrupt id 104</description>
           <addressOffset>0x1A0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_105</name>
           <description>PRIORITY Register for interrupt id 105</description>
           <addressOffset>0x1A4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_106</name>
           <description>PRIORITY Register for interrupt id 106</description>
           <addressOffset>0x1A8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_107</name>
           <description>PRIORITY Register for interrupt id 107</description>
           <addressOffset>0x1AC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_108</name>
           <description>PRIORITY Register for interrupt id 108</description>
           <addressOffset>0x1B0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_109</name>
           <description>PRIORITY Register for interrupt id 109</description>
           <addressOffset>0x1B4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_110</name>
           <description>PRIORITY Register for interrupt id 110</description>
           <addressOffset>0x1B8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_111</name>
           <description>PRIORITY Register for interrupt id 111</description>
           <addressOffset>0x1BC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_112</name>
           <description>PRIORITY Register for interrupt id 112</description>
           <addressOffset>0x1C0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_113</name>
           <description>PRIORITY Register for interrupt id 113</description>
           <addressOffset>0x1C4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_114</name>
           <description>PRIORITY Register for interrupt id 114</description>
           <addressOffset>0x1C8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_115</name>
           <description>PRIORITY Register for interrupt id 115</description>
           <addressOffset>0x1CC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_116</name>
           <description>PRIORITY Register for interrupt id 116</description>
           <addressOffset>0x1D0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_117</name>
           <description>PRIORITY Register for interrupt id 117</description>
           <addressOffset>0x1D4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_118</name>
           <description>PRIORITY Register for interrupt id 118</description>
           <addressOffset>0x1D8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_119</name>
           <description>PRIORITY Register for interrupt id 119</description>
           <addressOffset>0x1DC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_120</name>
           <description>PRIORITY Register for interrupt id 120</description>
           <addressOffset>0x1E0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_121</name>
           <description>PRIORITY Register for interrupt id 121</description>
           <addressOffset>0x1E4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_122</name>
           <description>PRIORITY Register for interrupt id 122</description>
           <addressOffset>0x1E8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_123</name>
           <description>PRIORITY Register for interrupt id 123</description>
           <addressOffset>0x1EC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_124</name>
           <description>PRIORITY Register for interrupt id 124</description>
           <addressOffset>0x1F0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_125</name>
           <description>PRIORITY Register for interrupt id 125</description>
           <addressOffset>0x1F4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_126</name>
           <description>PRIORITY Register for interrupt id 126</description>
           <addressOffset>0x1F8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_127</name>
           <description>PRIORITY Register for interrupt id 127</description>
           <addressOffset>0x1FC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_128</name>
           <description>PRIORITY Register for interrupt id 128</description>
           <addressOffset>0x200</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_129</name>
           <description>PRIORITY Register for interrupt id 129</description>
           <addressOffset>0x204</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_130</name>
           <description>PRIORITY Register for interrupt id 130</description>
           <addressOffset>0x208</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_131</name>
           <description>PRIORITY Register for interrupt id 131</description>
           <addressOffset>0x20C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_132</name>
           <description>PRIORITY Register for interrupt id 132</description>
           <addressOffset>0x210</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_133</name>
           <description>PRIORITY Register for interrupt id 133</description>
           <addressOffset>0x214</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_134</name>
           <description>PRIORITY Register for interrupt id 134</description>
           <addressOffset>0x218</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_135</name>
           <description>PRIORITY Register for interrupt id 135</description>
           <addressOffset>0x21C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_136</name>
           <description>PRIORITY Register for interrupt id 136</description>
           <addressOffset>0x220</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_0</name>
           <description>PENDING Register for interrupt ids 31 to 0</description>
           <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_1</name>
           <description>PENDING Register for interrupt ids 63 to 32</description>
           <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_2</name>
           <description>PENDING Register for interrupt ids 95 to 64</description>
           <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_3</name>
           <description>PENDING Register for interrupt ids 127 to 96</description>
           <addressOffset>0x100C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_4</name>
           <description>PENDING Register for interrupt ids 136 to 128</description>
           <addressOffset>0x1010</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_0</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 0</description>
           <addressOffset>0x2000</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_0</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 0</description>
           <addressOffset>0x2004</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_0</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 0</description>
           <addressOffset>0x2008</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_0</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 0</description>
           <addressOffset>0x200C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_0</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 0</description>
           <addressOffset>0x2010</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_1</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 1</description>
           <addressOffset>0x2080</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_1</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 1</description>
           <addressOffset>0x2084</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_1</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 1</description>
           <addressOffset>0x2088</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_1</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 1</description>
           <addressOffset>0x208C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_1</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 1</description>
           <addressOffset>0x2090</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_2</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 2</description>
           <addressOffset>0x2100</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_2</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 2</description>
           <addressOffset>0x2104</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_2</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 2</description>
           <addressOffset>0x2108</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_2</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 2</description>
           <addressOffset>0x210C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_2</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 2</description>
           <addressOffset>0x2110</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_3</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 3</description>
           <addressOffset>0x2180</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_3</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 3</description>
           <addressOffset>0x2184</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_3</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 3</description>
           <addressOffset>0x2188</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_3</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 3</description>
           <addressOffset>0x218C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_3</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 3</description>
           <addressOffset>0x2190</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_4</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 4</description>
           <addressOffset>0x2200</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_4</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 4</description>
           <addressOffset>0x2204</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_4</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 4</description>
           <addressOffset>0x2208</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_4</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 4</description>
           <addressOffset>0x220C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_4</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 4</description>
           <addressOffset>0x2210</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_0</name>
           <description>PRIORITY THRESHOLD Register for hart 0</description>
           <addressOffset>0x200000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_0</name>
           <description>CLAIM and COMPLETE Register for hart 0</description>
           <addressOffset>0x200004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_1</name>
           <description>PRIORITY THRESHOLD Register for hart 1</description>
           <addressOffset>0x201000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_1</name>
           <description>CLAIM and COMPLETE Register for hart 1</description>
           <addressOffset>0x201004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_2</name>
           <description>PRIORITY THRESHOLD Register for hart 2</description>
           <addressOffset>0x202000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_2</name>
           <description>CLAIM and COMPLETE Register for hart 2</description>
           <addressOffset>0x202004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_3</name>
           <description>PRIORITY THRESHOLD Register for hart 3</description>
           <addressOffset>0x203000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_3</name>
           <description>CLAIM and COMPLETE Register for hart 3</description>
           <addressOffset>0x203004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_4</name>
           <description>PRIORITY THRESHOLD Register for hart 4</description>
           <addressOffset>0x204000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_4</name>
           <description>CLAIM and COMPLETE Register for hart 4</description>
           <addressOffset>0x204004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
       </registers>
     </peripheral>

--- a/jh7110-vf2-12a-pac/src/plic.rs
+++ b/jh7110-vf2-12a-pac/src/plic.rs
@@ -1072,882 +1072,882 @@ impl RegisterBlock {
         &self.claimplete_4
     }
 }
-#[doc = "priority_1 (rw) register accessor: PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_1`]
+#[doc = "priority_1 (rw) register accessor: PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_1`]
 module"]
 pub type PRIORITY_1 = crate::Reg<priority_1::PRIORITY_1_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 1"]
 pub mod priority_1;
-#[doc = "priority_2 (rw) register accessor: PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_2`]
+#[doc = "priority_2 (rw) register accessor: PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_2`]
 module"]
 pub type PRIORITY_2 = crate::Reg<priority_2::PRIORITY_2_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 2"]
 pub mod priority_2;
-#[doc = "priority_3 (rw) register accessor: PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_3`]
+#[doc = "priority_3 (rw) register accessor: PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_3`]
 module"]
 pub type PRIORITY_3 = crate::Reg<priority_3::PRIORITY_3_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 3"]
 pub mod priority_3;
-#[doc = "priority_4 (rw) register accessor: PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_4`]
+#[doc = "priority_4 (rw) register accessor: PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_4`]
 module"]
 pub type PRIORITY_4 = crate::Reg<priority_4::PRIORITY_4_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 4"]
 pub mod priority_4;
-#[doc = "priority_5 (rw) register accessor: PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_5`]
+#[doc = "priority_5 (rw) register accessor: PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_5`]
 module"]
 pub type PRIORITY_5 = crate::Reg<priority_5::PRIORITY_5_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 5"]
 pub mod priority_5;
-#[doc = "priority_6 (rw) register accessor: PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_6`]
+#[doc = "priority_6 (rw) register accessor: PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_6`]
 module"]
 pub type PRIORITY_6 = crate::Reg<priority_6::PRIORITY_6_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 6"]
 pub mod priority_6;
-#[doc = "priority_7 (rw) register accessor: PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_7`]
+#[doc = "priority_7 (rw) register accessor: PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_7`]
 module"]
 pub type PRIORITY_7 = crate::Reg<priority_7::PRIORITY_7_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 7"]
 pub mod priority_7;
-#[doc = "priority_8 (rw) register accessor: PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_8`]
+#[doc = "priority_8 (rw) register accessor: PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_8`]
 module"]
 pub type PRIORITY_8 = crate::Reg<priority_8::PRIORITY_8_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 8"]
 pub mod priority_8;
-#[doc = "priority_9 (rw) register accessor: PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_9`]
+#[doc = "priority_9 (rw) register accessor: PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_9`]
 module"]
 pub type PRIORITY_9 = crate::Reg<priority_9::PRIORITY_9_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 9"]
 pub mod priority_9;
-#[doc = "priority_10 (rw) register accessor: PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_10`]
+#[doc = "priority_10 (rw) register accessor: PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_10`]
 module"]
 pub type PRIORITY_10 = crate::Reg<priority_10::PRIORITY_10_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 10"]
 pub mod priority_10;
-#[doc = "priority_11 (rw) register accessor: PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_11`]
+#[doc = "priority_11 (rw) register accessor: PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_11`]
 module"]
 pub type PRIORITY_11 = crate::Reg<priority_11::PRIORITY_11_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 11"]
 pub mod priority_11;
-#[doc = "priority_12 (rw) register accessor: PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_12`]
+#[doc = "priority_12 (rw) register accessor: PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_12`]
 module"]
 pub type PRIORITY_12 = crate::Reg<priority_12::PRIORITY_12_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 12"]
 pub mod priority_12;
-#[doc = "priority_13 (rw) register accessor: PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_13`]
+#[doc = "priority_13 (rw) register accessor: PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_13`]
 module"]
 pub type PRIORITY_13 = crate::Reg<priority_13::PRIORITY_13_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 13"]
 pub mod priority_13;
-#[doc = "priority_14 (rw) register accessor: PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_14`]
+#[doc = "priority_14 (rw) register accessor: PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_14`]
 module"]
 pub type PRIORITY_14 = crate::Reg<priority_14::PRIORITY_14_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 14"]
 pub mod priority_14;
-#[doc = "priority_15 (rw) register accessor: PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_15`]
+#[doc = "priority_15 (rw) register accessor: PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_15`]
 module"]
 pub type PRIORITY_15 = crate::Reg<priority_15::PRIORITY_15_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 15"]
 pub mod priority_15;
-#[doc = "priority_16 (rw) register accessor: PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_16`]
+#[doc = "priority_16 (rw) register accessor: PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_16`]
 module"]
 pub type PRIORITY_16 = crate::Reg<priority_16::PRIORITY_16_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 16"]
 pub mod priority_16;
-#[doc = "priority_17 (rw) register accessor: PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_17`]
+#[doc = "priority_17 (rw) register accessor: PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_17`]
 module"]
 pub type PRIORITY_17 = crate::Reg<priority_17::PRIORITY_17_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 17"]
 pub mod priority_17;
-#[doc = "priority_18 (rw) register accessor: PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_18`]
+#[doc = "priority_18 (rw) register accessor: PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_18`]
 module"]
 pub type PRIORITY_18 = crate::Reg<priority_18::PRIORITY_18_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 18"]
 pub mod priority_18;
-#[doc = "priority_19 (rw) register accessor: PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_19`]
+#[doc = "priority_19 (rw) register accessor: PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_19`]
 module"]
 pub type PRIORITY_19 = crate::Reg<priority_19::PRIORITY_19_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 19"]
 pub mod priority_19;
-#[doc = "priority_20 (rw) register accessor: PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_20`]
+#[doc = "priority_20 (rw) register accessor: PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_20`]
 module"]
 pub type PRIORITY_20 = crate::Reg<priority_20::PRIORITY_20_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 20"]
 pub mod priority_20;
-#[doc = "priority_21 (rw) register accessor: PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_21`]
+#[doc = "priority_21 (rw) register accessor: PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_21`]
 module"]
 pub type PRIORITY_21 = crate::Reg<priority_21::PRIORITY_21_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 21"]
 pub mod priority_21;
-#[doc = "priority_22 (rw) register accessor: PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_22`]
+#[doc = "priority_22 (rw) register accessor: PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_22`]
 module"]
 pub type PRIORITY_22 = crate::Reg<priority_22::PRIORITY_22_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 22"]
 pub mod priority_22;
-#[doc = "priority_23 (rw) register accessor: PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_23`]
+#[doc = "priority_23 (rw) register accessor: PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_23`]
 module"]
 pub type PRIORITY_23 = crate::Reg<priority_23::PRIORITY_23_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 23"]
 pub mod priority_23;
-#[doc = "priority_24 (rw) register accessor: PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_24`]
+#[doc = "priority_24 (rw) register accessor: PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_24`]
 module"]
 pub type PRIORITY_24 = crate::Reg<priority_24::PRIORITY_24_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 24"]
 pub mod priority_24;
-#[doc = "priority_25 (rw) register accessor: PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_25`]
+#[doc = "priority_25 (rw) register accessor: PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_25`]
 module"]
 pub type PRIORITY_25 = crate::Reg<priority_25::PRIORITY_25_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 25"]
 pub mod priority_25;
-#[doc = "priority_26 (rw) register accessor: PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_26`]
+#[doc = "priority_26 (rw) register accessor: PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_26`]
 module"]
 pub type PRIORITY_26 = crate::Reg<priority_26::PRIORITY_26_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 26"]
 pub mod priority_26;
-#[doc = "priority_27 (rw) register accessor: PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_27`]
+#[doc = "priority_27 (rw) register accessor: PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_27`]
 module"]
 pub type PRIORITY_27 = crate::Reg<priority_27::PRIORITY_27_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 27"]
 pub mod priority_27;
-#[doc = "priority_28 (rw) register accessor: PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_28`]
+#[doc = "priority_28 (rw) register accessor: PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_28`]
 module"]
 pub type PRIORITY_28 = crate::Reg<priority_28::PRIORITY_28_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 28"]
 pub mod priority_28;
-#[doc = "priority_29 (rw) register accessor: PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_29`]
+#[doc = "priority_29 (rw) register accessor: PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_29`]
 module"]
 pub type PRIORITY_29 = crate::Reg<priority_29::PRIORITY_29_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 29"]
 pub mod priority_29;
-#[doc = "priority_30 (rw) register accessor: PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_30`]
+#[doc = "priority_30 (rw) register accessor: PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_30`]
 module"]
 pub type PRIORITY_30 = crate::Reg<priority_30::PRIORITY_30_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 30"]
 pub mod priority_30;
-#[doc = "priority_31 (rw) register accessor: PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_31`]
+#[doc = "priority_31 (rw) register accessor: PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_31`]
 module"]
 pub type PRIORITY_31 = crate::Reg<priority_31::PRIORITY_31_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 31"]
 pub mod priority_31;
-#[doc = "priority_32 (rw) register accessor: PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_32`]
+#[doc = "priority_32 (rw) register accessor: PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_32`]
 module"]
 pub type PRIORITY_32 = crate::Reg<priority_32::PRIORITY_32_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 32"]
 pub mod priority_32;
-#[doc = "priority_33 (rw) register accessor: PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_33`]
+#[doc = "priority_33 (rw) register accessor: PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_33`]
 module"]
 pub type PRIORITY_33 = crate::Reg<priority_33::PRIORITY_33_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 33"]
 pub mod priority_33;
-#[doc = "priority_34 (rw) register accessor: PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_34`]
+#[doc = "priority_34 (rw) register accessor: PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_34`]
 module"]
 pub type PRIORITY_34 = crate::Reg<priority_34::PRIORITY_34_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 34"]
 pub mod priority_34;
-#[doc = "priority_35 (rw) register accessor: PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_35`]
+#[doc = "priority_35 (rw) register accessor: PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_35`]
 module"]
 pub type PRIORITY_35 = crate::Reg<priority_35::PRIORITY_35_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 35"]
 pub mod priority_35;
-#[doc = "priority_36 (rw) register accessor: PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_36`]
+#[doc = "priority_36 (rw) register accessor: PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_36`]
 module"]
 pub type PRIORITY_36 = crate::Reg<priority_36::PRIORITY_36_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 36"]
 pub mod priority_36;
-#[doc = "priority_37 (rw) register accessor: PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_37`]
+#[doc = "priority_37 (rw) register accessor: PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_37`]
 module"]
 pub type PRIORITY_37 = crate::Reg<priority_37::PRIORITY_37_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 37"]
 pub mod priority_37;
-#[doc = "priority_38 (rw) register accessor: PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_38`]
+#[doc = "priority_38 (rw) register accessor: PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_38`]
 module"]
 pub type PRIORITY_38 = crate::Reg<priority_38::PRIORITY_38_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 38"]
 pub mod priority_38;
-#[doc = "priority_39 (rw) register accessor: PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_39`]
+#[doc = "priority_39 (rw) register accessor: PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_39`]
 module"]
 pub type PRIORITY_39 = crate::Reg<priority_39::PRIORITY_39_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 39"]
 pub mod priority_39;
-#[doc = "priority_40 (rw) register accessor: PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_40`]
+#[doc = "priority_40 (rw) register accessor: PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_40`]
 module"]
 pub type PRIORITY_40 = crate::Reg<priority_40::PRIORITY_40_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 40"]
 pub mod priority_40;
-#[doc = "priority_41 (rw) register accessor: PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_41`]
+#[doc = "priority_41 (rw) register accessor: PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_41`]
 module"]
 pub type PRIORITY_41 = crate::Reg<priority_41::PRIORITY_41_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 41"]
 pub mod priority_41;
-#[doc = "priority_42 (rw) register accessor: PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_42`]
+#[doc = "priority_42 (rw) register accessor: PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_42`]
 module"]
 pub type PRIORITY_42 = crate::Reg<priority_42::PRIORITY_42_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 42"]
 pub mod priority_42;
-#[doc = "priority_43 (rw) register accessor: PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_43`]
+#[doc = "priority_43 (rw) register accessor: PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_43`]
 module"]
 pub type PRIORITY_43 = crate::Reg<priority_43::PRIORITY_43_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 43"]
 pub mod priority_43;
-#[doc = "priority_44 (rw) register accessor: PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_44`]
+#[doc = "priority_44 (rw) register accessor: PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_44`]
 module"]
 pub type PRIORITY_44 = crate::Reg<priority_44::PRIORITY_44_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 44"]
 pub mod priority_44;
-#[doc = "priority_45 (rw) register accessor: PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_45`]
+#[doc = "priority_45 (rw) register accessor: PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_45`]
 module"]
 pub type PRIORITY_45 = crate::Reg<priority_45::PRIORITY_45_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 45"]
 pub mod priority_45;
-#[doc = "priority_46 (rw) register accessor: PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_46`]
+#[doc = "priority_46 (rw) register accessor: PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_46`]
 module"]
 pub type PRIORITY_46 = crate::Reg<priority_46::PRIORITY_46_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 46"]
 pub mod priority_46;
-#[doc = "priority_47 (rw) register accessor: PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_47`]
+#[doc = "priority_47 (rw) register accessor: PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_47`]
 module"]
 pub type PRIORITY_47 = crate::Reg<priority_47::PRIORITY_47_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 47"]
 pub mod priority_47;
-#[doc = "priority_48 (rw) register accessor: PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_48`]
+#[doc = "priority_48 (rw) register accessor: PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_48`]
 module"]
 pub type PRIORITY_48 = crate::Reg<priority_48::PRIORITY_48_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 48"]
 pub mod priority_48;
-#[doc = "priority_49 (rw) register accessor: PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_49`]
+#[doc = "priority_49 (rw) register accessor: PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_49`]
 module"]
 pub type PRIORITY_49 = crate::Reg<priority_49::PRIORITY_49_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 49"]
 pub mod priority_49;
-#[doc = "priority_50 (rw) register accessor: PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_50`]
+#[doc = "priority_50 (rw) register accessor: PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_50`]
 module"]
 pub type PRIORITY_50 = crate::Reg<priority_50::PRIORITY_50_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 50"]
 pub mod priority_50;
-#[doc = "priority_51 (rw) register accessor: PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_51`]
+#[doc = "priority_51 (rw) register accessor: PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_51`]
 module"]
 pub type PRIORITY_51 = crate::Reg<priority_51::PRIORITY_51_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 51"]
 pub mod priority_51;
-#[doc = "priority_52 (rw) register accessor: PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_52`]
+#[doc = "priority_52 (rw) register accessor: PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_52`]
 module"]
 pub type PRIORITY_52 = crate::Reg<priority_52::PRIORITY_52_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 52"]
 pub mod priority_52;
-#[doc = "priority_53 (rw) register accessor: PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_53`]
+#[doc = "priority_53 (rw) register accessor: PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_53`]
 module"]
 pub type PRIORITY_53 = crate::Reg<priority_53::PRIORITY_53_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 53"]
 pub mod priority_53;
-#[doc = "priority_54 (rw) register accessor: PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_54`]
+#[doc = "priority_54 (rw) register accessor: PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_54`]
 module"]
 pub type PRIORITY_54 = crate::Reg<priority_54::PRIORITY_54_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 54"]
 pub mod priority_54;
-#[doc = "priority_55 (rw) register accessor: PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_55`]
+#[doc = "priority_55 (rw) register accessor: PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_55`]
 module"]
 pub type PRIORITY_55 = crate::Reg<priority_55::PRIORITY_55_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 55"]
 pub mod priority_55;
-#[doc = "priority_56 (rw) register accessor: PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_56`]
+#[doc = "priority_56 (rw) register accessor: PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_56`]
 module"]
 pub type PRIORITY_56 = crate::Reg<priority_56::PRIORITY_56_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 56"]
 pub mod priority_56;
-#[doc = "priority_57 (rw) register accessor: PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_57`]
+#[doc = "priority_57 (rw) register accessor: PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_57`]
 module"]
 pub type PRIORITY_57 = crate::Reg<priority_57::PRIORITY_57_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 57"]
 pub mod priority_57;
-#[doc = "priority_58 (rw) register accessor: PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_58`]
+#[doc = "priority_58 (rw) register accessor: PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_58`]
 module"]
 pub type PRIORITY_58 = crate::Reg<priority_58::PRIORITY_58_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 58"]
 pub mod priority_58;
-#[doc = "priority_59 (rw) register accessor: PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_59`]
+#[doc = "priority_59 (rw) register accessor: PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_59`]
 module"]
 pub type PRIORITY_59 = crate::Reg<priority_59::PRIORITY_59_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 59"]
 pub mod priority_59;
-#[doc = "priority_60 (rw) register accessor: PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_60`]
+#[doc = "priority_60 (rw) register accessor: PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_60`]
 module"]
 pub type PRIORITY_60 = crate::Reg<priority_60::PRIORITY_60_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 60"]
 pub mod priority_60;
-#[doc = "priority_61 (rw) register accessor: PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_61`]
+#[doc = "priority_61 (rw) register accessor: PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_61`]
 module"]
 pub type PRIORITY_61 = crate::Reg<priority_61::PRIORITY_61_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 61"]
 pub mod priority_61;
-#[doc = "priority_62 (rw) register accessor: PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_62`]
+#[doc = "priority_62 (rw) register accessor: PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_62`]
 module"]
 pub type PRIORITY_62 = crate::Reg<priority_62::PRIORITY_62_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 62"]
 pub mod priority_62;
-#[doc = "priority_63 (rw) register accessor: PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_63`]
+#[doc = "priority_63 (rw) register accessor: PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_63`]
 module"]
 pub type PRIORITY_63 = crate::Reg<priority_63::PRIORITY_63_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 63"]
 pub mod priority_63;
-#[doc = "priority_64 (rw) register accessor: PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_64`]
+#[doc = "priority_64 (rw) register accessor: PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_64`]
 module"]
 pub type PRIORITY_64 = crate::Reg<priority_64::PRIORITY_64_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 64"]
 pub mod priority_64;
-#[doc = "priority_65 (rw) register accessor: PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_65`]
+#[doc = "priority_65 (rw) register accessor: PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_65`]
 module"]
 pub type PRIORITY_65 = crate::Reg<priority_65::PRIORITY_65_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 65"]
 pub mod priority_65;
-#[doc = "priority_66 (rw) register accessor: PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_66`]
+#[doc = "priority_66 (rw) register accessor: PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_66`]
 module"]
 pub type PRIORITY_66 = crate::Reg<priority_66::PRIORITY_66_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 66"]
 pub mod priority_66;
-#[doc = "priority_67 (rw) register accessor: PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_67`]
+#[doc = "priority_67 (rw) register accessor: PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_67`]
 module"]
 pub type PRIORITY_67 = crate::Reg<priority_67::PRIORITY_67_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 67"]
 pub mod priority_67;
-#[doc = "priority_68 (rw) register accessor: PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_68`]
+#[doc = "priority_68 (rw) register accessor: PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_68`]
 module"]
 pub type PRIORITY_68 = crate::Reg<priority_68::PRIORITY_68_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 68"]
 pub mod priority_68;
-#[doc = "priority_69 (rw) register accessor: PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_69`]
+#[doc = "priority_69 (rw) register accessor: PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_69`]
 module"]
 pub type PRIORITY_69 = crate::Reg<priority_69::PRIORITY_69_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 69"]
 pub mod priority_69;
-#[doc = "priority_70 (rw) register accessor: PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_70`]
+#[doc = "priority_70 (rw) register accessor: PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_70`]
 module"]
 pub type PRIORITY_70 = crate::Reg<priority_70::PRIORITY_70_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 70"]
 pub mod priority_70;
-#[doc = "priority_71 (rw) register accessor: PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_71`]
+#[doc = "priority_71 (rw) register accessor: PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_71`]
 module"]
 pub type PRIORITY_71 = crate::Reg<priority_71::PRIORITY_71_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 71"]
 pub mod priority_71;
-#[doc = "priority_72 (rw) register accessor: PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_72`]
+#[doc = "priority_72 (rw) register accessor: PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_72`]
 module"]
 pub type PRIORITY_72 = crate::Reg<priority_72::PRIORITY_72_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 72"]
 pub mod priority_72;
-#[doc = "priority_73 (rw) register accessor: PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_73`]
+#[doc = "priority_73 (rw) register accessor: PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_73`]
 module"]
 pub type PRIORITY_73 = crate::Reg<priority_73::PRIORITY_73_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 73"]
 pub mod priority_73;
-#[doc = "priority_74 (rw) register accessor: PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_74`]
+#[doc = "priority_74 (rw) register accessor: PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_74`]
 module"]
 pub type PRIORITY_74 = crate::Reg<priority_74::PRIORITY_74_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 74"]
 pub mod priority_74;
-#[doc = "priority_75 (rw) register accessor: PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_75`]
+#[doc = "priority_75 (rw) register accessor: PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_75`]
 module"]
 pub type PRIORITY_75 = crate::Reg<priority_75::PRIORITY_75_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 75"]
 pub mod priority_75;
-#[doc = "priority_76 (rw) register accessor: PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_76`]
+#[doc = "priority_76 (rw) register accessor: PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_76`]
 module"]
 pub type PRIORITY_76 = crate::Reg<priority_76::PRIORITY_76_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 76"]
 pub mod priority_76;
-#[doc = "priority_77 (rw) register accessor: PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_77`]
+#[doc = "priority_77 (rw) register accessor: PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_77`]
 module"]
 pub type PRIORITY_77 = crate::Reg<priority_77::PRIORITY_77_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 77"]
 pub mod priority_77;
-#[doc = "priority_78 (rw) register accessor: PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_78`]
+#[doc = "priority_78 (rw) register accessor: PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_78`]
 module"]
 pub type PRIORITY_78 = crate::Reg<priority_78::PRIORITY_78_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 78"]
 pub mod priority_78;
-#[doc = "priority_79 (rw) register accessor: PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_79`]
+#[doc = "priority_79 (rw) register accessor: PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_79`]
 module"]
 pub type PRIORITY_79 = crate::Reg<priority_79::PRIORITY_79_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 79"]
 pub mod priority_79;
-#[doc = "priority_80 (rw) register accessor: PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_80`]
+#[doc = "priority_80 (rw) register accessor: PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_80`]
 module"]
 pub type PRIORITY_80 = crate::Reg<priority_80::PRIORITY_80_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 80"]
 pub mod priority_80;
-#[doc = "priority_81 (rw) register accessor: PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_81`]
+#[doc = "priority_81 (rw) register accessor: PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_81`]
 module"]
 pub type PRIORITY_81 = crate::Reg<priority_81::PRIORITY_81_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 81"]
 pub mod priority_81;
-#[doc = "priority_82 (rw) register accessor: PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_82`]
+#[doc = "priority_82 (rw) register accessor: PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_82`]
 module"]
 pub type PRIORITY_82 = crate::Reg<priority_82::PRIORITY_82_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 82"]
 pub mod priority_82;
-#[doc = "priority_83 (rw) register accessor: PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_83`]
+#[doc = "priority_83 (rw) register accessor: PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_83`]
 module"]
 pub type PRIORITY_83 = crate::Reg<priority_83::PRIORITY_83_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 83"]
 pub mod priority_83;
-#[doc = "priority_84 (rw) register accessor: PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_84`]
+#[doc = "priority_84 (rw) register accessor: PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_84`]
 module"]
 pub type PRIORITY_84 = crate::Reg<priority_84::PRIORITY_84_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 84"]
 pub mod priority_84;
-#[doc = "priority_85 (rw) register accessor: PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_85`]
+#[doc = "priority_85 (rw) register accessor: PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_85`]
 module"]
 pub type PRIORITY_85 = crate::Reg<priority_85::PRIORITY_85_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 85"]
 pub mod priority_85;
-#[doc = "priority_86 (rw) register accessor: PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_86`]
+#[doc = "priority_86 (rw) register accessor: PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_86`]
 module"]
 pub type PRIORITY_86 = crate::Reg<priority_86::PRIORITY_86_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 86"]
 pub mod priority_86;
-#[doc = "priority_87 (rw) register accessor: PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_87`]
+#[doc = "priority_87 (rw) register accessor: PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_87`]
 module"]
 pub type PRIORITY_87 = crate::Reg<priority_87::PRIORITY_87_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 87"]
 pub mod priority_87;
-#[doc = "priority_88 (rw) register accessor: PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_88`]
+#[doc = "priority_88 (rw) register accessor: PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_88`]
 module"]
 pub type PRIORITY_88 = crate::Reg<priority_88::PRIORITY_88_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 88"]
 pub mod priority_88;
-#[doc = "priority_89 (rw) register accessor: PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_89`]
+#[doc = "priority_89 (rw) register accessor: PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_89`]
 module"]
 pub type PRIORITY_89 = crate::Reg<priority_89::PRIORITY_89_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 89"]
 pub mod priority_89;
-#[doc = "priority_90 (rw) register accessor: PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_90`]
+#[doc = "priority_90 (rw) register accessor: PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_90`]
 module"]
 pub type PRIORITY_90 = crate::Reg<priority_90::PRIORITY_90_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 90"]
 pub mod priority_90;
-#[doc = "priority_91 (rw) register accessor: PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_91`]
+#[doc = "priority_91 (rw) register accessor: PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_91`]
 module"]
 pub type PRIORITY_91 = crate::Reg<priority_91::PRIORITY_91_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 91"]
 pub mod priority_91;
-#[doc = "priority_92 (rw) register accessor: PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_92`]
+#[doc = "priority_92 (rw) register accessor: PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_92`]
 module"]
 pub type PRIORITY_92 = crate::Reg<priority_92::PRIORITY_92_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 92"]
 pub mod priority_92;
-#[doc = "priority_93 (rw) register accessor: PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_93`]
+#[doc = "priority_93 (rw) register accessor: PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_93`]
 module"]
 pub type PRIORITY_93 = crate::Reg<priority_93::PRIORITY_93_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 93"]
 pub mod priority_93;
-#[doc = "priority_94 (rw) register accessor: PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_94`]
+#[doc = "priority_94 (rw) register accessor: PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_94`]
 module"]
 pub type PRIORITY_94 = crate::Reg<priority_94::PRIORITY_94_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 94"]
 pub mod priority_94;
-#[doc = "priority_95 (rw) register accessor: PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_95`]
+#[doc = "priority_95 (rw) register accessor: PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_95`]
 module"]
 pub type PRIORITY_95 = crate::Reg<priority_95::PRIORITY_95_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 95"]
 pub mod priority_95;
-#[doc = "priority_96 (rw) register accessor: PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_96`]
+#[doc = "priority_96 (rw) register accessor: PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_96`]
 module"]
 pub type PRIORITY_96 = crate::Reg<priority_96::PRIORITY_96_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 96"]
 pub mod priority_96;
-#[doc = "priority_97 (rw) register accessor: PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_97`]
+#[doc = "priority_97 (rw) register accessor: PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_97`]
 module"]
 pub type PRIORITY_97 = crate::Reg<priority_97::PRIORITY_97_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 97"]
 pub mod priority_97;
-#[doc = "priority_98 (rw) register accessor: PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_98`]
+#[doc = "priority_98 (rw) register accessor: PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_98`]
 module"]
 pub type PRIORITY_98 = crate::Reg<priority_98::PRIORITY_98_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 98"]
 pub mod priority_98;
-#[doc = "priority_99 (rw) register accessor: PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_99`]
+#[doc = "priority_99 (rw) register accessor: PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_99`]
 module"]
 pub type PRIORITY_99 = crate::Reg<priority_99::PRIORITY_99_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 99"]
 pub mod priority_99;
-#[doc = "priority_100 (rw) register accessor: PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_100`]
+#[doc = "priority_100 (rw) register accessor: PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_100`]
 module"]
 pub type PRIORITY_100 = crate::Reg<priority_100::PRIORITY_100_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 100"]
 pub mod priority_100;
-#[doc = "priority_101 (rw) register accessor: PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_101`]
+#[doc = "priority_101 (rw) register accessor: PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_101`]
 module"]
 pub type PRIORITY_101 = crate::Reg<priority_101::PRIORITY_101_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 101"]
 pub mod priority_101;
-#[doc = "priority_102 (rw) register accessor: PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_102`]
+#[doc = "priority_102 (rw) register accessor: PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_102`]
 module"]
 pub type PRIORITY_102 = crate::Reg<priority_102::PRIORITY_102_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 102"]
 pub mod priority_102;
-#[doc = "priority_103 (rw) register accessor: PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_103`]
+#[doc = "priority_103 (rw) register accessor: PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_103`]
 module"]
 pub type PRIORITY_103 = crate::Reg<priority_103::PRIORITY_103_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 103"]
 pub mod priority_103;
-#[doc = "priority_104 (rw) register accessor: PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_104`]
+#[doc = "priority_104 (rw) register accessor: PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_104`]
 module"]
 pub type PRIORITY_104 = crate::Reg<priority_104::PRIORITY_104_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 104"]
 pub mod priority_104;
-#[doc = "priority_105 (rw) register accessor: PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_105`]
+#[doc = "priority_105 (rw) register accessor: PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_105`]
 module"]
 pub type PRIORITY_105 = crate::Reg<priority_105::PRIORITY_105_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 105"]
 pub mod priority_105;
-#[doc = "priority_106 (rw) register accessor: PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_106`]
+#[doc = "priority_106 (rw) register accessor: PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_106`]
 module"]
 pub type PRIORITY_106 = crate::Reg<priority_106::PRIORITY_106_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 106"]
 pub mod priority_106;
-#[doc = "priority_107 (rw) register accessor: PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_107`]
+#[doc = "priority_107 (rw) register accessor: PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_107`]
 module"]
 pub type PRIORITY_107 = crate::Reg<priority_107::PRIORITY_107_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 107"]
 pub mod priority_107;
-#[doc = "priority_108 (rw) register accessor: PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_108`]
+#[doc = "priority_108 (rw) register accessor: PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_108`]
 module"]
 pub type PRIORITY_108 = crate::Reg<priority_108::PRIORITY_108_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 108"]
 pub mod priority_108;
-#[doc = "priority_109 (rw) register accessor: PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_109`]
+#[doc = "priority_109 (rw) register accessor: PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_109`]
 module"]
 pub type PRIORITY_109 = crate::Reg<priority_109::PRIORITY_109_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 109"]
 pub mod priority_109;
-#[doc = "priority_110 (rw) register accessor: PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_110`]
+#[doc = "priority_110 (rw) register accessor: PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_110`]
 module"]
 pub type PRIORITY_110 = crate::Reg<priority_110::PRIORITY_110_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 110"]
 pub mod priority_110;
-#[doc = "priority_111 (rw) register accessor: PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_111`]
+#[doc = "priority_111 (rw) register accessor: PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_111`]
 module"]
 pub type PRIORITY_111 = crate::Reg<priority_111::PRIORITY_111_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 111"]
 pub mod priority_111;
-#[doc = "priority_112 (rw) register accessor: PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_112`]
+#[doc = "priority_112 (rw) register accessor: PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_112`]
 module"]
 pub type PRIORITY_112 = crate::Reg<priority_112::PRIORITY_112_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 112"]
 pub mod priority_112;
-#[doc = "priority_113 (rw) register accessor: PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_113`]
+#[doc = "priority_113 (rw) register accessor: PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_113`]
 module"]
 pub type PRIORITY_113 = crate::Reg<priority_113::PRIORITY_113_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 113"]
 pub mod priority_113;
-#[doc = "priority_114 (rw) register accessor: PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_114`]
+#[doc = "priority_114 (rw) register accessor: PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_114`]
 module"]
 pub type PRIORITY_114 = crate::Reg<priority_114::PRIORITY_114_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 114"]
 pub mod priority_114;
-#[doc = "priority_115 (rw) register accessor: PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_115`]
+#[doc = "priority_115 (rw) register accessor: PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_115`]
 module"]
 pub type PRIORITY_115 = crate::Reg<priority_115::PRIORITY_115_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 115"]
 pub mod priority_115;
-#[doc = "priority_116 (rw) register accessor: PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_116`]
+#[doc = "priority_116 (rw) register accessor: PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_116`]
 module"]
 pub type PRIORITY_116 = crate::Reg<priority_116::PRIORITY_116_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 116"]
 pub mod priority_116;
-#[doc = "priority_117 (rw) register accessor: PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_117`]
+#[doc = "priority_117 (rw) register accessor: PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_117`]
 module"]
 pub type PRIORITY_117 = crate::Reg<priority_117::PRIORITY_117_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 117"]
 pub mod priority_117;
-#[doc = "priority_118 (rw) register accessor: PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_118`]
+#[doc = "priority_118 (rw) register accessor: PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_118`]
 module"]
 pub type PRIORITY_118 = crate::Reg<priority_118::PRIORITY_118_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 118"]
 pub mod priority_118;
-#[doc = "priority_119 (rw) register accessor: PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_119`]
+#[doc = "priority_119 (rw) register accessor: PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_119`]
 module"]
 pub type PRIORITY_119 = crate::Reg<priority_119::PRIORITY_119_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 119"]
 pub mod priority_119;
-#[doc = "priority_120 (rw) register accessor: PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_120`]
+#[doc = "priority_120 (rw) register accessor: PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_120`]
 module"]
 pub type PRIORITY_120 = crate::Reg<priority_120::PRIORITY_120_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 120"]
 pub mod priority_120;
-#[doc = "priority_121 (rw) register accessor: PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_121`]
+#[doc = "priority_121 (rw) register accessor: PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_121`]
 module"]
 pub type PRIORITY_121 = crate::Reg<priority_121::PRIORITY_121_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 121"]
 pub mod priority_121;
-#[doc = "priority_122 (rw) register accessor: PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_122`]
+#[doc = "priority_122 (rw) register accessor: PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_122`]
 module"]
 pub type PRIORITY_122 = crate::Reg<priority_122::PRIORITY_122_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 122"]
 pub mod priority_122;
-#[doc = "priority_123 (rw) register accessor: PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_123`]
+#[doc = "priority_123 (rw) register accessor: PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_123`]
 module"]
 pub type PRIORITY_123 = crate::Reg<priority_123::PRIORITY_123_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 123"]
 pub mod priority_123;
-#[doc = "priority_124 (rw) register accessor: PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_124`]
+#[doc = "priority_124 (rw) register accessor: PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_124`]
 module"]
 pub type PRIORITY_124 = crate::Reg<priority_124::PRIORITY_124_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 124"]
 pub mod priority_124;
-#[doc = "priority_125 (rw) register accessor: PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_125`]
+#[doc = "priority_125 (rw) register accessor: PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_125`]
 module"]
 pub type PRIORITY_125 = crate::Reg<priority_125::PRIORITY_125_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 125"]
 pub mod priority_125;
-#[doc = "priority_126 (rw) register accessor: PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_126`]
+#[doc = "priority_126 (rw) register accessor: PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_126`]
 module"]
 pub type PRIORITY_126 = crate::Reg<priority_126::PRIORITY_126_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 126"]
 pub mod priority_126;
-#[doc = "priority_127 (rw) register accessor: PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_127`]
+#[doc = "priority_127 (rw) register accessor: PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_127`]
 module"]
 pub type PRIORITY_127 = crate::Reg<priority_127::PRIORITY_127_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 127"]
 pub mod priority_127;
-#[doc = "priority_128 (rw) register accessor: PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_128`]
+#[doc = "priority_128 (rw) register accessor: PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_128`]
 module"]
 pub type PRIORITY_128 = crate::Reg<priority_128::PRIORITY_128_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 128"]
 pub mod priority_128;
-#[doc = "priority_129 (rw) register accessor: PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_129`]
+#[doc = "priority_129 (rw) register accessor: PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_129`]
 module"]
 pub type PRIORITY_129 = crate::Reg<priority_129::PRIORITY_129_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 129"]
 pub mod priority_129;
-#[doc = "priority_130 (rw) register accessor: PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_130`]
+#[doc = "priority_130 (rw) register accessor: PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_130`]
 module"]
 pub type PRIORITY_130 = crate::Reg<priority_130::PRIORITY_130_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 130"]
 pub mod priority_130;
-#[doc = "priority_131 (rw) register accessor: PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_131`]
+#[doc = "priority_131 (rw) register accessor: PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_131`]
 module"]
 pub type PRIORITY_131 = crate::Reg<priority_131::PRIORITY_131_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 131"]
 pub mod priority_131;
-#[doc = "priority_132 (rw) register accessor: PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_132`]
+#[doc = "priority_132 (rw) register accessor: PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_132`]
 module"]
 pub type PRIORITY_132 = crate::Reg<priority_132::PRIORITY_132_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 132"]
 pub mod priority_132;
-#[doc = "priority_133 (rw) register accessor: PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_133`]
+#[doc = "priority_133 (rw) register accessor: PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_133`]
 module"]
 pub type PRIORITY_133 = crate::Reg<priority_133::PRIORITY_133_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 133"]
 pub mod priority_133;
-#[doc = "priority_134 (rw) register accessor: PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_134`]
+#[doc = "priority_134 (rw) register accessor: PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_134`]
 module"]
 pub type PRIORITY_134 = crate::Reg<priority_134::PRIORITY_134_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 134"]
 pub mod priority_134;
-#[doc = "priority_135 (rw) register accessor: PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_135`]
+#[doc = "priority_135 (rw) register accessor: PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_135`]
 module"]
 pub type PRIORITY_135 = crate::Reg<priority_135::PRIORITY_135_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 135"]
 pub mod priority_135;
-#[doc = "priority_136 (rw) register accessor: PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_136`]
+#[doc = "priority_136 (rw) register accessor: PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_136`]
 module"]
 pub type PRIORITY_136 = crate::Reg<priority_136::PRIORITY_136_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 136"]
 pub mod priority_136;
-#[doc = "pending_0 (rw) register accessor: PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_0`]
+#[doc = "pending_0 (rw) register accessor: PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_0`]
 module"]
 pub type PENDING_0 = crate::Reg<pending_0::PENDING_0_SPEC>;
 #[doc = "PENDING Register for interrupt ids 31 to 0"]
 pub mod pending_0;
-#[doc = "pending_1 (rw) register accessor: PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_1`]
+#[doc = "pending_1 (rw) register accessor: PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_1`]
 module"]
 pub type PENDING_1 = crate::Reg<pending_1::PENDING_1_SPEC>;
 #[doc = "PENDING Register for interrupt ids 63 to 32"]
 pub mod pending_1;
-#[doc = "pending_2 (rw) register accessor: PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_2`]
+#[doc = "pending_2 (rw) register accessor: PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_2`]
 module"]
 pub type PENDING_2 = crate::Reg<pending_2::PENDING_2_SPEC>;
 #[doc = "PENDING Register for interrupt ids 95 to 64"]
 pub mod pending_2;
-#[doc = "pending_3 (rw) register accessor: PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_3`]
+#[doc = "pending_3 (rw) register accessor: PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_3`]
 module"]
 pub type PENDING_3 = crate::Reg<pending_3::PENDING_3_SPEC>;
 #[doc = "PENDING Register for interrupt ids 127 to 96"]
 pub mod pending_3;
-#[doc = "pending_4 (rw) register accessor: PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_4`]
+#[doc = "pending_4 (rw) register accessor: PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_4`]
 module"]
 pub type PENDING_4 = crate::Reg<pending_4::PENDING_4_SPEC>;
 #[doc = "PENDING Register for interrupt ids 136 to 128"]
 pub mod pending_4;
-#[doc = "enable_0_0 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_0`]
+#[doc = "enable_0_0 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_0`]
 module"]
 pub type ENABLE_0_0 = crate::Reg<enable_0_0::ENABLE_0_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0"]
 pub mod enable_0_0;
-#[doc = "enable_1_0 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_0`]
+#[doc = "enable_1_0 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_0`]
 module"]
 pub type ENABLE_1_0 = crate::Reg<enable_1_0::ENABLE_1_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0"]
 pub mod enable_1_0;
-#[doc = "enable_2_0 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_0`]
+#[doc = "enable_2_0 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_0`]
 module"]
 pub type ENABLE_2_0 = crate::Reg<enable_2_0::ENABLE_2_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0"]
 pub mod enable_2_0;
-#[doc = "enable_3_0 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_0`]
+#[doc = "enable_3_0 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_0`]
 module"]
 pub type ENABLE_3_0 = crate::Reg<enable_3_0::ENABLE_3_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0"]
 pub mod enable_3_0;
-#[doc = "enable_4_0 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_0`]
+#[doc = "enable_4_0 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_0`]
 module"]
 pub type ENABLE_4_0 = crate::Reg<enable_4_0::ENABLE_4_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0"]
 pub mod enable_4_0;
-#[doc = "enable_0_1 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_1`]
+#[doc = "enable_0_1 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_1`]
 module"]
 pub type ENABLE_0_1 = crate::Reg<enable_0_1::ENABLE_0_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1"]
 pub mod enable_0_1;
-#[doc = "enable_1_1 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_1`]
+#[doc = "enable_1_1 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_1`]
 module"]
 pub type ENABLE_1_1 = crate::Reg<enable_1_1::ENABLE_1_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1"]
 pub mod enable_1_1;
-#[doc = "enable_2_1 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_1`]
+#[doc = "enable_2_1 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_1`]
 module"]
 pub type ENABLE_2_1 = crate::Reg<enable_2_1::ENABLE_2_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1"]
 pub mod enable_2_1;
-#[doc = "enable_3_1 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_1`]
+#[doc = "enable_3_1 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_1`]
 module"]
 pub type ENABLE_3_1 = crate::Reg<enable_3_1::ENABLE_3_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1"]
 pub mod enable_3_1;
-#[doc = "enable_4_1 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_1`]
+#[doc = "enable_4_1 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_1`]
 module"]
 pub type ENABLE_4_1 = crate::Reg<enable_4_1::ENABLE_4_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1"]
 pub mod enable_4_1;
-#[doc = "enable_0_2 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_2`]
+#[doc = "enable_0_2 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_2`]
 module"]
 pub type ENABLE_0_2 = crate::Reg<enable_0_2::ENABLE_0_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2"]
 pub mod enable_0_2;
-#[doc = "enable_1_2 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_2`]
+#[doc = "enable_1_2 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_2`]
 module"]
 pub type ENABLE_1_2 = crate::Reg<enable_1_2::ENABLE_1_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2"]
 pub mod enable_1_2;
-#[doc = "enable_2_2 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_2`]
+#[doc = "enable_2_2 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_2`]
 module"]
 pub type ENABLE_2_2 = crate::Reg<enable_2_2::ENABLE_2_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2"]
 pub mod enable_2_2;
-#[doc = "enable_3_2 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_2`]
+#[doc = "enable_3_2 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_2`]
 module"]
 pub type ENABLE_3_2 = crate::Reg<enable_3_2::ENABLE_3_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2"]
 pub mod enable_3_2;
-#[doc = "enable_4_2 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_2`]
+#[doc = "enable_4_2 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_2`]
 module"]
 pub type ENABLE_4_2 = crate::Reg<enable_4_2::ENABLE_4_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2"]
 pub mod enable_4_2;
-#[doc = "enable_0_3 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_3`]
+#[doc = "enable_0_3 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_3`]
 module"]
 pub type ENABLE_0_3 = crate::Reg<enable_0_3::ENABLE_0_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3"]
 pub mod enable_0_3;
-#[doc = "enable_1_3 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_3`]
+#[doc = "enable_1_3 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_3`]
 module"]
 pub type ENABLE_1_3 = crate::Reg<enable_1_3::ENABLE_1_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3"]
 pub mod enable_1_3;
-#[doc = "enable_2_3 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_3`]
+#[doc = "enable_2_3 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_3`]
 module"]
 pub type ENABLE_2_3 = crate::Reg<enable_2_3::ENABLE_2_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3"]
 pub mod enable_2_3;
-#[doc = "enable_3_3 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_3`]
+#[doc = "enable_3_3 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_3`]
 module"]
 pub type ENABLE_3_3 = crate::Reg<enable_3_3::ENABLE_3_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3"]
 pub mod enable_3_3;
-#[doc = "enable_4_3 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_3`]
+#[doc = "enable_4_3 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_3`]
 module"]
 pub type ENABLE_4_3 = crate::Reg<enable_4_3::ENABLE_4_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3"]
 pub mod enable_4_3;
-#[doc = "enable_0_4 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_4`]
+#[doc = "enable_0_4 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_4`]
 module"]
 pub type ENABLE_0_4 = crate::Reg<enable_0_4::ENABLE_0_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4"]
 pub mod enable_0_4;
-#[doc = "enable_1_4 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_4`]
+#[doc = "enable_1_4 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_4`]
 module"]
 pub type ENABLE_1_4 = crate::Reg<enable_1_4::ENABLE_1_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4"]
 pub mod enable_1_4;
-#[doc = "enable_2_4 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_4`]
+#[doc = "enable_2_4 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_4`]
 module"]
 pub type ENABLE_2_4 = crate::Reg<enable_2_4::ENABLE_2_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4"]
 pub mod enable_2_4;
-#[doc = "enable_3_4 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_4`]
+#[doc = "enable_3_4 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_4`]
 module"]
 pub type ENABLE_3_4 = crate::Reg<enable_3_4::ENABLE_3_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4"]
 pub mod enable_3_4;
-#[doc = "enable_4_4 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_4`]
+#[doc = "enable_4_4 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_4`]
 module"]
 pub type ENABLE_4_4 = crate::Reg<enable_4_4::ENABLE_4_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4"]
 pub mod enable_4_4;
-#[doc = "threshold_0 (rw) register accessor: PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_0`]
+#[doc = "threshold_0 (rw) register accessor: PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_0`]
 module"]
 pub type THRESHOLD_0 = crate::Reg<threshold_0::THRESHOLD_0_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 0"]
 pub mod threshold_0;
-#[doc = "claimplete_0 (rw) register accessor: CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_0`]
+#[doc = "claimplete_0 (rw) register accessor: CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_0`]
 module"]
 pub type CLAIMPLETE_0 = crate::Reg<claimplete_0::CLAIMPLETE_0_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 0"]
 pub mod claimplete_0;
-#[doc = "threshold_1 (rw) register accessor: PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_1`]
+#[doc = "threshold_1 (rw) register accessor: PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_1`]
 module"]
 pub type THRESHOLD_1 = crate::Reg<threshold_1::THRESHOLD_1_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 1"]
 pub mod threshold_1;
-#[doc = "claimplete_1 (rw) register accessor: CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_1`]
+#[doc = "claimplete_1 (rw) register accessor: CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_1`]
 module"]
 pub type CLAIMPLETE_1 = crate::Reg<claimplete_1::CLAIMPLETE_1_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 1"]
 pub mod claimplete_1;
-#[doc = "threshold_2 (rw) register accessor: PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_2`]
+#[doc = "threshold_2 (rw) register accessor: PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_2`]
 module"]
 pub type THRESHOLD_2 = crate::Reg<threshold_2::THRESHOLD_2_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 2"]
 pub mod threshold_2;
-#[doc = "claimplete_2 (rw) register accessor: CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_2`]
+#[doc = "claimplete_2 (rw) register accessor: CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_2`]
 module"]
 pub type CLAIMPLETE_2 = crate::Reg<claimplete_2::CLAIMPLETE_2_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 2"]
 pub mod claimplete_2;
-#[doc = "threshold_3 (rw) register accessor: PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_3`]
+#[doc = "threshold_3 (rw) register accessor: PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_3`]
 module"]
 pub type THRESHOLD_3 = crate::Reg<threshold_3::THRESHOLD_3_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 3"]
 pub mod threshold_3;
-#[doc = "claimplete_3 (rw) register accessor: CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_3`]
+#[doc = "claimplete_3 (rw) register accessor: CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_3`]
 module"]
 pub type CLAIMPLETE_3 = crate::Reg<claimplete_3::CLAIMPLETE_3_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 3"]
 pub mod claimplete_3;
-#[doc = "threshold_4 (rw) register accessor: PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_4`]
+#[doc = "threshold_4 (rw) register accessor: PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_4`]
 module"]
 pub type THRESHOLD_4 = crate::Reg<threshold_4::THRESHOLD_4_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 4"]
 pub mod threshold_4;
-#[doc = "claimplete_4 (rw) register accessor: CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_4`]
+#[doc = "claimplete_4 (rw) register accessor: CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_4`]
 module"]
 pub type CLAIMPLETE_4 = crate::Reg<claimplete_4::CLAIMPLETE_4_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 4"]

--- a/jh7110-vf2-12a-pac/src/plic/claimplete_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/claimplete_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_0_SPEC>;
 #[doc = "Register `claimplete_0` writer"]
 pub type W = crate::W<CLAIMPLETE_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_0_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_0_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_0_SPEC {}
 impl crate::Writable for CLAIMPLETE_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_0 to value 0"]
+impl crate::Resettable for CLAIMPLETE_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/claimplete_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/claimplete_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_1_SPEC>;
 #[doc = "Register `claimplete_1` writer"]
 pub type W = crate::W<CLAIMPLETE_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_1_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_1_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_1_SPEC {}
 impl crate::Writable for CLAIMPLETE_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_1 to value 0"]
+impl crate::Resettable for CLAIMPLETE_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/claimplete_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/claimplete_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_2_SPEC>;
 #[doc = "Register `claimplete_2` writer"]
 pub type W = crate::W<CLAIMPLETE_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_2_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_2_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_2_SPEC {}
 impl crate::Writable for CLAIMPLETE_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_2 to value 0"]
+impl crate::Resettable for CLAIMPLETE_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/claimplete_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/claimplete_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_3_SPEC>;
 #[doc = "Register `claimplete_3` writer"]
 pub type W = crate::W<CLAIMPLETE_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_3_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_3_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_3_SPEC {}
 impl crate::Writable for CLAIMPLETE_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_3 to value 0"]
+impl crate::Resettable for CLAIMPLETE_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/claimplete_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/claimplete_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_4_SPEC>;
 #[doc = "Register `claimplete_4` writer"]
 pub type W = crate::W<CLAIMPLETE_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_4_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_4_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_4_SPEC {}
 impl crate::Writable for CLAIMPLETE_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_4 to value 0"]
+impl crate::Resettable for CLAIMPLETE_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_0_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_0_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_0_SPEC>;
 #[doc = "Register `enable_0_0` writer"]
 pub type W = crate::W<ENABLE_0_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_0_SPEC;
 impl crate::RegisterSpec for ENABLE_0_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_0_SPEC {}
 impl crate::Writable for ENABLE_0_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_0 to value 0"]
+impl crate::Resettable for ENABLE_0_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_0_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_0_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_1_SPEC>;
 #[doc = "Register `enable_0_1` writer"]
 pub type W = crate::W<ENABLE_0_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_1_SPEC;
 impl crate::RegisterSpec for ENABLE_0_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_1_SPEC {}
 impl crate::Writable for ENABLE_0_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_1 to value 0"]
+impl crate::Resettable for ENABLE_0_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_0_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_0_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_2_SPEC>;
 #[doc = "Register `enable_0_2` writer"]
 pub type W = crate::W<ENABLE_0_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_2_SPEC;
 impl crate::RegisterSpec for ENABLE_0_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_2_SPEC {}
 impl crate::Writable for ENABLE_0_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_2 to value 0"]
+impl crate::Resettable for ENABLE_0_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_0_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_0_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_3_SPEC>;
 #[doc = "Register `enable_0_3` writer"]
 pub type W = crate::W<ENABLE_0_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_3_SPEC;
 impl crate::RegisterSpec for ENABLE_0_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_3_SPEC {}
 impl crate::Writable for ENABLE_0_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_3 to value 0"]
+impl crate::Resettable for ENABLE_0_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_0_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_0_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_4_SPEC>;
 #[doc = "Register `enable_0_4` writer"]
 pub type W = crate::W<ENABLE_0_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_4_SPEC;
 impl crate::RegisterSpec for ENABLE_0_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_4_SPEC {}
 impl crate::Writable for ENABLE_0_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_4 to value 0"]
+impl crate::Resettable for ENABLE_0_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_1_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_1_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_0_SPEC>;
 #[doc = "Register `enable_1_0` writer"]
 pub type W = crate::W<ENABLE_1_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_0_SPEC;
 impl crate::RegisterSpec for ENABLE_1_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_0_SPEC {}
 impl crate::Writable for ENABLE_1_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_0 to value 0"]
+impl crate::Resettable for ENABLE_1_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_1_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_1_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_1_SPEC>;
 #[doc = "Register `enable_1_1` writer"]
 pub type W = crate::W<ENABLE_1_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_1_SPEC;
 impl crate::RegisterSpec for ENABLE_1_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_1_SPEC {}
 impl crate::Writable for ENABLE_1_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_1 to value 0"]
+impl crate::Resettable for ENABLE_1_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_1_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_1_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_2_SPEC>;
 #[doc = "Register `enable_1_2` writer"]
 pub type W = crate::W<ENABLE_1_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_2_SPEC;
 impl crate::RegisterSpec for ENABLE_1_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_2_SPEC {}
 impl crate::Writable for ENABLE_1_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_2 to value 0"]
+impl crate::Resettable for ENABLE_1_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_1_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_1_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_3_SPEC>;
 #[doc = "Register `enable_1_3` writer"]
 pub type W = crate::W<ENABLE_1_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_3_SPEC;
 impl crate::RegisterSpec for ENABLE_1_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_3_SPEC {}
 impl crate::Writable for ENABLE_1_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_3 to value 0"]
+impl crate::Resettable for ENABLE_1_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_1_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_1_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_4_SPEC>;
 #[doc = "Register `enable_1_4` writer"]
 pub type W = crate::W<ENABLE_1_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_4_SPEC;
 impl crate::RegisterSpec for ENABLE_1_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_4_SPEC {}
 impl crate::Writable for ENABLE_1_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_4 to value 0"]
+impl crate::Resettable for ENABLE_1_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_2_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_2_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_0_SPEC>;
 #[doc = "Register `enable_2_0` writer"]
 pub type W = crate::W<ENABLE_2_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_0_SPEC;
 impl crate::RegisterSpec for ENABLE_2_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_0_SPEC {}
 impl crate::Writable for ENABLE_2_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_0 to value 0"]
+impl crate::Resettable for ENABLE_2_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_2_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_2_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_1_SPEC>;
 #[doc = "Register `enable_2_1` writer"]
 pub type W = crate::W<ENABLE_2_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_1_SPEC;
 impl crate::RegisterSpec for ENABLE_2_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_1_SPEC {}
 impl crate::Writable for ENABLE_2_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_1 to value 0"]
+impl crate::Resettable for ENABLE_2_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_2_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_2_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_2_SPEC>;
 #[doc = "Register `enable_2_2` writer"]
 pub type W = crate::W<ENABLE_2_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_2_SPEC;
 impl crate::RegisterSpec for ENABLE_2_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_2_SPEC {}
 impl crate::Writable for ENABLE_2_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_2 to value 0"]
+impl crate::Resettable for ENABLE_2_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_2_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_2_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_3_SPEC>;
 #[doc = "Register `enable_2_3` writer"]
 pub type W = crate::W<ENABLE_2_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_3_SPEC;
 impl crate::RegisterSpec for ENABLE_2_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_3_SPEC {}
 impl crate::Writable for ENABLE_2_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_3 to value 0"]
+impl crate::Resettable for ENABLE_2_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_2_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_2_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_4_SPEC>;
 #[doc = "Register `enable_2_4` writer"]
 pub type W = crate::W<ENABLE_2_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_4_SPEC;
 impl crate::RegisterSpec for ENABLE_2_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_4_SPEC {}
 impl crate::Writable for ENABLE_2_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_4 to value 0"]
+impl crate::Resettable for ENABLE_2_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_3_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_3_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_0_SPEC>;
 #[doc = "Register `enable_3_0` writer"]
 pub type W = crate::W<ENABLE_3_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_0_SPEC;
 impl crate::RegisterSpec for ENABLE_3_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_0_SPEC {}
 impl crate::Writable for ENABLE_3_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_0 to value 0"]
+impl crate::Resettable for ENABLE_3_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_3_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_3_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_1_SPEC>;
 #[doc = "Register `enable_3_1` writer"]
 pub type W = crate::W<ENABLE_3_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_1_SPEC;
 impl crate::RegisterSpec for ENABLE_3_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_1_SPEC {}
 impl crate::Writable for ENABLE_3_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_1 to value 0"]
+impl crate::Resettable for ENABLE_3_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_3_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_3_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_2_SPEC>;
 #[doc = "Register `enable_3_2` writer"]
 pub type W = crate::W<ENABLE_3_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_2_SPEC;
 impl crate::RegisterSpec for ENABLE_3_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_2_SPEC {}
 impl crate::Writable for ENABLE_3_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_2 to value 0"]
+impl crate::Resettable for ENABLE_3_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_3_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_3_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_3_SPEC>;
 #[doc = "Register `enable_3_3` writer"]
 pub type W = crate::W<ENABLE_3_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_3_SPEC;
 impl crate::RegisterSpec for ENABLE_3_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_3_SPEC {}
 impl crate::Writable for ENABLE_3_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_3 to value 0"]
+impl crate::Resettable for ENABLE_3_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_3_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_3_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_4_SPEC>;
 #[doc = "Register `enable_3_4` writer"]
 pub type W = crate::W<ENABLE_3_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_4_SPEC;
 impl crate::RegisterSpec for ENABLE_3_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_4_SPEC {}
 impl crate::Writable for ENABLE_3_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_4 to value 0"]
+impl crate::Resettable for ENABLE_3_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_4_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_4_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_0_SPEC>;
 #[doc = "Register `enable_4_0` writer"]
 pub type W = crate::W<ENABLE_4_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_0_SPEC;
 impl crate::RegisterSpec for ENABLE_4_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_0_SPEC {}
 impl crate::Writable for ENABLE_4_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_0 to value 0"]
+impl crate::Resettable for ENABLE_4_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_4_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_4_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_1_SPEC>;
 #[doc = "Register `enable_4_1` writer"]
 pub type W = crate::W<ENABLE_4_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_1_SPEC;
 impl crate::RegisterSpec for ENABLE_4_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_1_SPEC {}
 impl crate::Writable for ENABLE_4_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_1 to value 0"]
+impl crate::Resettable for ENABLE_4_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_4_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_4_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_2_SPEC>;
 #[doc = "Register `enable_4_2` writer"]
 pub type W = crate::W<ENABLE_4_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_2_SPEC;
 impl crate::RegisterSpec for ENABLE_4_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_2_SPEC {}
 impl crate::Writable for ENABLE_4_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_2 to value 0"]
+impl crate::Resettable for ENABLE_4_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_4_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_4_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_3_SPEC>;
 #[doc = "Register `enable_4_3` writer"]
 pub type W = crate::W<ENABLE_4_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_3_SPEC;
 impl crate::RegisterSpec for ENABLE_4_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_3_SPEC {}
 impl crate::Writable for ENABLE_4_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_3 to value 0"]
+impl crate::Resettable for ENABLE_4_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/enable_4_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/enable_4_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_4_SPEC>;
 #[doc = "Register `enable_4_4` writer"]
 pub type W = crate::W<ENABLE_4_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_4_SPEC;
 impl crate::RegisterSpec for ENABLE_4_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_4_SPEC {}
 impl crate::Writable for ENABLE_4_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_4 to value 0"]
+impl crate::Resettable for ENABLE_4_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/pending_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/pending_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_0_SPEC>;
 #[doc = "Register `pending_0` writer"]
 pub type W = crate::W<PENDING_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_0_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_0_SPEC;
 impl crate::RegisterSpec for PENDING_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_0_SPEC {}
 impl crate::Writable for PENDING_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_0 to value 0"]
+impl crate::Resettable for PENDING_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/pending_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/pending_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_1_SPEC>;
 #[doc = "Register `pending_1` writer"]
 pub type W = crate::W<PENDING_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_1_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_1_SPEC;
 impl crate::RegisterSpec for PENDING_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_1_SPEC {}
 impl crate::Writable for PENDING_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_1 to value 0"]
+impl crate::Resettable for PENDING_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/pending_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/pending_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_2_SPEC>;
 #[doc = "Register `pending_2` writer"]
 pub type W = crate::W<PENDING_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_2_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_2_SPEC;
 impl crate::RegisterSpec for PENDING_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_2_SPEC {}
 impl crate::Writable for PENDING_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_2 to value 0"]
+impl crate::Resettable for PENDING_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/pending_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/pending_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_3_SPEC>;
 #[doc = "Register `pending_3` writer"]
 pub type W = crate::W<PENDING_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_3_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_3_SPEC;
 impl crate::RegisterSpec for PENDING_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_3_SPEC {}
 impl crate::Writable for PENDING_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_3 to value 0"]
+impl crate::Resettable for PENDING_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/pending_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/pending_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_4_SPEC>;
 #[doc = "Register `pending_4` writer"]
 pub type W = crate::W<PENDING_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_4_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_4_SPEC;
 impl crate::RegisterSpec for PENDING_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_4_SPEC {}
 impl crate::Writable for PENDING_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_4 to value 0"]
+impl crate::Resettable for PENDING_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_1_SPEC>;
 #[doc = "Register `priority_1` writer"]
 pub type W = crate::W<PRIORITY_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_1_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_1_SPEC;
 impl crate::RegisterSpec for PRIORITY_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_1_SPEC {}
 impl crate::Writable for PRIORITY_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_1 to value 0"]
+impl crate::Resettable for PRIORITY_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_10.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_10.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_10_SPEC>;
 #[doc = "Register `priority_10` writer"]
 pub type W = crate::W<PRIORITY_10_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_10_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_10_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_10_SPEC;
 impl crate::RegisterSpec for PRIORITY_10_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_10_SPEC {}
 impl crate::Writable for PRIORITY_10_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_10 to value 0"]
+impl crate::Resettable for PRIORITY_10_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_100.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_100.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_100_SPEC>;
 #[doc = "Register `priority_100` writer"]
 pub type W = crate::W<PRIORITY_100_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_100_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_100_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_100_SPEC;
 impl crate::RegisterSpec for PRIORITY_100_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_100_SPEC {}
 impl crate::Writable for PRIORITY_100_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_100 to value 0"]
+impl crate::Resettable for PRIORITY_100_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_101.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_101.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_101_SPEC>;
 #[doc = "Register `priority_101` writer"]
 pub type W = crate::W<PRIORITY_101_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_101_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_101_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_101_SPEC;
 impl crate::RegisterSpec for PRIORITY_101_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_101_SPEC {}
 impl crate::Writable for PRIORITY_101_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_101 to value 0"]
+impl crate::Resettable for PRIORITY_101_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_102.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_102.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_102_SPEC>;
 #[doc = "Register `priority_102` writer"]
 pub type W = crate::W<PRIORITY_102_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_102_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_102_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_102_SPEC;
 impl crate::RegisterSpec for PRIORITY_102_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_102_SPEC {}
 impl crate::Writable for PRIORITY_102_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_102 to value 0"]
+impl crate::Resettable for PRIORITY_102_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_103.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_103.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_103_SPEC>;
 #[doc = "Register `priority_103` writer"]
 pub type W = crate::W<PRIORITY_103_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_103_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_103_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_103_SPEC;
 impl crate::RegisterSpec for PRIORITY_103_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_103_SPEC {}
 impl crate::Writable for PRIORITY_103_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_103 to value 0"]
+impl crate::Resettable for PRIORITY_103_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_104.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_104.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_104_SPEC>;
 #[doc = "Register `priority_104` writer"]
 pub type W = crate::W<PRIORITY_104_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_104_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_104_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_104_SPEC;
 impl crate::RegisterSpec for PRIORITY_104_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_104_SPEC {}
 impl crate::Writable for PRIORITY_104_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_104 to value 0"]
+impl crate::Resettable for PRIORITY_104_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_105.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_105.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_105_SPEC>;
 #[doc = "Register `priority_105` writer"]
 pub type W = crate::W<PRIORITY_105_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_105_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_105_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_105_SPEC;
 impl crate::RegisterSpec for PRIORITY_105_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_105_SPEC {}
 impl crate::Writable for PRIORITY_105_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_105 to value 0"]
+impl crate::Resettable for PRIORITY_105_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_106.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_106.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_106_SPEC>;
 #[doc = "Register `priority_106` writer"]
 pub type W = crate::W<PRIORITY_106_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_106_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_106_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_106_SPEC;
 impl crate::RegisterSpec for PRIORITY_106_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_106_SPEC {}
 impl crate::Writable for PRIORITY_106_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_106 to value 0"]
+impl crate::Resettable for PRIORITY_106_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_107.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_107.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_107_SPEC>;
 #[doc = "Register `priority_107` writer"]
 pub type W = crate::W<PRIORITY_107_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_107_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_107_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_107_SPEC;
 impl crate::RegisterSpec for PRIORITY_107_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_107_SPEC {}
 impl crate::Writable for PRIORITY_107_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_107 to value 0"]
+impl crate::Resettable for PRIORITY_107_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_108.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_108.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_108_SPEC>;
 #[doc = "Register `priority_108` writer"]
 pub type W = crate::W<PRIORITY_108_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_108_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_108_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_108_SPEC;
 impl crate::RegisterSpec for PRIORITY_108_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_108_SPEC {}
 impl crate::Writable for PRIORITY_108_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_108 to value 0"]
+impl crate::Resettable for PRIORITY_108_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_109.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_109.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_109_SPEC>;
 #[doc = "Register `priority_109` writer"]
 pub type W = crate::W<PRIORITY_109_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_109_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_109_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_109_SPEC;
 impl crate::RegisterSpec for PRIORITY_109_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_109_SPEC {}
 impl crate::Writable for PRIORITY_109_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_109 to value 0"]
+impl crate::Resettable for PRIORITY_109_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_11.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_11.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_11_SPEC>;
 #[doc = "Register `priority_11` writer"]
 pub type W = crate::W<PRIORITY_11_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_11_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_11_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_11_SPEC;
 impl crate::RegisterSpec for PRIORITY_11_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_11_SPEC {}
 impl crate::Writable for PRIORITY_11_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_11 to value 0"]
+impl crate::Resettable for PRIORITY_11_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_110.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_110.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_110_SPEC>;
 #[doc = "Register `priority_110` writer"]
 pub type W = crate::W<PRIORITY_110_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_110_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_110_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_110_SPEC;
 impl crate::RegisterSpec for PRIORITY_110_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_110_SPEC {}
 impl crate::Writable for PRIORITY_110_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_110 to value 0"]
+impl crate::Resettable for PRIORITY_110_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_111.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_111.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_111_SPEC>;
 #[doc = "Register `priority_111` writer"]
 pub type W = crate::W<PRIORITY_111_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_111_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_111_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_111_SPEC;
 impl crate::RegisterSpec for PRIORITY_111_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_111_SPEC {}
 impl crate::Writable for PRIORITY_111_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_111 to value 0"]
+impl crate::Resettable for PRIORITY_111_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_112.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_112.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_112_SPEC>;
 #[doc = "Register `priority_112` writer"]
 pub type W = crate::W<PRIORITY_112_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_112_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_112_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_112_SPEC;
 impl crate::RegisterSpec for PRIORITY_112_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_112_SPEC {}
 impl crate::Writable for PRIORITY_112_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_112 to value 0"]
+impl crate::Resettable for PRIORITY_112_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_113.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_113.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_113_SPEC>;
 #[doc = "Register `priority_113` writer"]
 pub type W = crate::W<PRIORITY_113_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_113_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_113_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_113_SPEC;
 impl crate::RegisterSpec for PRIORITY_113_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_113_SPEC {}
 impl crate::Writable for PRIORITY_113_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_113 to value 0"]
+impl crate::Resettable for PRIORITY_113_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_114.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_114.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_114_SPEC>;
 #[doc = "Register `priority_114` writer"]
 pub type W = crate::W<PRIORITY_114_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_114_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_114_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_114_SPEC;
 impl crate::RegisterSpec for PRIORITY_114_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_114_SPEC {}
 impl crate::Writable for PRIORITY_114_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_114 to value 0"]
+impl crate::Resettable for PRIORITY_114_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_115.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_115.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_115_SPEC>;
 #[doc = "Register `priority_115` writer"]
 pub type W = crate::W<PRIORITY_115_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_115_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_115_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_115_SPEC;
 impl crate::RegisterSpec for PRIORITY_115_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_115_SPEC {}
 impl crate::Writable for PRIORITY_115_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_115 to value 0"]
+impl crate::Resettable for PRIORITY_115_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_116.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_116.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_116_SPEC>;
 #[doc = "Register `priority_116` writer"]
 pub type W = crate::W<PRIORITY_116_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_116_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_116_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_116_SPEC;
 impl crate::RegisterSpec for PRIORITY_116_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_116_SPEC {}
 impl crate::Writable for PRIORITY_116_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_116 to value 0"]
+impl crate::Resettable for PRIORITY_116_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_117.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_117.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_117_SPEC>;
 #[doc = "Register `priority_117` writer"]
 pub type W = crate::W<PRIORITY_117_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_117_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_117_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_117_SPEC;
 impl crate::RegisterSpec for PRIORITY_117_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_117_SPEC {}
 impl crate::Writable for PRIORITY_117_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_117 to value 0"]
+impl crate::Resettable for PRIORITY_117_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_118.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_118.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_118_SPEC>;
 #[doc = "Register `priority_118` writer"]
 pub type W = crate::W<PRIORITY_118_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_118_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_118_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_118_SPEC;
 impl crate::RegisterSpec for PRIORITY_118_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_118_SPEC {}
 impl crate::Writable for PRIORITY_118_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_118 to value 0"]
+impl crate::Resettable for PRIORITY_118_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_119.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_119.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_119_SPEC>;
 #[doc = "Register `priority_119` writer"]
 pub type W = crate::W<PRIORITY_119_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_119_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_119_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_119_SPEC;
 impl crate::RegisterSpec for PRIORITY_119_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_119_SPEC {}
 impl crate::Writable for PRIORITY_119_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_119 to value 0"]
+impl crate::Resettable for PRIORITY_119_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_12.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_12.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_12_SPEC>;
 #[doc = "Register `priority_12` writer"]
 pub type W = crate::W<PRIORITY_12_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_12_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_12_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_12_SPEC;
 impl crate::RegisterSpec for PRIORITY_12_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_12_SPEC {}
 impl crate::Writable for PRIORITY_12_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_12 to value 0"]
+impl crate::Resettable for PRIORITY_12_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_120.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_120.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_120_SPEC>;
 #[doc = "Register `priority_120` writer"]
 pub type W = crate::W<PRIORITY_120_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_120_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_120_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_120_SPEC;
 impl crate::RegisterSpec for PRIORITY_120_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_120_SPEC {}
 impl crate::Writable for PRIORITY_120_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_120 to value 0"]
+impl crate::Resettable for PRIORITY_120_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_121.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_121.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_121_SPEC>;
 #[doc = "Register `priority_121` writer"]
 pub type W = crate::W<PRIORITY_121_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_121_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_121_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_121_SPEC;
 impl crate::RegisterSpec for PRIORITY_121_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_121_SPEC {}
 impl crate::Writable for PRIORITY_121_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_121 to value 0"]
+impl crate::Resettable for PRIORITY_121_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_122.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_122.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_122_SPEC>;
 #[doc = "Register `priority_122` writer"]
 pub type W = crate::W<PRIORITY_122_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_122_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_122_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_122_SPEC;
 impl crate::RegisterSpec for PRIORITY_122_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_122_SPEC {}
 impl crate::Writable for PRIORITY_122_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_122 to value 0"]
+impl crate::Resettable for PRIORITY_122_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_123.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_123.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_123_SPEC>;
 #[doc = "Register `priority_123` writer"]
 pub type W = crate::W<PRIORITY_123_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_123_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_123_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_123_SPEC;
 impl crate::RegisterSpec for PRIORITY_123_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_123_SPEC {}
 impl crate::Writable for PRIORITY_123_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_123 to value 0"]
+impl crate::Resettable for PRIORITY_123_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_124.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_124.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_124_SPEC>;
 #[doc = "Register `priority_124` writer"]
 pub type W = crate::W<PRIORITY_124_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_124_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_124_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_124_SPEC;
 impl crate::RegisterSpec for PRIORITY_124_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_124_SPEC {}
 impl crate::Writable for PRIORITY_124_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_124 to value 0"]
+impl crate::Resettable for PRIORITY_124_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_125.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_125.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_125_SPEC>;
 #[doc = "Register `priority_125` writer"]
 pub type W = crate::W<PRIORITY_125_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_125_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_125_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_125_SPEC;
 impl crate::RegisterSpec for PRIORITY_125_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_125_SPEC {}
 impl crate::Writable for PRIORITY_125_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_125 to value 0"]
+impl crate::Resettable for PRIORITY_125_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_126.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_126.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_126_SPEC>;
 #[doc = "Register `priority_126` writer"]
 pub type W = crate::W<PRIORITY_126_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_126_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_126_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_126_SPEC;
 impl crate::RegisterSpec for PRIORITY_126_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_126_SPEC {}
 impl crate::Writable for PRIORITY_126_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_126 to value 0"]
+impl crate::Resettable for PRIORITY_126_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_127.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_127.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_127_SPEC>;
 #[doc = "Register `priority_127` writer"]
 pub type W = crate::W<PRIORITY_127_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_127_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_127_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_127_SPEC;
 impl crate::RegisterSpec for PRIORITY_127_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_127_SPEC {}
 impl crate::Writable for PRIORITY_127_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_127 to value 0"]
+impl crate::Resettable for PRIORITY_127_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_128.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_128.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_128_SPEC>;
 #[doc = "Register `priority_128` writer"]
 pub type W = crate::W<PRIORITY_128_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_128_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_128_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_128_SPEC;
 impl crate::RegisterSpec for PRIORITY_128_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_128_SPEC {}
 impl crate::Writable for PRIORITY_128_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_128 to value 0"]
+impl crate::Resettable for PRIORITY_128_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_129.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_129.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_129_SPEC>;
 #[doc = "Register `priority_129` writer"]
 pub type W = crate::W<PRIORITY_129_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_129_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_129_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_129_SPEC;
 impl crate::RegisterSpec for PRIORITY_129_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_129_SPEC {}
 impl crate::Writable for PRIORITY_129_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_129 to value 0"]
+impl crate::Resettable for PRIORITY_129_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_13.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_13.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_13_SPEC>;
 #[doc = "Register `priority_13` writer"]
 pub type W = crate::W<PRIORITY_13_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_13_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_13_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_13_SPEC;
 impl crate::RegisterSpec for PRIORITY_13_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_13_SPEC {}
 impl crate::Writable for PRIORITY_13_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_13 to value 0"]
+impl crate::Resettable for PRIORITY_13_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_130.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_130.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_130_SPEC>;
 #[doc = "Register `priority_130` writer"]
 pub type W = crate::W<PRIORITY_130_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_130_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_130_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_130_SPEC;
 impl crate::RegisterSpec for PRIORITY_130_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_130_SPEC {}
 impl crate::Writable for PRIORITY_130_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_130 to value 0"]
+impl crate::Resettable for PRIORITY_130_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_131.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_131.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_131_SPEC>;
 #[doc = "Register `priority_131` writer"]
 pub type W = crate::W<PRIORITY_131_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_131_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_131_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_131_SPEC;
 impl crate::RegisterSpec for PRIORITY_131_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_131_SPEC {}
 impl crate::Writable for PRIORITY_131_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_131 to value 0"]
+impl crate::Resettable for PRIORITY_131_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_132.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_132.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_132_SPEC>;
 #[doc = "Register `priority_132` writer"]
 pub type W = crate::W<PRIORITY_132_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_132_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_132_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_132_SPEC;
 impl crate::RegisterSpec for PRIORITY_132_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_132_SPEC {}
 impl crate::Writable for PRIORITY_132_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_132 to value 0"]
+impl crate::Resettable for PRIORITY_132_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_133.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_133.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_133_SPEC>;
 #[doc = "Register `priority_133` writer"]
 pub type W = crate::W<PRIORITY_133_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_133_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_133_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_133_SPEC;
 impl crate::RegisterSpec for PRIORITY_133_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_133_SPEC {}
 impl crate::Writable for PRIORITY_133_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_133 to value 0"]
+impl crate::Resettable for PRIORITY_133_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_134.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_134.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_134_SPEC>;
 #[doc = "Register `priority_134` writer"]
 pub type W = crate::W<PRIORITY_134_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_134_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_134_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_134_SPEC;
 impl crate::RegisterSpec for PRIORITY_134_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_134_SPEC {}
 impl crate::Writable for PRIORITY_134_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_134 to value 0"]
+impl crate::Resettable for PRIORITY_134_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_135.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_135.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_135_SPEC>;
 #[doc = "Register `priority_135` writer"]
 pub type W = crate::W<PRIORITY_135_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_135_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_135_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_135_SPEC;
 impl crate::RegisterSpec for PRIORITY_135_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_135_SPEC {}
 impl crate::Writable for PRIORITY_135_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_135 to value 0"]
+impl crate::Resettable for PRIORITY_135_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_136.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_136.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_136_SPEC>;
 #[doc = "Register `priority_136` writer"]
 pub type W = crate::W<PRIORITY_136_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_136_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_136_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_136_SPEC;
 impl crate::RegisterSpec for PRIORITY_136_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_136_SPEC {}
 impl crate::Writable for PRIORITY_136_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_136 to value 0"]
+impl crate::Resettable for PRIORITY_136_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_14.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_14.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_14_SPEC>;
 #[doc = "Register `priority_14` writer"]
 pub type W = crate::W<PRIORITY_14_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_14_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_14_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_14_SPEC;
 impl crate::RegisterSpec for PRIORITY_14_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_14_SPEC {}
 impl crate::Writable for PRIORITY_14_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_14 to value 0"]
+impl crate::Resettable for PRIORITY_14_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_15.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_15.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_15_SPEC>;
 #[doc = "Register `priority_15` writer"]
 pub type W = crate::W<PRIORITY_15_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_15_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_15_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_15_SPEC;
 impl crate::RegisterSpec for PRIORITY_15_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_15_SPEC {}
 impl crate::Writable for PRIORITY_15_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_15 to value 0"]
+impl crate::Resettable for PRIORITY_15_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_16.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_16.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_16_SPEC>;
 #[doc = "Register `priority_16` writer"]
 pub type W = crate::W<PRIORITY_16_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_16_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_16_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_16_SPEC;
 impl crate::RegisterSpec for PRIORITY_16_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_16_SPEC {}
 impl crate::Writable for PRIORITY_16_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_16 to value 0"]
+impl crate::Resettable for PRIORITY_16_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_17.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_17.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_17_SPEC>;
 #[doc = "Register `priority_17` writer"]
 pub type W = crate::W<PRIORITY_17_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_17_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_17_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_17_SPEC;
 impl crate::RegisterSpec for PRIORITY_17_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_17_SPEC {}
 impl crate::Writable for PRIORITY_17_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_17 to value 0"]
+impl crate::Resettable for PRIORITY_17_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_18.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_18.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_18_SPEC>;
 #[doc = "Register `priority_18` writer"]
 pub type W = crate::W<PRIORITY_18_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_18_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_18_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_18_SPEC;
 impl crate::RegisterSpec for PRIORITY_18_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_18_SPEC {}
 impl crate::Writable for PRIORITY_18_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_18 to value 0"]
+impl crate::Resettable for PRIORITY_18_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_19.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_19.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_19_SPEC>;
 #[doc = "Register `priority_19` writer"]
 pub type W = crate::W<PRIORITY_19_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_19_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_19_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_19_SPEC;
 impl crate::RegisterSpec for PRIORITY_19_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_19_SPEC {}
 impl crate::Writable for PRIORITY_19_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_19 to value 0"]
+impl crate::Resettable for PRIORITY_19_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_2_SPEC>;
 #[doc = "Register `priority_2` writer"]
 pub type W = crate::W<PRIORITY_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_2_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_2_SPEC;
 impl crate::RegisterSpec for PRIORITY_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_2_SPEC {}
 impl crate::Writable for PRIORITY_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_2 to value 0"]
+impl crate::Resettable for PRIORITY_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_20.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_20.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_20_SPEC>;
 #[doc = "Register `priority_20` writer"]
 pub type W = crate::W<PRIORITY_20_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_20_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_20_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_20_SPEC;
 impl crate::RegisterSpec for PRIORITY_20_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_20_SPEC {}
 impl crate::Writable for PRIORITY_20_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_20 to value 0"]
+impl crate::Resettable for PRIORITY_20_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_21.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_21.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_21_SPEC>;
 #[doc = "Register `priority_21` writer"]
 pub type W = crate::W<PRIORITY_21_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_21_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_21_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_21_SPEC;
 impl crate::RegisterSpec for PRIORITY_21_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_21_SPEC {}
 impl crate::Writable for PRIORITY_21_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_21 to value 0"]
+impl crate::Resettable for PRIORITY_21_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_22.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_22.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_22_SPEC>;
 #[doc = "Register `priority_22` writer"]
 pub type W = crate::W<PRIORITY_22_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_22_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_22_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_22_SPEC;
 impl crate::RegisterSpec for PRIORITY_22_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_22_SPEC {}
 impl crate::Writable for PRIORITY_22_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_22 to value 0"]
+impl crate::Resettable for PRIORITY_22_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_23.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_23.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_23_SPEC>;
 #[doc = "Register `priority_23` writer"]
 pub type W = crate::W<PRIORITY_23_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_23_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_23_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_23_SPEC;
 impl crate::RegisterSpec for PRIORITY_23_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_23_SPEC {}
 impl crate::Writable for PRIORITY_23_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_23 to value 0"]
+impl crate::Resettable for PRIORITY_23_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_24.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_24.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_24_SPEC>;
 #[doc = "Register `priority_24` writer"]
 pub type W = crate::W<PRIORITY_24_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_24_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_24_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_24_SPEC;
 impl crate::RegisterSpec for PRIORITY_24_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_24_SPEC {}
 impl crate::Writable for PRIORITY_24_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_24 to value 0"]
+impl crate::Resettable for PRIORITY_24_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_25.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_25.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_25_SPEC>;
 #[doc = "Register `priority_25` writer"]
 pub type W = crate::W<PRIORITY_25_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_25_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_25_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_25_SPEC;
 impl crate::RegisterSpec for PRIORITY_25_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_25_SPEC {}
 impl crate::Writable for PRIORITY_25_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_25 to value 0"]
+impl crate::Resettable for PRIORITY_25_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_26.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_26.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_26_SPEC>;
 #[doc = "Register `priority_26` writer"]
 pub type W = crate::W<PRIORITY_26_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_26_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_26_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_26_SPEC;
 impl crate::RegisterSpec for PRIORITY_26_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_26_SPEC {}
 impl crate::Writable for PRIORITY_26_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_26 to value 0"]
+impl crate::Resettable for PRIORITY_26_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_27.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_27.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_27_SPEC>;
 #[doc = "Register `priority_27` writer"]
 pub type W = crate::W<PRIORITY_27_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_27_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_27_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_27_SPEC;
 impl crate::RegisterSpec for PRIORITY_27_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_27_SPEC {}
 impl crate::Writable for PRIORITY_27_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_27 to value 0"]
+impl crate::Resettable for PRIORITY_27_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_28.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_28.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_28_SPEC>;
 #[doc = "Register `priority_28` writer"]
 pub type W = crate::W<PRIORITY_28_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_28_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_28_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_28_SPEC;
 impl crate::RegisterSpec for PRIORITY_28_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_28_SPEC {}
 impl crate::Writable for PRIORITY_28_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_28 to value 0"]
+impl crate::Resettable for PRIORITY_28_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_29.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_29.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_29_SPEC>;
 #[doc = "Register `priority_29` writer"]
 pub type W = crate::W<PRIORITY_29_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_29_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_29_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_29_SPEC;
 impl crate::RegisterSpec for PRIORITY_29_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_29_SPEC {}
 impl crate::Writable for PRIORITY_29_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_29 to value 0"]
+impl crate::Resettable for PRIORITY_29_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_3_SPEC>;
 #[doc = "Register `priority_3` writer"]
 pub type W = crate::W<PRIORITY_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_3_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_3_SPEC;
 impl crate::RegisterSpec for PRIORITY_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_3_SPEC {}
 impl crate::Writable for PRIORITY_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_3 to value 0"]
+impl crate::Resettable for PRIORITY_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_30.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_30.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_30_SPEC>;
 #[doc = "Register `priority_30` writer"]
 pub type W = crate::W<PRIORITY_30_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_30_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_30_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_30_SPEC;
 impl crate::RegisterSpec for PRIORITY_30_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_30_SPEC {}
 impl crate::Writable for PRIORITY_30_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_30 to value 0"]
+impl crate::Resettable for PRIORITY_30_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_31.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_31.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_31_SPEC>;
 #[doc = "Register `priority_31` writer"]
 pub type W = crate::W<PRIORITY_31_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_31_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_31_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_31_SPEC;
 impl crate::RegisterSpec for PRIORITY_31_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_31_SPEC {}
 impl crate::Writable for PRIORITY_31_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_31 to value 0"]
+impl crate::Resettable for PRIORITY_31_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_32.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_32.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_32_SPEC>;
 #[doc = "Register `priority_32` writer"]
 pub type W = crate::W<PRIORITY_32_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_32_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_32_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_32_SPEC;
 impl crate::RegisterSpec for PRIORITY_32_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_32_SPEC {}
 impl crate::Writable for PRIORITY_32_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_32 to value 0"]
+impl crate::Resettable for PRIORITY_32_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_33.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_33.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_33_SPEC>;
 #[doc = "Register `priority_33` writer"]
 pub type W = crate::W<PRIORITY_33_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_33_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_33_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_33_SPEC;
 impl crate::RegisterSpec for PRIORITY_33_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_33_SPEC {}
 impl crate::Writable for PRIORITY_33_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_33 to value 0"]
+impl crate::Resettable for PRIORITY_33_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_34.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_34.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_34_SPEC>;
 #[doc = "Register `priority_34` writer"]
 pub type W = crate::W<PRIORITY_34_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_34_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_34_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_34_SPEC;
 impl crate::RegisterSpec for PRIORITY_34_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_34_SPEC {}
 impl crate::Writable for PRIORITY_34_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_34 to value 0"]
+impl crate::Resettable for PRIORITY_34_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_35.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_35.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_35_SPEC>;
 #[doc = "Register `priority_35` writer"]
 pub type W = crate::W<PRIORITY_35_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_35_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_35_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_35_SPEC;
 impl crate::RegisterSpec for PRIORITY_35_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_35_SPEC {}
 impl crate::Writable for PRIORITY_35_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_35 to value 0"]
+impl crate::Resettable for PRIORITY_35_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_36.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_36.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_36_SPEC>;
 #[doc = "Register `priority_36` writer"]
 pub type W = crate::W<PRIORITY_36_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_36_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_36_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_36_SPEC;
 impl crate::RegisterSpec for PRIORITY_36_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_36_SPEC {}
 impl crate::Writable for PRIORITY_36_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_36 to value 0"]
+impl crate::Resettable for PRIORITY_36_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_37.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_37.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_37_SPEC>;
 #[doc = "Register `priority_37` writer"]
 pub type W = crate::W<PRIORITY_37_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_37_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_37_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_37_SPEC;
 impl crate::RegisterSpec for PRIORITY_37_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_37_SPEC {}
 impl crate::Writable for PRIORITY_37_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_37 to value 0"]
+impl crate::Resettable for PRIORITY_37_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_38.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_38.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_38_SPEC>;
 #[doc = "Register `priority_38` writer"]
 pub type W = crate::W<PRIORITY_38_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_38_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_38_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_38_SPEC;
 impl crate::RegisterSpec for PRIORITY_38_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_38_SPEC {}
 impl crate::Writable for PRIORITY_38_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_38 to value 0"]
+impl crate::Resettable for PRIORITY_38_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_39.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_39.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_39_SPEC>;
 #[doc = "Register `priority_39` writer"]
 pub type W = crate::W<PRIORITY_39_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_39_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_39_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_39_SPEC;
 impl crate::RegisterSpec for PRIORITY_39_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_39_SPEC {}
 impl crate::Writable for PRIORITY_39_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_39 to value 0"]
+impl crate::Resettable for PRIORITY_39_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_4_SPEC>;
 #[doc = "Register `priority_4` writer"]
 pub type W = crate::W<PRIORITY_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_4_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_4_SPEC;
 impl crate::RegisterSpec for PRIORITY_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_4_SPEC {}
 impl crate::Writable for PRIORITY_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_4 to value 0"]
+impl crate::Resettable for PRIORITY_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_40.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_40.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_40_SPEC>;
 #[doc = "Register `priority_40` writer"]
 pub type W = crate::W<PRIORITY_40_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_40_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_40_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_40_SPEC;
 impl crate::RegisterSpec for PRIORITY_40_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_40_SPEC {}
 impl crate::Writable for PRIORITY_40_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_40 to value 0"]
+impl crate::Resettable for PRIORITY_40_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_41.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_41.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_41_SPEC>;
 #[doc = "Register `priority_41` writer"]
 pub type W = crate::W<PRIORITY_41_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_41_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_41_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_41_SPEC;
 impl crate::RegisterSpec for PRIORITY_41_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_41_SPEC {}
 impl crate::Writable for PRIORITY_41_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_41 to value 0"]
+impl crate::Resettable for PRIORITY_41_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_42.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_42.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_42_SPEC>;
 #[doc = "Register `priority_42` writer"]
 pub type W = crate::W<PRIORITY_42_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_42_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_42_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_42_SPEC;
 impl crate::RegisterSpec for PRIORITY_42_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_42_SPEC {}
 impl crate::Writable for PRIORITY_42_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_42 to value 0"]
+impl crate::Resettable for PRIORITY_42_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_43.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_43.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_43_SPEC>;
 #[doc = "Register `priority_43` writer"]
 pub type W = crate::W<PRIORITY_43_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_43_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_43_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_43_SPEC;
 impl crate::RegisterSpec for PRIORITY_43_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_43_SPEC {}
 impl crate::Writable for PRIORITY_43_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_43 to value 0"]
+impl crate::Resettable for PRIORITY_43_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_44.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_44.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_44_SPEC>;
 #[doc = "Register `priority_44` writer"]
 pub type W = crate::W<PRIORITY_44_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_44_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_44_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_44_SPEC;
 impl crate::RegisterSpec for PRIORITY_44_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_44_SPEC {}
 impl crate::Writable for PRIORITY_44_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_44 to value 0"]
+impl crate::Resettable for PRIORITY_44_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_45.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_45.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_45_SPEC>;
 #[doc = "Register `priority_45` writer"]
 pub type W = crate::W<PRIORITY_45_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_45_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_45_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_45_SPEC;
 impl crate::RegisterSpec for PRIORITY_45_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_45_SPEC {}
 impl crate::Writable for PRIORITY_45_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_45 to value 0"]
+impl crate::Resettable for PRIORITY_45_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_46.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_46.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_46_SPEC>;
 #[doc = "Register `priority_46` writer"]
 pub type W = crate::W<PRIORITY_46_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_46_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_46_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_46_SPEC;
 impl crate::RegisterSpec for PRIORITY_46_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_46_SPEC {}
 impl crate::Writable for PRIORITY_46_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_46 to value 0"]
+impl crate::Resettable for PRIORITY_46_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_47.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_47.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_47_SPEC>;
 #[doc = "Register `priority_47` writer"]
 pub type W = crate::W<PRIORITY_47_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_47_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_47_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_47_SPEC;
 impl crate::RegisterSpec for PRIORITY_47_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_47_SPEC {}
 impl crate::Writable for PRIORITY_47_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_47 to value 0"]
+impl crate::Resettable for PRIORITY_47_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_48.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_48.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_48_SPEC>;
 #[doc = "Register `priority_48` writer"]
 pub type W = crate::W<PRIORITY_48_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_48_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_48_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_48_SPEC;
 impl crate::RegisterSpec for PRIORITY_48_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_48_SPEC {}
 impl crate::Writable for PRIORITY_48_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_48 to value 0"]
+impl crate::Resettable for PRIORITY_48_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_49.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_49.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_49_SPEC>;
 #[doc = "Register `priority_49` writer"]
 pub type W = crate::W<PRIORITY_49_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_49_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_49_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_49_SPEC;
 impl crate::RegisterSpec for PRIORITY_49_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_49_SPEC {}
 impl crate::Writable for PRIORITY_49_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_49 to value 0"]
+impl crate::Resettable for PRIORITY_49_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_5.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_5.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_5_SPEC>;
 #[doc = "Register `priority_5` writer"]
 pub type W = crate::W<PRIORITY_5_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_5_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_5_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_5_SPEC;
 impl crate::RegisterSpec for PRIORITY_5_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_5_SPEC {}
 impl crate::Writable for PRIORITY_5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_5 to value 0"]
+impl crate::Resettable for PRIORITY_5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_50.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_50.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_50_SPEC>;
 #[doc = "Register `priority_50` writer"]
 pub type W = crate::W<PRIORITY_50_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_50_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_50_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_50_SPEC;
 impl crate::RegisterSpec for PRIORITY_50_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_50_SPEC {}
 impl crate::Writable for PRIORITY_50_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_50 to value 0"]
+impl crate::Resettable for PRIORITY_50_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_51.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_51.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_51_SPEC>;
 #[doc = "Register `priority_51` writer"]
 pub type W = crate::W<PRIORITY_51_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_51_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_51_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_51_SPEC;
 impl crate::RegisterSpec for PRIORITY_51_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_51_SPEC {}
 impl crate::Writable for PRIORITY_51_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_51 to value 0"]
+impl crate::Resettable for PRIORITY_51_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_52.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_52.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_52_SPEC>;
 #[doc = "Register `priority_52` writer"]
 pub type W = crate::W<PRIORITY_52_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_52_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_52_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_52_SPEC;
 impl crate::RegisterSpec for PRIORITY_52_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_52_SPEC {}
 impl crate::Writable for PRIORITY_52_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_52 to value 0"]
+impl crate::Resettable for PRIORITY_52_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_53.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_53.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_53_SPEC>;
 #[doc = "Register `priority_53` writer"]
 pub type W = crate::W<PRIORITY_53_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_53_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_53_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_53_SPEC;
 impl crate::RegisterSpec for PRIORITY_53_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_53_SPEC {}
 impl crate::Writable for PRIORITY_53_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_53 to value 0"]
+impl crate::Resettable for PRIORITY_53_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_54.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_54.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_54_SPEC>;
 #[doc = "Register `priority_54` writer"]
 pub type W = crate::W<PRIORITY_54_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_54_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_54_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_54_SPEC;
 impl crate::RegisterSpec for PRIORITY_54_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_54_SPEC {}
 impl crate::Writable for PRIORITY_54_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_54 to value 0"]
+impl crate::Resettable for PRIORITY_54_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_55.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_55.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_55_SPEC>;
 #[doc = "Register `priority_55` writer"]
 pub type W = crate::W<PRIORITY_55_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_55_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_55_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_55_SPEC;
 impl crate::RegisterSpec for PRIORITY_55_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_55_SPEC {}
 impl crate::Writable for PRIORITY_55_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_55 to value 0"]
+impl crate::Resettable for PRIORITY_55_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_56.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_56.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_56_SPEC>;
 #[doc = "Register `priority_56` writer"]
 pub type W = crate::W<PRIORITY_56_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_56_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_56_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_56_SPEC;
 impl crate::RegisterSpec for PRIORITY_56_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_56_SPEC {}
 impl crate::Writable for PRIORITY_56_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_56 to value 0"]
+impl crate::Resettable for PRIORITY_56_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_57.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_57.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_57_SPEC>;
 #[doc = "Register `priority_57` writer"]
 pub type W = crate::W<PRIORITY_57_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_57_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_57_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_57_SPEC;
 impl crate::RegisterSpec for PRIORITY_57_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_57_SPEC {}
 impl crate::Writable for PRIORITY_57_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_57 to value 0"]
+impl crate::Resettable for PRIORITY_57_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_58.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_58.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_58_SPEC>;
 #[doc = "Register `priority_58` writer"]
 pub type W = crate::W<PRIORITY_58_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_58_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_58_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_58_SPEC;
 impl crate::RegisterSpec for PRIORITY_58_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_58_SPEC {}
 impl crate::Writable for PRIORITY_58_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_58 to value 0"]
+impl crate::Resettable for PRIORITY_58_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_59.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_59.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_59_SPEC>;
 #[doc = "Register `priority_59` writer"]
 pub type W = crate::W<PRIORITY_59_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_59_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_59_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_59_SPEC;
 impl crate::RegisterSpec for PRIORITY_59_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_59_SPEC {}
 impl crate::Writable for PRIORITY_59_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_59 to value 0"]
+impl crate::Resettable for PRIORITY_59_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_6.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_6.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_6_SPEC>;
 #[doc = "Register `priority_6` writer"]
 pub type W = crate::W<PRIORITY_6_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_6_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_6_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_6_SPEC;
 impl crate::RegisterSpec for PRIORITY_6_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_6_SPEC {}
 impl crate::Writable for PRIORITY_6_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_6 to value 0"]
+impl crate::Resettable for PRIORITY_6_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_60.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_60.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_60_SPEC>;
 #[doc = "Register `priority_60` writer"]
 pub type W = crate::W<PRIORITY_60_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_60_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_60_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_60_SPEC;
 impl crate::RegisterSpec for PRIORITY_60_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_60_SPEC {}
 impl crate::Writable for PRIORITY_60_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_60 to value 0"]
+impl crate::Resettable for PRIORITY_60_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_61.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_61.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_61_SPEC>;
 #[doc = "Register `priority_61` writer"]
 pub type W = crate::W<PRIORITY_61_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_61_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_61_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_61_SPEC;
 impl crate::RegisterSpec for PRIORITY_61_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_61_SPEC {}
 impl crate::Writable for PRIORITY_61_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_61 to value 0"]
+impl crate::Resettable for PRIORITY_61_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_62.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_62.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_62_SPEC>;
 #[doc = "Register `priority_62` writer"]
 pub type W = crate::W<PRIORITY_62_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_62_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_62_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_62_SPEC;
 impl crate::RegisterSpec for PRIORITY_62_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_62_SPEC {}
 impl crate::Writable for PRIORITY_62_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_62 to value 0"]
+impl crate::Resettable for PRIORITY_62_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_63.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_63.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_63_SPEC>;
 #[doc = "Register `priority_63` writer"]
 pub type W = crate::W<PRIORITY_63_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_63_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_63_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_63_SPEC;
 impl crate::RegisterSpec for PRIORITY_63_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_63_SPEC {}
 impl crate::Writable for PRIORITY_63_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_63 to value 0"]
+impl crate::Resettable for PRIORITY_63_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_64.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_64.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_64_SPEC>;
 #[doc = "Register `priority_64` writer"]
 pub type W = crate::W<PRIORITY_64_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_64_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_64_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_64_SPEC;
 impl crate::RegisterSpec for PRIORITY_64_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_64_SPEC {}
 impl crate::Writable for PRIORITY_64_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_64 to value 0"]
+impl crate::Resettable for PRIORITY_64_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_65.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_65.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_65_SPEC>;
 #[doc = "Register `priority_65` writer"]
 pub type W = crate::W<PRIORITY_65_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_65_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_65_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_65_SPEC;
 impl crate::RegisterSpec for PRIORITY_65_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_65_SPEC {}
 impl crate::Writable for PRIORITY_65_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_65 to value 0"]
+impl crate::Resettable for PRIORITY_65_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_66.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_66.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_66_SPEC>;
 #[doc = "Register `priority_66` writer"]
 pub type W = crate::W<PRIORITY_66_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_66_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_66_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_66_SPEC;
 impl crate::RegisterSpec for PRIORITY_66_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_66_SPEC {}
 impl crate::Writable for PRIORITY_66_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_66 to value 0"]
+impl crate::Resettable for PRIORITY_66_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_67.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_67.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_67_SPEC>;
 #[doc = "Register `priority_67` writer"]
 pub type W = crate::W<PRIORITY_67_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_67_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_67_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_67_SPEC;
 impl crate::RegisterSpec for PRIORITY_67_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_67_SPEC {}
 impl crate::Writable for PRIORITY_67_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_67 to value 0"]
+impl crate::Resettable for PRIORITY_67_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_68.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_68.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_68_SPEC>;
 #[doc = "Register `priority_68` writer"]
 pub type W = crate::W<PRIORITY_68_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_68_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_68_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_68_SPEC;
 impl crate::RegisterSpec for PRIORITY_68_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_68_SPEC {}
 impl crate::Writable for PRIORITY_68_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_68 to value 0"]
+impl crate::Resettable for PRIORITY_68_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_69.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_69.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_69_SPEC>;
 #[doc = "Register `priority_69` writer"]
 pub type W = crate::W<PRIORITY_69_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_69_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_69_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_69_SPEC;
 impl crate::RegisterSpec for PRIORITY_69_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_69_SPEC {}
 impl crate::Writable for PRIORITY_69_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_69 to value 0"]
+impl crate::Resettable for PRIORITY_69_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_7.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_7.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_7_SPEC>;
 #[doc = "Register `priority_7` writer"]
 pub type W = crate::W<PRIORITY_7_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_7_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_7_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_7_SPEC;
 impl crate::RegisterSpec for PRIORITY_7_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_7_SPEC {}
 impl crate::Writable for PRIORITY_7_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_7 to value 0"]
+impl crate::Resettable for PRIORITY_7_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_70.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_70.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_70_SPEC>;
 #[doc = "Register `priority_70` writer"]
 pub type W = crate::W<PRIORITY_70_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_70_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_70_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_70_SPEC;
 impl crate::RegisterSpec for PRIORITY_70_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_70_SPEC {}
 impl crate::Writable for PRIORITY_70_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_70 to value 0"]
+impl crate::Resettable for PRIORITY_70_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_71.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_71.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_71_SPEC>;
 #[doc = "Register `priority_71` writer"]
 pub type W = crate::W<PRIORITY_71_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_71_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_71_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_71_SPEC;
 impl crate::RegisterSpec for PRIORITY_71_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_71_SPEC {}
 impl crate::Writable for PRIORITY_71_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_71 to value 0"]
+impl crate::Resettable for PRIORITY_71_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_72.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_72.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_72_SPEC>;
 #[doc = "Register `priority_72` writer"]
 pub type W = crate::W<PRIORITY_72_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_72_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_72_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_72_SPEC;
 impl crate::RegisterSpec for PRIORITY_72_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_72_SPEC {}
 impl crate::Writable for PRIORITY_72_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_72 to value 0"]
+impl crate::Resettable for PRIORITY_72_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_73.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_73.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_73_SPEC>;
 #[doc = "Register `priority_73` writer"]
 pub type W = crate::W<PRIORITY_73_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_73_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_73_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_73_SPEC;
 impl crate::RegisterSpec for PRIORITY_73_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_73_SPEC {}
 impl crate::Writable for PRIORITY_73_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_73 to value 0"]
+impl crate::Resettable for PRIORITY_73_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_74.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_74.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_74_SPEC>;
 #[doc = "Register `priority_74` writer"]
 pub type W = crate::W<PRIORITY_74_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_74_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_74_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_74_SPEC;
 impl crate::RegisterSpec for PRIORITY_74_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_74_SPEC {}
 impl crate::Writable for PRIORITY_74_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_74 to value 0"]
+impl crate::Resettable for PRIORITY_74_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_75.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_75.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_75_SPEC>;
 #[doc = "Register `priority_75` writer"]
 pub type W = crate::W<PRIORITY_75_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_75_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_75_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_75_SPEC;
 impl crate::RegisterSpec for PRIORITY_75_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_75_SPEC {}
 impl crate::Writable for PRIORITY_75_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_75 to value 0"]
+impl crate::Resettable for PRIORITY_75_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_76.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_76.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_76_SPEC>;
 #[doc = "Register `priority_76` writer"]
 pub type W = crate::W<PRIORITY_76_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_76_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_76_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_76_SPEC;
 impl crate::RegisterSpec for PRIORITY_76_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_76_SPEC {}
 impl crate::Writable for PRIORITY_76_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_76 to value 0"]
+impl crate::Resettable for PRIORITY_76_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_77.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_77.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_77_SPEC>;
 #[doc = "Register `priority_77` writer"]
 pub type W = crate::W<PRIORITY_77_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_77_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_77_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_77_SPEC;
 impl crate::RegisterSpec for PRIORITY_77_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_77_SPEC {}
 impl crate::Writable for PRIORITY_77_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_77 to value 0"]
+impl crate::Resettable for PRIORITY_77_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_78.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_78.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_78_SPEC>;
 #[doc = "Register `priority_78` writer"]
 pub type W = crate::W<PRIORITY_78_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_78_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_78_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_78_SPEC;
 impl crate::RegisterSpec for PRIORITY_78_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_78_SPEC {}
 impl crate::Writable for PRIORITY_78_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_78 to value 0"]
+impl crate::Resettable for PRIORITY_78_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_79.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_79.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_79_SPEC>;
 #[doc = "Register `priority_79` writer"]
 pub type W = crate::W<PRIORITY_79_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_79_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_79_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_79_SPEC;
 impl crate::RegisterSpec for PRIORITY_79_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_79_SPEC {}
 impl crate::Writable for PRIORITY_79_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_79 to value 0"]
+impl crate::Resettable for PRIORITY_79_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_8.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_8.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_8_SPEC>;
 #[doc = "Register `priority_8` writer"]
 pub type W = crate::W<PRIORITY_8_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_8_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_8_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_8_SPEC;
 impl crate::RegisterSpec for PRIORITY_8_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_8_SPEC {}
 impl crate::Writable for PRIORITY_8_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_8 to value 0"]
+impl crate::Resettable for PRIORITY_8_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_80.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_80.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_80_SPEC>;
 #[doc = "Register `priority_80` writer"]
 pub type W = crate::W<PRIORITY_80_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_80_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_80_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_80_SPEC;
 impl crate::RegisterSpec for PRIORITY_80_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_80_SPEC {}
 impl crate::Writable for PRIORITY_80_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_80 to value 0"]
+impl crate::Resettable for PRIORITY_80_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_81.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_81.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_81_SPEC>;
 #[doc = "Register `priority_81` writer"]
 pub type W = crate::W<PRIORITY_81_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_81_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_81_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_81_SPEC;
 impl crate::RegisterSpec for PRIORITY_81_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_81_SPEC {}
 impl crate::Writable for PRIORITY_81_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_81 to value 0"]
+impl crate::Resettable for PRIORITY_81_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_82.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_82.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_82_SPEC>;
 #[doc = "Register `priority_82` writer"]
 pub type W = crate::W<PRIORITY_82_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_82_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_82_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_82_SPEC;
 impl crate::RegisterSpec for PRIORITY_82_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_82_SPEC {}
 impl crate::Writable for PRIORITY_82_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_82 to value 0"]
+impl crate::Resettable for PRIORITY_82_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_83.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_83.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_83_SPEC>;
 #[doc = "Register `priority_83` writer"]
 pub type W = crate::W<PRIORITY_83_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_83_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_83_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_83_SPEC;
 impl crate::RegisterSpec for PRIORITY_83_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_83_SPEC {}
 impl crate::Writable for PRIORITY_83_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_83 to value 0"]
+impl crate::Resettable for PRIORITY_83_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_84.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_84.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_84_SPEC>;
 #[doc = "Register `priority_84` writer"]
 pub type W = crate::W<PRIORITY_84_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_84_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_84_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_84_SPEC;
 impl crate::RegisterSpec for PRIORITY_84_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_84_SPEC {}
 impl crate::Writable for PRIORITY_84_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_84 to value 0"]
+impl crate::Resettable for PRIORITY_84_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_85.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_85.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_85_SPEC>;
 #[doc = "Register `priority_85` writer"]
 pub type W = crate::W<PRIORITY_85_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_85_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_85_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_85_SPEC;
 impl crate::RegisterSpec for PRIORITY_85_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_85_SPEC {}
 impl crate::Writable for PRIORITY_85_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_85 to value 0"]
+impl crate::Resettable for PRIORITY_85_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_86.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_86.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_86_SPEC>;
 #[doc = "Register `priority_86` writer"]
 pub type W = crate::W<PRIORITY_86_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_86_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_86_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_86_SPEC;
 impl crate::RegisterSpec for PRIORITY_86_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_86_SPEC {}
 impl crate::Writable for PRIORITY_86_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_86 to value 0"]
+impl crate::Resettable for PRIORITY_86_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_87.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_87.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_87_SPEC>;
 #[doc = "Register `priority_87` writer"]
 pub type W = crate::W<PRIORITY_87_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_87_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_87_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_87_SPEC;
 impl crate::RegisterSpec for PRIORITY_87_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_87_SPEC {}
 impl crate::Writable for PRIORITY_87_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_87 to value 0"]
+impl crate::Resettable for PRIORITY_87_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_88.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_88.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_88_SPEC>;
 #[doc = "Register `priority_88` writer"]
 pub type W = crate::W<PRIORITY_88_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_88_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_88_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_88_SPEC;
 impl crate::RegisterSpec for PRIORITY_88_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_88_SPEC {}
 impl crate::Writable for PRIORITY_88_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_88 to value 0"]
+impl crate::Resettable for PRIORITY_88_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_89.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_89.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_89_SPEC>;
 #[doc = "Register `priority_89` writer"]
 pub type W = crate::W<PRIORITY_89_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_89_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_89_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_89_SPEC;
 impl crate::RegisterSpec for PRIORITY_89_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_89_SPEC {}
 impl crate::Writable for PRIORITY_89_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_89 to value 0"]
+impl crate::Resettable for PRIORITY_89_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_9.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_9.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_9_SPEC>;
 #[doc = "Register `priority_9` writer"]
 pub type W = crate::W<PRIORITY_9_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_9_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_9_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_9_SPEC;
 impl crate::RegisterSpec for PRIORITY_9_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_9_SPEC {}
 impl crate::Writable for PRIORITY_9_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_9 to value 0"]
+impl crate::Resettable for PRIORITY_9_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_90.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_90.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_90_SPEC>;
 #[doc = "Register `priority_90` writer"]
 pub type W = crate::W<PRIORITY_90_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_90_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_90_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_90_SPEC;
 impl crate::RegisterSpec for PRIORITY_90_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_90_SPEC {}
 impl crate::Writable for PRIORITY_90_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_90 to value 0"]
+impl crate::Resettable for PRIORITY_90_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_91.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_91.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_91_SPEC>;
 #[doc = "Register `priority_91` writer"]
 pub type W = crate::W<PRIORITY_91_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_91_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_91_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_91_SPEC;
 impl crate::RegisterSpec for PRIORITY_91_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_91_SPEC {}
 impl crate::Writable for PRIORITY_91_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_91 to value 0"]
+impl crate::Resettable for PRIORITY_91_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_92.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_92.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_92_SPEC>;
 #[doc = "Register `priority_92` writer"]
 pub type W = crate::W<PRIORITY_92_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_92_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_92_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_92_SPEC;
 impl crate::RegisterSpec for PRIORITY_92_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_92_SPEC {}
 impl crate::Writable for PRIORITY_92_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_92 to value 0"]
+impl crate::Resettable for PRIORITY_92_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_93.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_93.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_93_SPEC>;
 #[doc = "Register `priority_93` writer"]
 pub type W = crate::W<PRIORITY_93_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_93_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_93_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_93_SPEC;
 impl crate::RegisterSpec for PRIORITY_93_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_93_SPEC {}
 impl crate::Writable for PRIORITY_93_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_93 to value 0"]
+impl crate::Resettable for PRIORITY_93_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_94.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_94.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_94_SPEC>;
 #[doc = "Register `priority_94` writer"]
 pub type W = crate::W<PRIORITY_94_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_94_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_94_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_94_SPEC;
 impl crate::RegisterSpec for PRIORITY_94_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_94_SPEC {}
 impl crate::Writable for PRIORITY_94_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_94 to value 0"]
+impl crate::Resettable for PRIORITY_94_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_95.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_95.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_95_SPEC>;
 #[doc = "Register `priority_95` writer"]
 pub type W = crate::W<PRIORITY_95_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_95_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_95_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_95_SPEC;
 impl crate::RegisterSpec for PRIORITY_95_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_95_SPEC {}
 impl crate::Writable for PRIORITY_95_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_95 to value 0"]
+impl crate::Resettable for PRIORITY_95_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_96.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_96.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_96_SPEC>;
 #[doc = "Register `priority_96` writer"]
 pub type W = crate::W<PRIORITY_96_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_96_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_96_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_96_SPEC;
 impl crate::RegisterSpec for PRIORITY_96_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_96_SPEC {}
 impl crate::Writable for PRIORITY_96_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_96 to value 0"]
+impl crate::Resettable for PRIORITY_96_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_97.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_97.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_97_SPEC>;
 #[doc = "Register `priority_97` writer"]
 pub type W = crate::W<PRIORITY_97_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_97_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_97_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_97_SPEC;
 impl crate::RegisterSpec for PRIORITY_97_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_97_SPEC {}
 impl crate::Writable for PRIORITY_97_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_97 to value 0"]
+impl crate::Resettable for PRIORITY_97_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_98.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_98.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_98_SPEC>;
 #[doc = "Register `priority_98` writer"]
 pub type W = crate::W<PRIORITY_98_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_98_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_98_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_98_SPEC;
 impl crate::RegisterSpec for PRIORITY_98_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_98_SPEC {}
 impl crate::Writable for PRIORITY_98_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_98 to value 0"]
+impl crate::Resettable for PRIORITY_98_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/priority_99.rs
+++ b/jh7110-vf2-12a-pac/src/plic/priority_99.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_99_SPEC>;
 #[doc = "Register `priority_99` writer"]
 pub type W = crate::W<PRIORITY_99_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_99_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_99_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_99_SPEC;
 impl crate::RegisterSpec for PRIORITY_99_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_99_SPEC {}
 impl crate::Writable for PRIORITY_99_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_99 to value 0"]
+impl crate::Resettable for PRIORITY_99_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/threshold_0.rs
+++ b/jh7110-vf2-12a-pac/src/plic/threshold_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_0_SPEC>;
 #[doc = "Register `threshold_0` writer"]
 pub type W = crate::W<THRESHOLD_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_0_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_0_SPEC;
 impl crate::RegisterSpec for THRESHOLD_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_0_SPEC {}
 impl crate::Writable for THRESHOLD_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_0 to value 0"]
+impl crate::Resettable for THRESHOLD_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/threshold_1.rs
+++ b/jh7110-vf2-12a-pac/src/plic/threshold_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_1_SPEC>;
 #[doc = "Register `threshold_1` writer"]
 pub type W = crate::W<THRESHOLD_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_1_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_1_SPEC;
 impl crate::RegisterSpec for THRESHOLD_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_1_SPEC {}
 impl crate::Writable for THRESHOLD_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_1 to value 0"]
+impl crate::Resettable for THRESHOLD_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/threshold_2.rs
+++ b/jh7110-vf2-12a-pac/src/plic/threshold_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_2_SPEC>;
 #[doc = "Register `threshold_2` writer"]
 pub type W = crate::W<THRESHOLD_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_2_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_2_SPEC;
 impl crate::RegisterSpec for THRESHOLD_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_2_SPEC {}
 impl crate::Writable for THRESHOLD_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_2 to value 0"]
+impl crate::Resettable for THRESHOLD_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/threshold_3.rs
+++ b/jh7110-vf2-12a-pac/src/plic/threshold_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_3_SPEC>;
 #[doc = "Register `threshold_3` writer"]
 pub type W = crate::W<THRESHOLD_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_3_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_3_SPEC;
 impl crate::RegisterSpec for THRESHOLD_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_3_SPEC {}
 impl crate::Writable for THRESHOLD_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_3 to value 0"]
+impl crate::Resettable for THRESHOLD_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/plic/threshold_4.rs
+++ b/jh7110-vf2-12a-pac/src/plic/threshold_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_4_SPEC>;
 #[doc = "Register `threshold_4` writer"]
 pub type W = crate::W<THRESHOLD_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_4_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_4_SPEC;
 impl crate::RegisterSpec for THRESHOLD_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_4_SPEC {}
 impl crate::Writable for THRESHOLD_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_4 to value 0"]
+impl crate::Resettable for THRESHOLD_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -125,881 +125,2616 @@
           <name>priority_1</name>
           <description>PRIORITY Register for interrupt id 1</description>
           <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_2</name>
           <description>PRIORITY Register for interrupt id 2</description>
           <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_3</name>
           <description>PRIORITY Register for interrupt id 3</description>
           <addressOffset>0xC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_4</name>
           <description>PRIORITY Register for interrupt id 4</description>
           <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_5</name>
           <description>PRIORITY Register for interrupt id 5</description>
           <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_6</name>
           <description>PRIORITY Register for interrupt id 6</description>
           <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_7</name>
           <description>PRIORITY Register for interrupt id 7</description>
           <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_8</name>
           <description>PRIORITY Register for interrupt id 8</description>
           <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_9</name>
           <description>PRIORITY Register for interrupt id 9</description>
           <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_10</name>
           <description>PRIORITY Register for interrupt id 10</description>
           <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_11</name>
           <description>PRIORITY Register for interrupt id 11</description>
           <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_12</name>
           <description>PRIORITY Register for interrupt id 12</description>
           <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_13</name>
           <description>PRIORITY Register for interrupt id 13</description>
           <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_14</name>
           <description>PRIORITY Register for interrupt id 14</description>
           <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_15</name>
           <description>PRIORITY Register for interrupt id 15</description>
           <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_16</name>
           <description>PRIORITY Register for interrupt id 16</description>
           <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_17</name>
           <description>PRIORITY Register for interrupt id 17</description>
           <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_18</name>
           <description>PRIORITY Register for interrupt id 18</description>
           <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_19</name>
           <description>PRIORITY Register for interrupt id 19</description>
           <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_20</name>
           <description>PRIORITY Register for interrupt id 20</description>
           <addressOffset>0x50</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_21</name>
           <description>PRIORITY Register for interrupt id 21</description>
           <addressOffset>0x54</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_22</name>
           <description>PRIORITY Register for interrupt id 22</description>
           <addressOffset>0x58</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_23</name>
           <description>PRIORITY Register for interrupt id 23</description>
           <addressOffset>0x5C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_24</name>
           <description>PRIORITY Register for interrupt id 24</description>
           <addressOffset>0x60</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_25</name>
           <description>PRIORITY Register for interrupt id 25</description>
           <addressOffset>0x64</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_26</name>
           <description>PRIORITY Register for interrupt id 26</description>
           <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_27</name>
           <description>PRIORITY Register for interrupt id 27</description>
           <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_28</name>
           <description>PRIORITY Register for interrupt id 28</description>
           <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_29</name>
           <description>PRIORITY Register for interrupt id 29</description>
           <addressOffset>0x74</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_30</name>
           <description>PRIORITY Register for interrupt id 30</description>
           <addressOffset>0x78</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_31</name>
           <description>PRIORITY Register for interrupt id 31</description>
           <addressOffset>0x7C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_32</name>
           <description>PRIORITY Register for interrupt id 32</description>
           <addressOffset>0x80</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_33</name>
           <description>PRIORITY Register for interrupt id 33</description>
           <addressOffset>0x84</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_34</name>
           <description>PRIORITY Register for interrupt id 34</description>
           <addressOffset>0x88</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_35</name>
           <description>PRIORITY Register for interrupt id 35</description>
           <addressOffset>0x8C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_36</name>
           <description>PRIORITY Register for interrupt id 36</description>
           <addressOffset>0x90</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_37</name>
           <description>PRIORITY Register for interrupt id 37</description>
           <addressOffset>0x94</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_38</name>
           <description>PRIORITY Register for interrupt id 38</description>
           <addressOffset>0x98</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_39</name>
           <description>PRIORITY Register for interrupt id 39</description>
           <addressOffset>0x9C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_40</name>
           <description>PRIORITY Register for interrupt id 40</description>
           <addressOffset>0xA0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_41</name>
           <description>PRIORITY Register for interrupt id 41</description>
           <addressOffset>0xA4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_42</name>
           <description>PRIORITY Register for interrupt id 42</description>
           <addressOffset>0xA8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_43</name>
           <description>PRIORITY Register for interrupt id 43</description>
           <addressOffset>0xAC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_44</name>
           <description>PRIORITY Register for interrupt id 44</description>
           <addressOffset>0xB0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_45</name>
           <description>PRIORITY Register for interrupt id 45</description>
           <addressOffset>0xB4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_46</name>
           <description>PRIORITY Register for interrupt id 46</description>
           <addressOffset>0xB8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_47</name>
           <description>PRIORITY Register for interrupt id 47</description>
           <addressOffset>0xBC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_48</name>
           <description>PRIORITY Register for interrupt id 48</description>
           <addressOffset>0xC0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_49</name>
           <description>PRIORITY Register for interrupt id 49</description>
           <addressOffset>0xC4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_50</name>
           <description>PRIORITY Register for interrupt id 50</description>
           <addressOffset>0xC8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_51</name>
           <description>PRIORITY Register for interrupt id 51</description>
           <addressOffset>0xCC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_52</name>
           <description>PRIORITY Register for interrupt id 52</description>
           <addressOffset>0xD0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_53</name>
           <description>PRIORITY Register for interrupt id 53</description>
           <addressOffset>0xD4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_54</name>
           <description>PRIORITY Register for interrupt id 54</description>
           <addressOffset>0xD8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_55</name>
           <description>PRIORITY Register for interrupt id 55</description>
           <addressOffset>0xDC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_56</name>
           <description>PRIORITY Register for interrupt id 56</description>
           <addressOffset>0xE0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_57</name>
           <description>PRIORITY Register for interrupt id 57</description>
           <addressOffset>0xE4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_58</name>
           <description>PRIORITY Register for interrupt id 58</description>
           <addressOffset>0xE8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_59</name>
           <description>PRIORITY Register for interrupt id 59</description>
           <addressOffset>0xEC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_60</name>
           <description>PRIORITY Register for interrupt id 60</description>
           <addressOffset>0xF0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_61</name>
           <description>PRIORITY Register for interrupt id 61</description>
           <addressOffset>0xF4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_62</name>
           <description>PRIORITY Register for interrupt id 62</description>
           <addressOffset>0xF8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_63</name>
           <description>PRIORITY Register for interrupt id 63</description>
           <addressOffset>0xFC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_64</name>
           <description>PRIORITY Register for interrupt id 64</description>
           <addressOffset>0x100</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_65</name>
           <description>PRIORITY Register for interrupt id 65</description>
           <addressOffset>0x104</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_66</name>
           <description>PRIORITY Register for interrupt id 66</description>
           <addressOffset>0x108</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_67</name>
           <description>PRIORITY Register for interrupt id 67</description>
           <addressOffset>0x10C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_68</name>
           <description>PRIORITY Register for interrupt id 68</description>
           <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_69</name>
           <description>PRIORITY Register for interrupt id 69</description>
           <addressOffset>0x114</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_70</name>
           <description>PRIORITY Register for interrupt id 70</description>
           <addressOffset>0x118</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_71</name>
           <description>PRIORITY Register for interrupt id 71</description>
           <addressOffset>0x11C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_72</name>
           <description>PRIORITY Register for interrupt id 72</description>
           <addressOffset>0x120</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_73</name>
           <description>PRIORITY Register for interrupt id 73</description>
           <addressOffset>0x124</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_74</name>
           <description>PRIORITY Register for interrupt id 74</description>
           <addressOffset>0x128</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_75</name>
           <description>PRIORITY Register for interrupt id 75</description>
           <addressOffset>0x12C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_76</name>
           <description>PRIORITY Register for interrupt id 76</description>
           <addressOffset>0x130</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_77</name>
           <description>PRIORITY Register for interrupt id 77</description>
           <addressOffset>0x134</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_78</name>
           <description>PRIORITY Register for interrupt id 78</description>
           <addressOffset>0x138</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_79</name>
           <description>PRIORITY Register for interrupt id 79</description>
           <addressOffset>0x13C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_80</name>
           <description>PRIORITY Register for interrupt id 80</description>
           <addressOffset>0x140</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_81</name>
           <description>PRIORITY Register for interrupt id 81</description>
           <addressOffset>0x144</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_82</name>
           <description>PRIORITY Register for interrupt id 82</description>
           <addressOffset>0x148</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_83</name>
           <description>PRIORITY Register for interrupt id 83</description>
           <addressOffset>0x14C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_84</name>
           <description>PRIORITY Register for interrupt id 84</description>
           <addressOffset>0x150</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_85</name>
           <description>PRIORITY Register for interrupt id 85</description>
           <addressOffset>0x154</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_86</name>
           <description>PRIORITY Register for interrupt id 86</description>
           <addressOffset>0x158</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_87</name>
           <description>PRIORITY Register for interrupt id 87</description>
           <addressOffset>0x15C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_88</name>
           <description>PRIORITY Register for interrupt id 88</description>
           <addressOffset>0x160</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_89</name>
           <description>PRIORITY Register for interrupt id 89</description>
           <addressOffset>0x164</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_90</name>
           <description>PRIORITY Register for interrupt id 90</description>
           <addressOffset>0x168</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_91</name>
           <description>PRIORITY Register for interrupt id 91</description>
           <addressOffset>0x16C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_92</name>
           <description>PRIORITY Register for interrupt id 92</description>
           <addressOffset>0x170</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_93</name>
           <description>PRIORITY Register for interrupt id 93</description>
           <addressOffset>0x174</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_94</name>
           <description>PRIORITY Register for interrupt id 94</description>
           <addressOffset>0x178</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_95</name>
           <description>PRIORITY Register for interrupt id 95</description>
           <addressOffset>0x17C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_96</name>
           <description>PRIORITY Register for interrupt id 96</description>
           <addressOffset>0x180</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_97</name>
           <description>PRIORITY Register for interrupt id 97</description>
           <addressOffset>0x184</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_98</name>
           <description>PRIORITY Register for interrupt id 98</description>
           <addressOffset>0x188</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_99</name>
           <description>PRIORITY Register for interrupt id 99</description>
           <addressOffset>0x18C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_100</name>
           <description>PRIORITY Register for interrupt id 100</description>
           <addressOffset>0x190</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_101</name>
           <description>PRIORITY Register for interrupt id 101</description>
           <addressOffset>0x194</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_102</name>
           <description>PRIORITY Register for interrupt id 102</description>
           <addressOffset>0x198</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_103</name>
           <description>PRIORITY Register for interrupt id 103</description>
           <addressOffset>0x19C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_104</name>
           <description>PRIORITY Register for interrupt id 104</description>
           <addressOffset>0x1A0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_105</name>
           <description>PRIORITY Register for interrupt id 105</description>
           <addressOffset>0x1A4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_106</name>
           <description>PRIORITY Register for interrupt id 106</description>
           <addressOffset>0x1A8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_107</name>
           <description>PRIORITY Register for interrupt id 107</description>
           <addressOffset>0x1AC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_108</name>
           <description>PRIORITY Register for interrupt id 108</description>
           <addressOffset>0x1B0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_109</name>
           <description>PRIORITY Register for interrupt id 109</description>
           <addressOffset>0x1B4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_110</name>
           <description>PRIORITY Register for interrupt id 110</description>
           <addressOffset>0x1B8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_111</name>
           <description>PRIORITY Register for interrupt id 111</description>
           <addressOffset>0x1BC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_112</name>
           <description>PRIORITY Register for interrupt id 112</description>
           <addressOffset>0x1C0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_113</name>
           <description>PRIORITY Register for interrupt id 113</description>
           <addressOffset>0x1C4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_114</name>
           <description>PRIORITY Register for interrupt id 114</description>
           <addressOffset>0x1C8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_115</name>
           <description>PRIORITY Register for interrupt id 115</description>
           <addressOffset>0x1CC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_116</name>
           <description>PRIORITY Register for interrupt id 116</description>
           <addressOffset>0x1D0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_117</name>
           <description>PRIORITY Register for interrupt id 117</description>
           <addressOffset>0x1D4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_118</name>
           <description>PRIORITY Register for interrupt id 118</description>
           <addressOffset>0x1D8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_119</name>
           <description>PRIORITY Register for interrupt id 119</description>
           <addressOffset>0x1DC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_120</name>
           <description>PRIORITY Register for interrupt id 120</description>
           <addressOffset>0x1E0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_121</name>
           <description>PRIORITY Register for interrupt id 121</description>
           <addressOffset>0x1E4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_122</name>
           <description>PRIORITY Register for interrupt id 122</description>
           <addressOffset>0x1E8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_123</name>
           <description>PRIORITY Register for interrupt id 123</description>
           <addressOffset>0x1EC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_124</name>
           <description>PRIORITY Register for interrupt id 124</description>
           <addressOffset>0x1F0</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_125</name>
           <description>PRIORITY Register for interrupt id 125</description>
           <addressOffset>0x1F4</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_126</name>
           <description>PRIORITY Register for interrupt id 126</description>
           <addressOffset>0x1F8</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_127</name>
           <description>PRIORITY Register for interrupt id 127</description>
           <addressOffset>0x1FC</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_128</name>
           <description>PRIORITY Register for interrupt id 128</description>
           <addressOffset>0x200</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_129</name>
           <description>PRIORITY Register for interrupt id 129</description>
           <addressOffset>0x204</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_130</name>
           <description>PRIORITY Register for interrupt id 130</description>
           <addressOffset>0x208</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_131</name>
           <description>PRIORITY Register for interrupt id 131</description>
           <addressOffset>0x20C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_132</name>
           <description>PRIORITY Register for interrupt id 132</description>
           <addressOffset>0x210</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_133</name>
           <description>PRIORITY Register for interrupt id 133</description>
           <addressOffset>0x214</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_134</name>
           <description>PRIORITY Register for interrupt id 134</description>
           <addressOffset>0x218</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_135</name>
           <description>PRIORITY Register for interrupt id 135</description>
           <addressOffset>0x21C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>priority_136</name>
           <description>PRIORITY Register for interrupt id 136</description>
           <addressOffset>0x220</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_0</name>
           <description>PENDING Register for interrupt ids 31 to 0</description>
           <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_1</name>
           <description>PENDING Register for interrupt ids 63 to 32</description>
           <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_2</name>
           <description>PENDING Register for interrupt ids 95 to 64</description>
           <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_3</name>
           <description>PENDING Register for interrupt ids 127 to 96</description>
           <addressOffset>0x100C</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>pending_4</name>
           <description>PENDING Register for interrupt ids 136 to 128</description>
           <addressOffset>0x1010</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>pending</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_0</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 0</description>
           <addressOffset>0x2000</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_0</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 0</description>
           <addressOffset>0x2004</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_0</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 0</description>
           <addressOffset>0x2008</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_0</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 0</description>
           <addressOffset>0x200C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_0</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 0</description>
           <addressOffset>0x2010</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_1</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 1</description>
           <addressOffset>0x2080</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_1</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 1</description>
           <addressOffset>0x2084</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_1</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 1</description>
           <addressOffset>0x2088</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_1</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 1</description>
           <addressOffset>0x208C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_1</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 1</description>
           <addressOffset>0x2090</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_2</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 2</description>
           <addressOffset>0x2100</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_2</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 2</description>
           <addressOffset>0x2104</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_2</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 2</description>
           <addressOffset>0x2108</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_2</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 2</description>
           <addressOffset>0x210C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_2</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 2</description>
           <addressOffset>0x2110</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_3</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 3</description>
           <addressOffset>0x2180</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_3</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 3</description>
           <addressOffset>0x2184</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_3</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 3</description>
           <addressOffset>0x2188</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_3</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 3</description>
           <addressOffset>0x218C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_3</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 3</description>
           <addressOffset>0x2190</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_0_4</name>
           <description>ENABLE Register for interrupt ids 31 to 0 for hart 4</description>
           <addressOffset>0x2200</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_1_4</name>
           <description>ENABLE Register for interrupt ids 63 to 32 for hart 4</description>
           <addressOffset>0x2204</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_2_4</name>
           <description>ENABLE Register for interrupt ids 95 to 64 for hart 4</description>
           <addressOffset>0x2208</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_3_4</name>
           <description>ENABLE Register for interrupt ids 127 to 96 for hart 4</description>
           <addressOffset>0x220C</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>enable_4_4</name>
           <description>ENABLE Register for interrupt ids 136 to 128 for hart 4</description>
           <addressOffset>0x2210</addressOffset>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>enable</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_0</name>
           <description>PRIORITY THRESHOLD Register for hart 0</description>
           <addressOffset>0x200000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_0</name>
           <description>CLAIM and COMPLETE Register for hart 0</description>
           <addressOffset>0x200004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_1</name>
           <description>PRIORITY THRESHOLD Register for hart 1</description>
           <addressOffset>0x201000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_1</name>
           <description>CLAIM and COMPLETE Register for hart 1</description>
           <addressOffset>0x201004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_2</name>
           <description>PRIORITY THRESHOLD Register for hart 2</description>
           <addressOffset>0x202000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_2</name>
           <description>CLAIM and COMPLETE Register for hart 2</description>
           <addressOffset>0x202004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_3</name>
           <description>PRIORITY THRESHOLD Register for hart 3</description>
           <addressOffset>0x203000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_3</name>
           <description>CLAIM and COMPLETE Register for hart 3</description>
           <addressOffset>0x203004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>threshold_4</name>
           <description>PRIORITY THRESHOLD Register for hart 4</description>
           <addressOffset>0x204000</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>priority</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>claimplete_4</name>
           <description>CLAIM and COMPLETE Register for hart 4</description>
           <addressOffset>0x204004</addressOffset>
+          <size>32</size>
+          <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>claimplete</name>
+              <description></description>
+              <bitRange>[31:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
       </registers>
     </peripheral>

--- a/jh7110-vf2-13b-pac/src/plic.rs
+++ b/jh7110-vf2-13b-pac/src/plic.rs
@@ -1072,882 +1072,882 @@ impl RegisterBlock {
         &self.claimplete_4
     }
 }
-#[doc = "priority_1 (rw) register accessor: PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_1`]
+#[doc = "priority_1 (rw) register accessor: PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_1`]
 module"]
 pub type PRIORITY_1 = crate::Reg<priority_1::PRIORITY_1_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 1"]
 pub mod priority_1;
-#[doc = "priority_2 (rw) register accessor: PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_2`]
+#[doc = "priority_2 (rw) register accessor: PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_2`]
 module"]
 pub type PRIORITY_2 = crate::Reg<priority_2::PRIORITY_2_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 2"]
 pub mod priority_2;
-#[doc = "priority_3 (rw) register accessor: PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_3`]
+#[doc = "priority_3 (rw) register accessor: PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_3`]
 module"]
 pub type PRIORITY_3 = crate::Reg<priority_3::PRIORITY_3_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 3"]
 pub mod priority_3;
-#[doc = "priority_4 (rw) register accessor: PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_4`]
+#[doc = "priority_4 (rw) register accessor: PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_4`]
 module"]
 pub type PRIORITY_4 = crate::Reg<priority_4::PRIORITY_4_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 4"]
 pub mod priority_4;
-#[doc = "priority_5 (rw) register accessor: PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_5`]
+#[doc = "priority_5 (rw) register accessor: PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_5`]
 module"]
 pub type PRIORITY_5 = crate::Reg<priority_5::PRIORITY_5_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 5"]
 pub mod priority_5;
-#[doc = "priority_6 (rw) register accessor: PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_6`]
+#[doc = "priority_6 (rw) register accessor: PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_6`]
 module"]
 pub type PRIORITY_6 = crate::Reg<priority_6::PRIORITY_6_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 6"]
 pub mod priority_6;
-#[doc = "priority_7 (rw) register accessor: PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_7`]
+#[doc = "priority_7 (rw) register accessor: PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_7`]
 module"]
 pub type PRIORITY_7 = crate::Reg<priority_7::PRIORITY_7_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 7"]
 pub mod priority_7;
-#[doc = "priority_8 (rw) register accessor: PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_8`]
+#[doc = "priority_8 (rw) register accessor: PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_8`]
 module"]
 pub type PRIORITY_8 = crate::Reg<priority_8::PRIORITY_8_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 8"]
 pub mod priority_8;
-#[doc = "priority_9 (rw) register accessor: PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_9`]
+#[doc = "priority_9 (rw) register accessor: PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_9`]
 module"]
 pub type PRIORITY_9 = crate::Reg<priority_9::PRIORITY_9_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 9"]
 pub mod priority_9;
-#[doc = "priority_10 (rw) register accessor: PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_10`]
+#[doc = "priority_10 (rw) register accessor: PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_10`]
 module"]
 pub type PRIORITY_10 = crate::Reg<priority_10::PRIORITY_10_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 10"]
 pub mod priority_10;
-#[doc = "priority_11 (rw) register accessor: PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_11`]
+#[doc = "priority_11 (rw) register accessor: PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_11`]
 module"]
 pub type PRIORITY_11 = crate::Reg<priority_11::PRIORITY_11_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 11"]
 pub mod priority_11;
-#[doc = "priority_12 (rw) register accessor: PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_12`]
+#[doc = "priority_12 (rw) register accessor: PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_12`]
 module"]
 pub type PRIORITY_12 = crate::Reg<priority_12::PRIORITY_12_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 12"]
 pub mod priority_12;
-#[doc = "priority_13 (rw) register accessor: PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_13`]
+#[doc = "priority_13 (rw) register accessor: PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_13`]
 module"]
 pub type PRIORITY_13 = crate::Reg<priority_13::PRIORITY_13_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 13"]
 pub mod priority_13;
-#[doc = "priority_14 (rw) register accessor: PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_14`]
+#[doc = "priority_14 (rw) register accessor: PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_14`]
 module"]
 pub type PRIORITY_14 = crate::Reg<priority_14::PRIORITY_14_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 14"]
 pub mod priority_14;
-#[doc = "priority_15 (rw) register accessor: PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_15`]
+#[doc = "priority_15 (rw) register accessor: PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_15`]
 module"]
 pub type PRIORITY_15 = crate::Reg<priority_15::PRIORITY_15_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 15"]
 pub mod priority_15;
-#[doc = "priority_16 (rw) register accessor: PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_16`]
+#[doc = "priority_16 (rw) register accessor: PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_16`]
 module"]
 pub type PRIORITY_16 = crate::Reg<priority_16::PRIORITY_16_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 16"]
 pub mod priority_16;
-#[doc = "priority_17 (rw) register accessor: PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_17`]
+#[doc = "priority_17 (rw) register accessor: PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_17`]
 module"]
 pub type PRIORITY_17 = crate::Reg<priority_17::PRIORITY_17_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 17"]
 pub mod priority_17;
-#[doc = "priority_18 (rw) register accessor: PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_18`]
+#[doc = "priority_18 (rw) register accessor: PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_18`]
 module"]
 pub type PRIORITY_18 = crate::Reg<priority_18::PRIORITY_18_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 18"]
 pub mod priority_18;
-#[doc = "priority_19 (rw) register accessor: PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_19`]
+#[doc = "priority_19 (rw) register accessor: PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_19`]
 module"]
 pub type PRIORITY_19 = crate::Reg<priority_19::PRIORITY_19_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 19"]
 pub mod priority_19;
-#[doc = "priority_20 (rw) register accessor: PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_20`]
+#[doc = "priority_20 (rw) register accessor: PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_20`]
 module"]
 pub type PRIORITY_20 = crate::Reg<priority_20::PRIORITY_20_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 20"]
 pub mod priority_20;
-#[doc = "priority_21 (rw) register accessor: PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_21`]
+#[doc = "priority_21 (rw) register accessor: PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_21`]
 module"]
 pub type PRIORITY_21 = crate::Reg<priority_21::PRIORITY_21_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 21"]
 pub mod priority_21;
-#[doc = "priority_22 (rw) register accessor: PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_22`]
+#[doc = "priority_22 (rw) register accessor: PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_22`]
 module"]
 pub type PRIORITY_22 = crate::Reg<priority_22::PRIORITY_22_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 22"]
 pub mod priority_22;
-#[doc = "priority_23 (rw) register accessor: PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_23`]
+#[doc = "priority_23 (rw) register accessor: PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_23`]
 module"]
 pub type PRIORITY_23 = crate::Reg<priority_23::PRIORITY_23_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 23"]
 pub mod priority_23;
-#[doc = "priority_24 (rw) register accessor: PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_24`]
+#[doc = "priority_24 (rw) register accessor: PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_24`]
 module"]
 pub type PRIORITY_24 = crate::Reg<priority_24::PRIORITY_24_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 24"]
 pub mod priority_24;
-#[doc = "priority_25 (rw) register accessor: PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_25`]
+#[doc = "priority_25 (rw) register accessor: PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_25`]
 module"]
 pub type PRIORITY_25 = crate::Reg<priority_25::PRIORITY_25_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 25"]
 pub mod priority_25;
-#[doc = "priority_26 (rw) register accessor: PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_26`]
+#[doc = "priority_26 (rw) register accessor: PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_26`]
 module"]
 pub type PRIORITY_26 = crate::Reg<priority_26::PRIORITY_26_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 26"]
 pub mod priority_26;
-#[doc = "priority_27 (rw) register accessor: PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_27`]
+#[doc = "priority_27 (rw) register accessor: PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_27`]
 module"]
 pub type PRIORITY_27 = crate::Reg<priority_27::PRIORITY_27_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 27"]
 pub mod priority_27;
-#[doc = "priority_28 (rw) register accessor: PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_28`]
+#[doc = "priority_28 (rw) register accessor: PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_28`]
 module"]
 pub type PRIORITY_28 = crate::Reg<priority_28::PRIORITY_28_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 28"]
 pub mod priority_28;
-#[doc = "priority_29 (rw) register accessor: PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_29`]
+#[doc = "priority_29 (rw) register accessor: PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_29`]
 module"]
 pub type PRIORITY_29 = crate::Reg<priority_29::PRIORITY_29_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 29"]
 pub mod priority_29;
-#[doc = "priority_30 (rw) register accessor: PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_30`]
+#[doc = "priority_30 (rw) register accessor: PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_30`]
 module"]
 pub type PRIORITY_30 = crate::Reg<priority_30::PRIORITY_30_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 30"]
 pub mod priority_30;
-#[doc = "priority_31 (rw) register accessor: PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_31`]
+#[doc = "priority_31 (rw) register accessor: PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_31`]
 module"]
 pub type PRIORITY_31 = crate::Reg<priority_31::PRIORITY_31_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 31"]
 pub mod priority_31;
-#[doc = "priority_32 (rw) register accessor: PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_32`]
+#[doc = "priority_32 (rw) register accessor: PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_32`]
 module"]
 pub type PRIORITY_32 = crate::Reg<priority_32::PRIORITY_32_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 32"]
 pub mod priority_32;
-#[doc = "priority_33 (rw) register accessor: PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_33`]
+#[doc = "priority_33 (rw) register accessor: PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_33`]
 module"]
 pub type PRIORITY_33 = crate::Reg<priority_33::PRIORITY_33_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 33"]
 pub mod priority_33;
-#[doc = "priority_34 (rw) register accessor: PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_34`]
+#[doc = "priority_34 (rw) register accessor: PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_34`]
 module"]
 pub type PRIORITY_34 = crate::Reg<priority_34::PRIORITY_34_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 34"]
 pub mod priority_34;
-#[doc = "priority_35 (rw) register accessor: PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_35`]
+#[doc = "priority_35 (rw) register accessor: PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_35`]
 module"]
 pub type PRIORITY_35 = crate::Reg<priority_35::PRIORITY_35_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 35"]
 pub mod priority_35;
-#[doc = "priority_36 (rw) register accessor: PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_36`]
+#[doc = "priority_36 (rw) register accessor: PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_36`]
 module"]
 pub type PRIORITY_36 = crate::Reg<priority_36::PRIORITY_36_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 36"]
 pub mod priority_36;
-#[doc = "priority_37 (rw) register accessor: PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_37`]
+#[doc = "priority_37 (rw) register accessor: PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_37`]
 module"]
 pub type PRIORITY_37 = crate::Reg<priority_37::PRIORITY_37_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 37"]
 pub mod priority_37;
-#[doc = "priority_38 (rw) register accessor: PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_38`]
+#[doc = "priority_38 (rw) register accessor: PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_38`]
 module"]
 pub type PRIORITY_38 = crate::Reg<priority_38::PRIORITY_38_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 38"]
 pub mod priority_38;
-#[doc = "priority_39 (rw) register accessor: PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_39`]
+#[doc = "priority_39 (rw) register accessor: PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_39`]
 module"]
 pub type PRIORITY_39 = crate::Reg<priority_39::PRIORITY_39_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 39"]
 pub mod priority_39;
-#[doc = "priority_40 (rw) register accessor: PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_40`]
+#[doc = "priority_40 (rw) register accessor: PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_40`]
 module"]
 pub type PRIORITY_40 = crate::Reg<priority_40::PRIORITY_40_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 40"]
 pub mod priority_40;
-#[doc = "priority_41 (rw) register accessor: PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_41`]
+#[doc = "priority_41 (rw) register accessor: PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_41`]
 module"]
 pub type PRIORITY_41 = crate::Reg<priority_41::PRIORITY_41_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 41"]
 pub mod priority_41;
-#[doc = "priority_42 (rw) register accessor: PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_42`]
+#[doc = "priority_42 (rw) register accessor: PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_42`]
 module"]
 pub type PRIORITY_42 = crate::Reg<priority_42::PRIORITY_42_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 42"]
 pub mod priority_42;
-#[doc = "priority_43 (rw) register accessor: PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_43`]
+#[doc = "priority_43 (rw) register accessor: PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_43`]
 module"]
 pub type PRIORITY_43 = crate::Reg<priority_43::PRIORITY_43_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 43"]
 pub mod priority_43;
-#[doc = "priority_44 (rw) register accessor: PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_44`]
+#[doc = "priority_44 (rw) register accessor: PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_44`]
 module"]
 pub type PRIORITY_44 = crate::Reg<priority_44::PRIORITY_44_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 44"]
 pub mod priority_44;
-#[doc = "priority_45 (rw) register accessor: PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_45`]
+#[doc = "priority_45 (rw) register accessor: PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_45`]
 module"]
 pub type PRIORITY_45 = crate::Reg<priority_45::PRIORITY_45_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 45"]
 pub mod priority_45;
-#[doc = "priority_46 (rw) register accessor: PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_46`]
+#[doc = "priority_46 (rw) register accessor: PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_46`]
 module"]
 pub type PRIORITY_46 = crate::Reg<priority_46::PRIORITY_46_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 46"]
 pub mod priority_46;
-#[doc = "priority_47 (rw) register accessor: PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_47`]
+#[doc = "priority_47 (rw) register accessor: PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_47`]
 module"]
 pub type PRIORITY_47 = crate::Reg<priority_47::PRIORITY_47_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 47"]
 pub mod priority_47;
-#[doc = "priority_48 (rw) register accessor: PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_48`]
+#[doc = "priority_48 (rw) register accessor: PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_48`]
 module"]
 pub type PRIORITY_48 = crate::Reg<priority_48::PRIORITY_48_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 48"]
 pub mod priority_48;
-#[doc = "priority_49 (rw) register accessor: PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_49`]
+#[doc = "priority_49 (rw) register accessor: PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_49`]
 module"]
 pub type PRIORITY_49 = crate::Reg<priority_49::PRIORITY_49_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 49"]
 pub mod priority_49;
-#[doc = "priority_50 (rw) register accessor: PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_50`]
+#[doc = "priority_50 (rw) register accessor: PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_50`]
 module"]
 pub type PRIORITY_50 = crate::Reg<priority_50::PRIORITY_50_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 50"]
 pub mod priority_50;
-#[doc = "priority_51 (rw) register accessor: PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_51`]
+#[doc = "priority_51 (rw) register accessor: PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_51`]
 module"]
 pub type PRIORITY_51 = crate::Reg<priority_51::PRIORITY_51_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 51"]
 pub mod priority_51;
-#[doc = "priority_52 (rw) register accessor: PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_52`]
+#[doc = "priority_52 (rw) register accessor: PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_52`]
 module"]
 pub type PRIORITY_52 = crate::Reg<priority_52::PRIORITY_52_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 52"]
 pub mod priority_52;
-#[doc = "priority_53 (rw) register accessor: PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_53`]
+#[doc = "priority_53 (rw) register accessor: PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_53`]
 module"]
 pub type PRIORITY_53 = crate::Reg<priority_53::PRIORITY_53_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 53"]
 pub mod priority_53;
-#[doc = "priority_54 (rw) register accessor: PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_54`]
+#[doc = "priority_54 (rw) register accessor: PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_54`]
 module"]
 pub type PRIORITY_54 = crate::Reg<priority_54::PRIORITY_54_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 54"]
 pub mod priority_54;
-#[doc = "priority_55 (rw) register accessor: PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_55`]
+#[doc = "priority_55 (rw) register accessor: PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_55`]
 module"]
 pub type PRIORITY_55 = crate::Reg<priority_55::PRIORITY_55_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 55"]
 pub mod priority_55;
-#[doc = "priority_56 (rw) register accessor: PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_56`]
+#[doc = "priority_56 (rw) register accessor: PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_56`]
 module"]
 pub type PRIORITY_56 = crate::Reg<priority_56::PRIORITY_56_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 56"]
 pub mod priority_56;
-#[doc = "priority_57 (rw) register accessor: PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_57`]
+#[doc = "priority_57 (rw) register accessor: PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_57`]
 module"]
 pub type PRIORITY_57 = crate::Reg<priority_57::PRIORITY_57_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 57"]
 pub mod priority_57;
-#[doc = "priority_58 (rw) register accessor: PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_58`]
+#[doc = "priority_58 (rw) register accessor: PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_58`]
 module"]
 pub type PRIORITY_58 = crate::Reg<priority_58::PRIORITY_58_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 58"]
 pub mod priority_58;
-#[doc = "priority_59 (rw) register accessor: PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_59`]
+#[doc = "priority_59 (rw) register accessor: PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_59`]
 module"]
 pub type PRIORITY_59 = crate::Reg<priority_59::PRIORITY_59_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 59"]
 pub mod priority_59;
-#[doc = "priority_60 (rw) register accessor: PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_60`]
+#[doc = "priority_60 (rw) register accessor: PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_60`]
 module"]
 pub type PRIORITY_60 = crate::Reg<priority_60::PRIORITY_60_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 60"]
 pub mod priority_60;
-#[doc = "priority_61 (rw) register accessor: PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_61`]
+#[doc = "priority_61 (rw) register accessor: PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_61`]
 module"]
 pub type PRIORITY_61 = crate::Reg<priority_61::PRIORITY_61_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 61"]
 pub mod priority_61;
-#[doc = "priority_62 (rw) register accessor: PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_62`]
+#[doc = "priority_62 (rw) register accessor: PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_62`]
 module"]
 pub type PRIORITY_62 = crate::Reg<priority_62::PRIORITY_62_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 62"]
 pub mod priority_62;
-#[doc = "priority_63 (rw) register accessor: PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_63`]
+#[doc = "priority_63 (rw) register accessor: PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_63`]
 module"]
 pub type PRIORITY_63 = crate::Reg<priority_63::PRIORITY_63_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 63"]
 pub mod priority_63;
-#[doc = "priority_64 (rw) register accessor: PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_64`]
+#[doc = "priority_64 (rw) register accessor: PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_64`]
 module"]
 pub type PRIORITY_64 = crate::Reg<priority_64::PRIORITY_64_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 64"]
 pub mod priority_64;
-#[doc = "priority_65 (rw) register accessor: PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_65`]
+#[doc = "priority_65 (rw) register accessor: PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_65`]
 module"]
 pub type PRIORITY_65 = crate::Reg<priority_65::PRIORITY_65_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 65"]
 pub mod priority_65;
-#[doc = "priority_66 (rw) register accessor: PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_66`]
+#[doc = "priority_66 (rw) register accessor: PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_66`]
 module"]
 pub type PRIORITY_66 = crate::Reg<priority_66::PRIORITY_66_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 66"]
 pub mod priority_66;
-#[doc = "priority_67 (rw) register accessor: PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_67`]
+#[doc = "priority_67 (rw) register accessor: PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_67`]
 module"]
 pub type PRIORITY_67 = crate::Reg<priority_67::PRIORITY_67_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 67"]
 pub mod priority_67;
-#[doc = "priority_68 (rw) register accessor: PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_68`]
+#[doc = "priority_68 (rw) register accessor: PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_68`]
 module"]
 pub type PRIORITY_68 = crate::Reg<priority_68::PRIORITY_68_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 68"]
 pub mod priority_68;
-#[doc = "priority_69 (rw) register accessor: PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_69`]
+#[doc = "priority_69 (rw) register accessor: PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_69`]
 module"]
 pub type PRIORITY_69 = crate::Reg<priority_69::PRIORITY_69_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 69"]
 pub mod priority_69;
-#[doc = "priority_70 (rw) register accessor: PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_70`]
+#[doc = "priority_70 (rw) register accessor: PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_70`]
 module"]
 pub type PRIORITY_70 = crate::Reg<priority_70::PRIORITY_70_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 70"]
 pub mod priority_70;
-#[doc = "priority_71 (rw) register accessor: PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_71`]
+#[doc = "priority_71 (rw) register accessor: PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_71`]
 module"]
 pub type PRIORITY_71 = crate::Reg<priority_71::PRIORITY_71_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 71"]
 pub mod priority_71;
-#[doc = "priority_72 (rw) register accessor: PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_72`]
+#[doc = "priority_72 (rw) register accessor: PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_72`]
 module"]
 pub type PRIORITY_72 = crate::Reg<priority_72::PRIORITY_72_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 72"]
 pub mod priority_72;
-#[doc = "priority_73 (rw) register accessor: PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_73`]
+#[doc = "priority_73 (rw) register accessor: PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_73`]
 module"]
 pub type PRIORITY_73 = crate::Reg<priority_73::PRIORITY_73_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 73"]
 pub mod priority_73;
-#[doc = "priority_74 (rw) register accessor: PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_74`]
+#[doc = "priority_74 (rw) register accessor: PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_74`]
 module"]
 pub type PRIORITY_74 = crate::Reg<priority_74::PRIORITY_74_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 74"]
 pub mod priority_74;
-#[doc = "priority_75 (rw) register accessor: PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_75`]
+#[doc = "priority_75 (rw) register accessor: PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_75`]
 module"]
 pub type PRIORITY_75 = crate::Reg<priority_75::PRIORITY_75_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 75"]
 pub mod priority_75;
-#[doc = "priority_76 (rw) register accessor: PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_76`]
+#[doc = "priority_76 (rw) register accessor: PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_76`]
 module"]
 pub type PRIORITY_76 = crate::Reg<priority_76::PRIORITY_76_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 76"]
 pub mod priority_76;
-#[doc = "priority_77 (rw) register accessor: PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_77`]
+#[doc = "priority_77 (rw) register accessor: PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_77`]
 module"]
 pub type PRIORITY_77 = crate::Reg<priority_77::PRIORITY_77_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 77"]
 pub mod priority_77;
-#[doc = "priority_78 (rw) register accessor: PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_78`]
+#[doc = "priority_78 (rw) register accessor: PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_78`]
 module"]
 pub type PRIORITY_78 = crate::Reg<priority_78::PRIORITY_78_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 78"]
 pub mod priority_78;
-#[doc = "priority_79 (rw) register accessor: PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_79`]
+#[doc = "priority_79 (rw) register accessor: PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_79`]
 module"]
 pub type PRIORITY_79 = crate::Reg<priority_79::PRIORITY_79_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 79"]
 pub mod priority_79;
-#[doc = "priority_80 (rw) register accessor: PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_80`]
+#[doc = "priority_80 (rw) register accessor: PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_80`]
 module"]
 pub type PRIORITY_80 = crate::Reg<priority_80::PRIORITY_80_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 80"]
 pub mod priority_80;
-#[doc = "priority_81 (rw) register accessor: PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_81`]
+#[doc = "priority_81 (rw) register accessor: PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_81`]
 module"]
 pub type PRIORITY_81 = crate::Reg<priority_81::PRIORITY_81_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 81"]
 pub mod priority_81;
-#[doc = "priority_82 (rw) register accessor: PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_82`]
+#[doc = "priority_82 (rw) register accessor: PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_82`]
 module"]
 pub type PRIORITY_82 = crate::Reg<priority_82::PRIORITY_82_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 82"]
 pub mod priority_82;
-#[doc = "priority_83 (rw) register accessor: PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_83`]
+#[doc = "priority_83 (rw) register accessor: PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_83`]
 module"]
 pub type PRIORITY_83 = crate::Reg<priority_83::PRIORITY_83_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 83"]
 pub mod priority_83;
-#[doc = "priority_84 (rw) register accessor: PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_84`]
+#[doc = "priority_84 (rw) register accessor: PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_84`]
 module"]
 pub type PRIORITY_84 = crate::Reg<priority_84::PRIORITY_84_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 84"]
 pub mod priority_84;
-#[doc = "priority_85 (rw) register accessor: PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_85`]
+#[doc = "priority_85 (rw) register accessor: PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_85`]
 module"]
 pub type PRIORITY_85 = crate::Reg<priority_85::PRIORITY_85_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 85"]
 pub mod priority_85;
-#[doc = "priority_86 (rw) register accessor: PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_86`]
+#[doc = "priority_86 (rw) register accessor: PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_86`]
 module"]
 pub type PRIORITY_86 = crate::Reg<priority_86::PRIORITY_86_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 86"]
 pub mod priority_86;
-#[doc = "priority_87 (rw) register accessor: PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_87`]
+#[doc = "priority_87 (rw) register accessor: PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_87`]
 module"]
 pub type PRIORITY_87 = crate::Reg<priority_87::PRIORITY_87_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 87"]
 pub mod priority_87;
-#[doc = "priority_88 (rw) register accessor: PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_88`]
+#[doc = "priority_88 (rw) register accessor: PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_88`]
 module"]
 pub type PRIORITY_88 = crate::Reg<priority_88::PRIORITY_88_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 88"]
 pub mod priority_88;
-#[doc = "priority_89 (rw) register accessor: PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_89`]
+#[doc = "priority_89 (rw) register accessor: PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_89`]
 module"]
 pub type PRIORITY_89 = crate::Reg<priority_89::PRIORITY_89_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 89"]
 pub mod priority_89;
-#[doc = "priority_90 (rw) register accessor: PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_90`]
+#[doc = "priority_90 (rw) register accessor: PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_90`]
 module"]
 pub type PRIORITY_90 = crate::Reg<priority_90::PRIORITY_90_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 90"]
 pub mod priority_90;
-#[doc = "priority_91 (rw) register accessor: PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_91`]
+#[doc = "priority_91 (rw) register accessor: PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_91`]
 module"]
 pub type PRIORITY_91 = crate::Reg<priority_91::PRIORITY_91_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 91"]
 pub mod priority_91;
-#[doc = "priority_92 (rw) register accessor: PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_92`]
+#[doc = "priority_92 (rw) register accessor: PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_92`]
 module"]
 pub type PRIORITY_92 = crate::Reg<priority_92::PRIORITY_92_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 92"]
 pub mod priority_92;
-#[doc = "priority_93 (rw) register accessor: PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_93`]
+#[doc = "priority_93 (rw) register accessor: PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_93`]
 module"]
 pub type PRIORITY_93 = crate::Reg<priority_93::PRIORITY_93_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 93"]
 pub mod priority_93;
-#[doc = "priority_94 (rw) register accessor: PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_94`]
+#[doc = "priority_94 (rw) register accessor: PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_94`]
 module"]
 pub type PRIORITY_94 = crate::Reg<priority_94::PRIORITY_94_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 94"]
 pub mod priority_94;
-#[doc = "priority_95 (rw) register accessor: PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_95`]
+#[doc = "priority_95 (rw) register accessor: PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_95`]
 module"]
 pub type PRIORITY_95 = crate::Reg<priority_95::PRIORITY_95_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 95"]
 pub mod priority_95;
-#[doc = "priority_96 (rw) register accessor: PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_96`]
+#[doc = "priority_96 (rw) register accessor: PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_96`]
 module"]
 pub type PRIORITY_96 = crate::Reg<priority_96::PRIORITY_96_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 96"]
 pub mod priority_96;
-#[doc = "priority_97 (rw) register accessor: PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_97`]
+#[doc = "priority_97 (rw) register accessor: PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_97`]
 module"]
 pub type PRIORITY_97 = crate::Reg<priority_97::PRIORITY_97_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 97"]
 pub mod priority_97;
-#[doc = "priority_98 (rw) register accessor: PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_98`]
+#[doc = "priority_98 (rw) register accessor: PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_98`]
 module"]
 pub type PRIORITY_98 = crate::Reg<priority_98::PRIORITY_98_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 98"]
 pub mod priority_98;
-#[doc = "priority_99 (rw) register accessor: PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_99`]
+#[doc = "priority_99 (rw) register accessor: PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_99`]
 module"]
 pub type PRIORITY_99 = crate::Reg<priority_99::PRIORITY_99_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 99"]
 pub mod priority_99;
-#[doc = "priority_100 (rw) register accessor: PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_100`]
+#[doc = "priority_100 (rw) register accessor: PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_100`]
 module"]
 pub type PRIORITY_100 = crate::Reg<priority_100::PRIORITY_100_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 100"]
 pub mod priority_100;
-#[doc = "priority_101 (rw) register accessor: PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_101`]
+#[doc = "priority_101 (rw) register accessor: PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_101`]
 module"]
 pub type PRIORITY_101 = crate::Reg<priority_101::PRIORITY_101_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 101"]
 pub mod priority_101;
-#[doc = "priority_102 (rw) register accessor: PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_102`]
+#[doc = "priority_102 (rw) register accessor: PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_102`]
 module"]
 pub type PRIORITY_102 = crate::Reg<priority_102::PRIORITY_102_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 102"]
 pub mod priority_102;
-#[doc = "priority_103 (rw) register accessor: PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_103`]
+#[doc = "priority_103 (rw) register accessor: PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_103`]
 module"]
 pub type PRIORITY_103 = crate::Reg<priority_103::PRIORITY_103_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 103"]
 pub mod priority_103;
-#[doc = "priority_104 (rw) register accessor: PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_104`]
+#[doc = "priority_104 (rw) register accessor: PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_104`]
 module"]
 pub type PRIORITY_104 = crate::Reg<priority_104::PRIORITY_104_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 104"]
 pub mod priority_104;
-#[doc = "priority_105 (rw) register accessor: PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_105`]
+#[doc = "priority_105 (rw) register accessor: PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_105`]
 module"]
 pub type PRIORITY_105 = crate::Reg<priority_105::PRIORITY_105_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 105"]
 pub mod priority_105;
-#[doc = "priority_106 (rw) register accessor: PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_106`]
+#[doc = "priority_106 (rw) register accessor: PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_106`]
 module"]
 pub type PRIORITY_106 = crate::Reg<priority_106::PRIORITY_106_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 106"]
 pub mod priority_106;
-#[doc = "priority_107 (rw) register accessor: PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_107`]
+#[doc = "priority_107 (rw) register accessor: PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_107`]
 module"]
 pub type PRIORITY_107 = crate::Reg<priority_107::PRIORITY_107_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 107"]
 pub mod priority_107;
-#[doc = "priority_108 (rw) register accessor: PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_108`]
+#[doc = "priority_108 (rw) register accessor: PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_108`]
 module"]
 pub type PRIORITY_108 = crate::Reg<priority_108::PRIORITY_108_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 108"]
 pub mod priority_108;
-#[doc = "priority_109 (rw) register accessor: PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_109`]
+#[doc = "priority_109 (rw) register accessor: PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_109`]
 module"]
 pub type PRIORITY_109 = crate::Reg<priority_109::PRIORITY_109_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 109"]
 pub mod priority_109;
-#[doc = "priority_110 (rw) register accessor: PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_110`]
+#[doc = "priority_110 (rw) register accessor: PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_110`]
 module"]
 pub type PRIORITY_110 = crate::Reg<priority_110::PRIORITY_110_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 110"]
 pub mod priority_110;
-#[doc = "priority_111 (rw) register accessor: PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_111`]
+#[doc = "priority_111 (rw) register accessor: PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_111`]
 module"]
 pub type PRIORITY_111 = crate::Reg<priority_111::PRIORITY_111_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 111"]
 pub mod priority_111;
-#[doc = "priority_112 (rw) register accessor: PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_112`]
+#[doc = "priority_112 (rw) register accessor: PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_112`]
 module"]
 pub type PRIORITY_112 = crate::Reg<priority_112::PRIORITY_112_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 112"]
 pub mod priority_112;
-#[doc = "priority_113 (rw) register accessor: PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_113`]
+#[doc = "priority_113 (rw) register accessor: PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_113`]
 module"]
 pub type PRIORITY_113 = crate::Reg<priority_113::PRIORITY_113_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 113"]
 pub mod priority_113;
-#[doc = "priority_114 (rw) register accessor: PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_114`]
+#[doc = "priority_114 (rw) register accessor: PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_114`]
 module"]
 pub type PRIORITY_114 = crate::Reg<priority_114::PRIORITY_114_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 114"]
 pub mod priority_114;
-#[doc = "priority_115 (rw) register accessor: PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_115`]
+#[doc = "priority_115 (rw) register accessor: PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_115`]
 module"]
 pub type PRIORITY_115 = crate::Reg<priority_115::PRIORITY_115_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 115"]
 pub mod priority_115;
-#[doc = "priority_116 (rw) register accessor: PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_116`]
+#[doc = "priority_116 (rw) register accessor: PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_116`]
 module"]
 pub type PRIORITY_116 = crate::Reg<priority_116::PRIORITY_116_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 116"]
 pub mod priority_116;
-#[doc = "priority_117 (rw) register accessor: PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_117`]
+#[doc = "priority_117 (rw) register accessor: PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_117`]
 module"]
 pub type PRIORITY_117 = crate::Reg<priority_117::PRIORITY_117_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 117"]
 pub mod priority_117;
-#[doc = "priority_118 (rw) register accessor: PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_118`]
+#[doc = "priority_118 (rw) register accessor: PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_118`]
 module"]
 pub type PRIORITY_118 = crate::Reg<priority_118::PRIORITY_118_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 118"]
 pub mod priority_118;
-#[doc = "priority_119 (rw) register accessor: PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_119`]
+#[doc = "priority_119 (rw) register accessor: PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_119`]
 module"]
 pub type PRIORITY_119 = crate::Reg<priority_119::PRIORITY_119_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 119"]
 pub mod priority_119;
-#[doc = "priority_120 (rw) register accessor: PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_120`]
+#[doc = "priority_120 (rw) register accessor: PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_120`]
 module"]
 pub type PRIORITY_120 = crate::Reg<priority_120::PRIORITY_120_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 120"]
 pub mod priority_120;
-#[doc = "priority_121 (rw) register accessor: PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_121`]
+#[doc = "priority_121 (rw) register accessor: PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_121`]
 module"]
 pub type PRIORITY_121 = crate::Reg<priority_121::PRIORITY_121_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 121"]
 pub mod priority_121;
-#[doc = "priority_122 (rw) register accessor: PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_122`]
+#[doc = "priority_122 (rw) register accessor: PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_122`]
 module"]
 pub type PRIORITY_122 = crate::Reg<priority_122::PRIORITY_122_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 122"]
 pub mod priority_122;
-#[doc = "priority_123 (rw) register accessor: PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_123`]
+#[doc = "priority_123 (rw) register accessor: PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_123`]
 module"]
 pub type PRIORITY_123 = crate::Reg<priority_123::PRIORITY_123_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 123"]
 pub mod priority_123;
-#[doc = "priority_124 (rw) register accessor: PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_124`]
+#[doc = "priority_124 (rw) register accessor: PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_124`]
 module"]
 pub type PRIORITY_124 = crate::Reg<priority_124::PRIORITY_124_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 124"]
 pub mod priority_124;
-#[doc = "priority_125 (rw) register accessor: PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_125`]
+#[doc = "priority_125 (rw) register accessor: PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_125`]
 module"]
 pub type PRIORITY_125 = crate::Reg<priority_125::PRIORITY_125_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 125"]
 pub mod priority_125;
-#[doc = "priority_126 (rw) register accessor: PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_126`]
+#[doc = "priority_126 (rw) register accessor: PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_126`]
 module"]
 pub type PRIORITY_126 = crate::Reg<priority_126::PRIORITY_126_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 126"]
 pub mod priority_126;
-#[doc = "priority_127 (rw) register accessor: PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_127`]
+#[doc = "priority_127 (rw) register accessor: PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_127`]
 module"]
 pub type PRIORITY_127 = crate::Reg<priority_127::PRIORITY_127_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 127"]
 pub mod priority_127;
-#[doc = "priority_128 (rw) register accessor: PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_128`]
+#[doc = "priority_128 (rw) register accessor: PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_128`]
 module"]
 pub type PRIORITY_128 = crate::Reg<priority_128::PRIORITY_128_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 128"]
 pub mod priority_128;
-#[doc = "priority_129 (rw) register accessor: PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_129`]
+#[doc = "priority_129 (rw) register accessor: PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_129`]
 module"]
 pub type PRIORITY_129 = crate::Reg<priority_129::PRIORITY_129_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 129"]
 pub mod priority_129;
-#[doc = "priority_130 (rw) register accessor: PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_130`]
+#[doc = "priority_130 (rw) register accessor: PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_130`]
 module"]
 pub type PRIORITY_130 = crate::Reg<priority_130::PRIORITY_130_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 130"]
 pub mod priority_130;
-#[doc = "priority_131 (rw) register accessor: PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_131`]
+#[doc = "priority_131 (rw) register accessor: PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_131`]
 module"]
 pub type PRIORITY_131 = crate::Reg<priority_131::PRIORITY_131_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 131"]
 pub mod priority_131;
-#[doc = "priority_132 (rw) register accessor: PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_132`]
+#[doc = "priority_132 (rw) register accessor: PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_132`]
 module"]
 pub type PRIORITY_132 = crate::Reg<priority_132::PRIORITY_132_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 132"]
 pub mod priority_132;
-#[doc = "priority_133 (rw) register accessor: PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_133`]
+#[doc = "priority_133 (rw) register accessor: PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_133`]
 module"]
 pub type PRIORITY_133 = crate::Reg<priority_133::PRIORITY_133_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 133"]
 pub mod priority_133;
-#[doc = "priority_134 (rw) register accessor: PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_134`]
+#[doc = "priority_134 (rw) register accessor: PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_134`]
 module"]
 pub type PRIORITY_134 = crate::Reg<priority_134::PRIORITY_134_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 134"]
 pub mod priority_134;
-#[doc = "priority_135 (rw) register accessor: PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_135`]
+#[doc = "priority_135 (rw) register accessor: PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_135`]
 module"]
 pub type PRIORITY_135 = crate::Reg<priority_135::PRIORITY_135_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 135"]
 pub mod priority_135;
-#[doc = "priority_136 (rw) register accessor: PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_136`]
+#[doc = "priority_136 (rw) register accessor: PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@priority_136`]
 module"]
 pub type PRIORITY_136 = crate::Reg<priority_136::PRIORITY_136_SPEC>;
 #[doc = "PRIORITY Register for interrupt id 136"]
 pub mod priority_136;
-#[doc = "pending_0 (rw) register accessor: PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_0`]
+#[doc = "pending_0 (rw) register accessor: PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_0`]
 module"]
 pub type PENDING_0 = crate::Reg<pending_0::PENDING_0_SPEC>;
 #[doc = "PENDING Register for interrupt ids 31 to 0"]
 pub mod pending_0;
-#[doc = "pending_1 (rw) register accessor: PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_1`]
+#[doc = "pending_1 (rw) register accessor: PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_1`]
 module"]
 pub type PENDING_1 = crate::Reg<pending_1::PENDING_1_SPEC>;
 #[doc = "PENDING Register for interrupt ids 63 to 32"]
 pub mod pending_1;
-#[doc = "pending_2 (rw) register accessor: PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_2`]
+#[doc = "pending_2 (rw) register accessor: PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_2`]
 module"]
 pub type PENDING_2 = crate::Reg<pending_2::PENDING_2_SPEC>;
 #[doc = "PENDING Register for interrupt ids 95 to 64"]
 pub mod pending_2;
-#[doc = "pending_3 (rw) register accessor: PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_3`]
+#[doc = "pending_3 (rw) register accessor: PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_3`]
 module"]
 pub type PENDING_3 = crate::Reg<pending_3::PENDING_3_SPEC>;
 #[doc = "PENDING Register for interrupt ids 127 to 96"]
 pub mod pending_3;
-#[doc = "pending_4 (rw) register accessor: PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_4`]
+#[doc = "pending_4 (rw) register accessor: PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@pending_4`]
 module"]
 pub type PENDING_4 = crate::Reg<pending_4::PENDING_4_SPEC>;
 #[doc = "PENDING Register for interrupt ids 136 to 128"]
 pub mod pending_4;
-#[doc = "enable_0_0 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_0`]
+#[doc = "enable_0_0 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_0`]
 module"]
 pub type ENABLE_0_0 = crate::Reg<enable_0_0::ENABLE_0_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0"]
 pub mod enable_0_0;
-#[doc = "enable_1_0 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_0`]
+#[doc = "enable_1_0 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_0`]
 module"]
 pub type ENABLE_1_0 = crate::Reg<enable_1_0::ENABLE_1_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0"]
 pub mod enable_1_0;
-#[doc = "enable_2_0 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_0`]
+#[doc = "enable_2_0 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_0`]
 module"]
 pub type ENABLE_2_0 = crate::Reg<enable_2_0::ENABLE_2_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0"]
 pub mod enable_2_0;
-#[doc = "enable_3_0 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_0`]
+#[doc = "enable_3_0 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_0`]
 module"]
 pub type ENABLE_3_0 = crate::Reg<enable_3_0::ENABLE_3_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0"]
 pub mod enable_3_0;
-#[doc = "enable_4_0 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_0`]
+#[doc = "enable_4_0 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_0`]
 module"]
 pub type ENABLE_4_0 = crate::Reg<enable_4_0::ENABLE_4_0_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0"]
 pub mod enable_4_0;
-#[doc = "enable_0_1 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_1`]
+#[doc = "enable_0_1 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_1`]
 module"]
 pub type ENABLE_0_1 = crate::Reg<enable_0_1::ENABLE_0_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1"]
 pub mod enable_0_1;
-#[doc = "enable_1_1 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_1`]
+#[doc = "enable_1_1 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_1`]
 module"]
 pub type ENABLE_1_1 = crate::Reg<enable_1_1::ENABLE_1_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1"]
 pub mod enable_1_1;
-#[doc = "enable_2_1 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_1`]
+#[doc = "enable_2_1 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_1`]
 module"]
 pub type ENABLE_2_1 = crate::Reg<enable_2_1::ENABLE_2_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1"]
 pub mod enable_2_1;
-#[doc = "enable_3_1 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_1`]
+#[doc = "enable_3_1 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_1`]
 module"]
 pub type ENABLE_3_1 = crate::Reg<enable_3_1::ENABLE_3_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1"]
 pub mod enable_3_1;
-#[doc = "enable_4_1 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_1`]
+#[doc = "enable_4_1 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_1`]
 module"]
 pub type ENABLE_4_1 = crate::Reg<enable_4_1::ENABLE_4_1_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1"]
 pub mod enable_4_1;
-#[doc = "enable_0_2 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_2`]
+#[doc = "enable_0_2 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_2`]
 module"]
 pub type ENABLE_0_2 = crate::Reg<enable_0_2::ENABLE_0_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2"]
 pub mod enable_0_2;
-#[doc = "enable_1_2 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_2`]
+#[doc = "enable_1_2 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_2`]
 module"]
 pub type ENABLE_1_2 = crate::Reg<enable_1_2::ENABLE_1_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2"]
 pub mod enable_1_2;
-#[doc = "enable_2_2 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_2`]
+#[doc = "enable_2_2 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_2`]
 module"]
 pub type ENABLE_2_2 = crate::Reg<enable_2_2::ENABLE_2_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2"]
 pub mod enable_2_2;
-#[doc = "enable_3_2 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_2`]
+#[doc = "enable_3_2 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_2`]
 module"]
 pub type ENABLE_3_2 = crate::Reg<enable_3_2::ENABLE_3_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2"]
 pub mod enable_3_2;
-#[doc = "enable_4_2 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_2`]
+#[doc = "enable_4_2 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_2`]
 module"]
 pub type ENABLE_4_2 = crate::Reg<enable_4_2::ENABLE_4_2_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2"]
 pub mod enable_4_2;
-#[doc = "enable_0_3 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_3`]
+#[doc = "enable_0_3 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_3`]
 module"]
 pub type ENABLE_0_3 = crate::Reg<enable_0_3::ENABLE_0_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3"]
 pub mod enable_0_3;
-#[doc = "enable_1_3 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_3`]
+#[doc = "enable_1_3 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_3`]
 module"]
 pub type ENABLE_1_3 = crate::Reg<enable_1_3::ENABLE_1_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3"]
 pub mod enable_1_3;
-#[doc = "enable_2_3 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_3`]
+#[doc = "enable_2_3 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_3`]
 module"]
 pub type ENABLE_2_3 = crate::Reg<enable_2_3::ENABLE_2_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3"]
 pub mod enable_2_3;
-#[doc = "enable_3_3 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_3`]
+#[doc = "enable_3_3 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_3`]
 module"]
 pub type ENABLE_3_3 = crate::Reg<enable_3_3::ENABLE_3_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3"]
 pub mod enable_3_3;
-#[doc = "enable_4_3 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_3`]
+#[doc = "enable_4_3 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_3`]
 module"]
 pub type ENABLE_4_3 = crate::Reg<enable_4_3::ENABLE_4_3_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3"]
 pub mod enable_4_3;
-#[doc = "enable_0_4 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_4`]
+#[doc = "enable_0_4 (rw) register accessor: ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_0_4`]
 module"]
 pub type ENABLE_0_4 = crate::Reg<enable_0_4::ENABLE_0_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4"]
 pub mod enable_0_4;
-#[doc = "enable_1_4 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_4`]
+#[doc = "enable_1_4 (rw) register accessor: ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_1_4`]
 module"]
 pub type ENABLE_1_4 = crate::Reg<enable_1_4::ENABLE_1_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4"]
 pub mod enable_1_4;
-#[doc = "enable_2_4 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_4`]
+#[doc = "enable_2_4 (rw) register accessor: ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_2_4`]
 module"]
 pub type ENABLE_2_4 = crate::Reg<enable_2_4::ENABLE_2_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4"]
 pub mod enable_2_4;
-#[doc = "enable_3_4 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_4`]
+#[doc = "enable_3_4 (rw) register accessor: ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_3_4`]
 module"]
 pub type ENABLE_3_4 = crate::Reg<enable_3_4::ENABLE_3_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4"]
 pub mod enable_3_4;
-#[doc = "enable_4_4 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_4`]
+#[doc = "enable_4_4 (rw) register accessor: ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@enable_4_4`]
 module"]
 pub type ENABLE_4_4 = crate::Reg<enable_4_4::ENABLE_4_4_SPEC>;
 #[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4"]
 pub mod enable_4_4;
-#[doc = "threshold_0 (rw) register accessor: PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_0`]
+#[doc = "threshold_0 (rw) register accessor: PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_0`]
 module"]
 pub type THRESHOLD_0 = crate::Reg<threshold_0::THRESHOLD_0_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 0"]
 pub mod threshold_0;
-#[doc = "claimplete_0 (rw) register accessor: CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_0`]
+#[doc = "claimplete_0 (rw) register accessor: CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_0`]
 module"]
 pub type CLAIMPLETE_0 = crate::Reg<claimplete_0::CLAIMPLETE_0_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 0"]
 pub mod claimplete_0;
-#[doc = "threshold_1 (rw) register accessor: PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_1`]
+#[doc = "threshold_1 (rw) register accessor: PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_1`]
 module"]
 pub type THRESHOLD_1 = crate::Reg<threshold_1::THRESHOLD_1_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 1"]
 pub mod threshold_1;
-#[doc = "claimplete_1 (rw) register accessor: CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_1`]
+#[doc = "claimplete_1 (rw) register accessor: CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_1`]
 module"]
 pub type CLAIMPLETE_1 = crate::Reg<claimplete_1::CLAIMPLETE_1_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 1"]
 pub mod claimplete_1;
-#[doc = "threshold_2 (rw) register accessor: PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_2`]
+#[doc = "threshold_2 (rw) register accessor: PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_2`]
 module"]
 pub type THRESHOLD_2 = crate::Reg<threshold_2::THRESHOLD_2_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 2"]
 pub mod threshold_2;
-#[doc = "claimplete_2 (rw) register accessor: CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_2`]
+#[doc = "claimplete_2 (rw) register accessor: CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_2`]
 module"]
 pub type CLAIMPLETE_2 = crate::Reg<claimplete_2::CLAIMPLETE_2_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 2"]
 pub mod claimplete_2;
-#[doc = "threshold_3 (rw) register accessor: PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_3`]
+#[doc = "threshold_3 (rw) register accessor: PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_3`]
 module"]
 pub type THRESHOLD_3 = crate::Reg<threshold_3::THRESHOLD_3_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 3"]
 pub mod threshold_3;
-#[doc = "claimplete_3 (rw) register accessor: CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_3`]
+#[doc = "claimplete_3 (rw) register accessor: CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_3`]
 module"]
 pub type CLAIMPLETE_3 = crate::Reg<claimplete_3::CLAIMPLETE_3_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 3"]
 pub mod claimplete_3;
-#[doc = "threshold_4 (rw) register accessor: PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_4`]
+#[doc = "threshold_4 (rw) register accessor: PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@threshold_4`]
 module"]
 pub type THRESHOLD_4 = crate::Reg<threshold_4::THRESHOLD_4_SPEC>;
 #[doc = "PRIORITY THRESHOLD Register for hart 4"]
 pub mod threshold_4;
-#[doc = "claimplete_4 (rw) register accessor: CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_4`]
+#[doc = "claimplete_4 (rw) register accessor: CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@claimplete_4`]
 module"]
 pub type CLAIMPLETE_4 = crate::Reg<claimplete_4::CLAIMPLETE_4_SPEC>;
 #[doc = "CLAIM and COMPLETE Register for hart 4"]

--- a/jh7110-vf2-13b-pac/src/plic/claimplete_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/claimplete_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_0_SPEC>;
 #[doc = "Register `claimplete_0` writer"]
 pub type W = crate::W<CLAIMPLETE_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_0_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_0_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_0_SPEC {}
 impl crate::Writable for CLAIMPLETE_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_0 to value 0"]
+impl crate::Resettable for CLAIMPLETE_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/claimplete_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/claimplete_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_1_SPEC>;
 #[doc = "Register `claimplete_1` writer"]
 pub type W = crate::W<CLAIMPLETE_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_1_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_1_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_1_SPEC {}
 impl crate::Writable for CLAIMPLETE_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_1 to value 0"]
+impl crate::Resettable for CLAIMPLETE_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/claimplete_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/claimplete_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_2_SPEC>;
 #[doc = "Register `claimplete_2` writer"]
 pub type W = crate::W<CLAIMPLETE_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_2_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_2_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_2_SPEC {}
 impl crate::Writable for CLAIMPLETE_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_2 to value 0"]
+impl crate::Resettable for CLAIMPLETE_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/claimplete_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/claimplete_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_3_SPEC>;
 #[doc = "Register `claimplete_3` writer"]
 pub type W = crate::W<CLAIMPLETE_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_3_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_3_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_3_SPEC {}
 impl crate::Writable for CLAIMPLETE_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_3 to value 0"]
+impl crate::Resettable for CLAIMPLETE_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/claimplete_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/claimplete_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<CLAIMPLETE_4_SPEC>;
 #[doc = "Register `claimplete_4` writer"]
 pub type W = crate::W<CLAIMPLETE_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<CLAIMPLETE_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `claimplete` reader - "]
+pub type CLAIMPLETE_R = crate::FieldReader<u32>;
+#[doc = "Field `claimplete` writer - "]
+pub type CLAIMPLETE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn claimplete(&self) -> CLAIMPLETE_R {
+        CLAIMPLETE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn claimplete(&mut self) -> CLAIMPLETE_W<CLAIMPLETE_4_SPEC> {
+        CLAIMPLETE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CLAIM and COMPLETE Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`claimplete_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`claimplete_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLAIMPLETE_4_SPEC;
 impl crate::RegisterSpec for CLAIMPLETE_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for CLAIMPLETE_4_SPEC {}
 impl crate::Writable for CLAIMPLETE_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets claimplete_4 to value 0"]
+impl crate::Resettable for CLAIMPLETE_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_0_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_0_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_0_SPEC>;
 #[doc = "Register `enable_0_0` writer"]
 pub type W = crate::W<ENABLE_0_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_0_SPEC;
 impl crate::RegisterSpec for ENABLE_0_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_0_SPEC {}
 impl crate::Writable for ENABLE_0_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_0 to value 0"]
+impl crate::Resettable for ENABLE_0_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_0_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_0_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_1_SPEC>;
 #[doc = "Register `enable_0_1` writer"]
 pub type W = crate::W<ENABLE_0_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_1_SPEC;
 impl crate::RegisterSpec for ENABLE_0_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_1_SPEC {}
 impl crate::Writable for ENABLE_0_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_1 to value 0"]
+impl crate::Resettable for ENABLE_0_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_0_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_0_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_2_SPEC>;
 #[doc = "Register `enable_0_2` writer"]
 pub type W = crate::W<ENABLE_0_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_2_SPEC;
 impl crate::RegisterSpec for ENABLE_0_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_2_SPEC {}
 impl crate::Writable for ENABLE_0_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_2 to value 0"]
+impl crate::Resettable for ENABLE_0_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_0_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_0_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_3_SPEC>;
 #[doc = "Register `enable_0_3` writer"]
 pub type W = crate::W<ENABLE_0_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_3_SPEC;
 impl crate::RegisterSpec for ENABLE_0_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_3_SPEC {}
 impl crate::Writable for ENABLE_0_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_3 to value 0"]
+impl crate::Resettable for ENABLE_0_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_0_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_0_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_0_4_SPEC>;
 #[doc = "Register `enable_0_4` writer"]
 pub type W = crate::W<ENABLE_0_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_0_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_0_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 31 to 0 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_0_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_0_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_0_4_SPEC;
 impl crate::RegisterSpec for ENABLE_0_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_0_4_SPEC {}
 impl crate::Writable for ENABLE_0_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_0_4 to value 0"]
+impl crate::Resettable for ENABLE_0_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_1_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_1_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_0_SPEC>;
 #[doc = "Register `enable_1_0` writer"]
 pub type W = crate::W<ENABLE_1_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_0_SPEC;
 impl crate::RegisterSpec for ENABLE_1_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_0_SPEC {}
 impl crate::Writable for ENABLE_1_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_0 to value 0"]
+impl crate::Resettable for ENABLE_1_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_1_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_1_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_1_SPEC>;
 #[doc = "Register `enable_1_1` writer"]
 pub type W = crate::W<ENABLE_1_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_1_SPEC;
 impl crate::RegisterSpec for ENABLE_1_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_1_SPEC {}
 impl crate::Writable for ENABLE_1_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_1 to value 0"]
+impl crate::Resettable for ENABLE_1_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_1_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_1_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_2_SPEC>;
 #[doc = "Register `enable_1_2` writer"]
 pub type W = crate::W<ENABLE_1_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_2_SPEC;
 impl crate::RegisterSpec for ENABLE_1_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_2_SPEC {}
 impl crate::Writable for ENABLE_1_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_2 to value 0"]
+impl crate::Resettable for ENABLE_1_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_1_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_1_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_3_SPEC>;
 #[doc = "Register `enable_1_3` writer"]
 pub type W = crate::W<ENABLE_1_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_3_SPEC;
 impl crate::RegisterSpec for ENABLE_1_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_3_SPEC {}
 impl crate::Writable for ENABLE_1_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_3 to value 0"]
+impl crate::Resettable for ENABLE_1_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_1_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_1_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_1_4_SPEC>;
 #[doc = "Register `enable_1_4` writer"]
 pub type W = crate::W<ENABLE_1_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_1_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_1_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 63 to 32 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_1_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_1_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_1_4_SPEC;
 impl crate::RegisterSpec for ENABLE_1_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_1_4_SPEC {}
 impl crate::Writable for ENABLE_1_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_1_4 to value 0"]
+impl crate::Resettable for ENABLE_1_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_2_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_2_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_0_SPEC>;
 #[doc = "Register `enable_2_0` writer"]
 pub type W = crate::W<ENABLE_2_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_0_SPEC;
 impl crate::RegisterSpec for ENABLE_2_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_0_SPEC {}
 impl crate::Writable for ENABLE_2_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_0 to value 0"]
+impl crate::Resettable for ENABLE_2_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_2_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_2_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_1_SPEC>;
 #[doc = "Register `enable_2_1` writer"]
 pub type W = crate::W<ENABLE_2_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_1_SPEC;
 impl crate::RegisterSpec for ENABLE_2_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_1_SPEC {}
 impl crate::Writable for ENABLE_2_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_1 to value 0"]
+impl crate::Resettable for ENABLE_2_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_2_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_2_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_2_SPEC>;
 #[doc = "Register `enable_2_2` writer"]
 pub type W = crate::W<ENABLE_2_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_2_SPEC;
 impl crate::RegisterSpec for ENABLE_2_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_2_SPEC {}
 impl crate::Writable for ENABLE_2_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_2 to value 0"]
+impl crate::Resettable for ENABLE_2_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_2_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_2_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_3_SPEC>;
 #[doc = "Register `enable_2_3` writer"]
 pub type W = crate::W<ENABLE_2_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_3_SPEC;
 impl crate::RegisterSpec for ENABLE_2_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_3_SPEC {}
 impl crate::Writable for ENABLE_2_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_3 to value 0"]
+impl crate::Resettable for ENABLE_2_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_2_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_2_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_2_4_SPEC>;
 #[doc = "Register `enable_2_4` writer"]
 pub type W = crate::W<ENABLE_2_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_2_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_2_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 95 to 64 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_2_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_2_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_2_4_SPEC;
 impl crate::RegisterSpec for ENABLE_2_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_2_4_SPEC {}
 impl crate::Writable for ENABLE_2_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_2_4 to value 0"]
+impl crate::Resettable for ENABLE_2_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_3_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_3_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_0_SPEC>;
 #[doc = "Register `enable_3_0` writer"]
 pub type W = crate::W<ENABLE_3_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_0_SPEC;
 impl crate::RegisterSpec for ENABLE_3_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_0_SPEC {}
 impl crate::Writable for ENABLE_3_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_0 to value 0"]
+impl crate::Resettable for ENABLE_3_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_3_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_3_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_1_SPEC>;
 #[doc = "Register `enable_3_1` writer"]
 pub type W = crate::W<ENABLE_3_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_1_SPEC;
 impl crate::RegisterSpec for ENABLE_3_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_1_SPEC {}
 impl crate::Writable for ENABLE_3_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_1 to value 0"]
+impl crate::Resettable for ENABLE_3_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_3_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_3_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_2_SPEC>;
 #[doc = "Register `enable_3_2` writer"]
 pub type W = crate::W<ENABLE_3_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_2_SPEC;
 impl crate::RegisterSpec for ENABLE_3_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_2_SPEC {}
 impl crate::Writable for ENABLE_3_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_2 to value 0"]
+impl crate::Resettable for ENABLE_3_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_3_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_3_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_3_SPEC>;
 #[doc = "Register `enable_3_3` writer"]
 pub type W = crate::W<ENABLE_3_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_3_SPEC;
 impl crate::RegisterSpec for ENABLE_3_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_3_SPEC {}
 impl crate::Writable for ENABLE_3_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_3 to value 0"]
+impl crate::Resettable for ENABLE_3_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_3_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_3_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_3_4_SPEC>;
 #[doc = "Register `enable_3_4` writer"]
 pub type W = crate::W<ENABLE_3_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_3_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_3_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 127 to 96 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_3_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_3_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_3_4_SPEC;
 impl crate::RegisterSpec for ENABLE_3_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_3_4_SPEC {}
 impl crate::Writable for ENABLE_3_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_3_4 to value 0"]
+impl crate::Resettable for ENABLE_3_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_4_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_4_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_0_SPEC>;
 #[doc = "Register `enable_4_0` writer"]
 pub type W = crate::W<ENABLE_4_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_0_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_0_SPEC;
 impl crate::RegisterSpec for ENABLE_4_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_0_SPEC {}
 impl crate::Writable for ENABLE_4_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_0 to value 0"]
+impl crate::Resettable for ENABLE_4_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_4_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_4_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_1_SPEC>;
 #[doc = "Register `enable_4_1` writer"]
 pub type W = crate::W<ENABLE_4_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_1_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_1_SPEC;
 impl crate::RegisterSpec for ENABLE_4_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_1_SPEC {}
 impl crate::Writable for ENABLE_4_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_1 to value 0"]
+impl crate::Resettable for ENABLE_4_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_4_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_4_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_2_SPEC>;
 #[doc = "Register `enable_4_2` writer"]
 pub type W = crate::W<ENABLE_4_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_2_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_2_SPEC;
 impl crate::RegisterSpec for ENABLE_4_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_2_SPEC {}
 impl crate::Writable for ENABLE_4_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_2 to value 0"]
+impl crate::Resettable for ENABLE_4_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_4_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_4_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_3_SPEC>;
 #[doc = "Register `enable_4_3` writer"]
 pub type W = crate::W<ENABLE_4_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_3_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_3_SPEC;
 impl crate::RegisterSpec for ENABLE_4_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_3_SPEC {}
 impl crate::Writable for ENABLE_4_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_3 to value 0"]
+impl crate::Resettable for ENABLE_4_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/enable_4_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/enable_4_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<ENABLE_4_4_SPEC>;
 #[doc = "Register `enable_4_4` writer"]
 pub type W = crate::W<ENABLE_4_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<ENABLE_4_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `enable` reader - "]
+pub type ENABLE_R = crate::FieldReader<u32>;
+#[doc = "Field `enable` writer - "]
+pub type ENABLE_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn enable(&mut self) -> ENABLE_W<ENABLE_4_4_SPEC> {
+        ENABLE_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "ENABLE Register for interrupt ids 136 to 128 for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`enable_4_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`enable_4_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct ENABLE_4_4_SPEC;
 impl crate::RegisterSpec for ENABLE_4_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for ENABLE_4_4_SPEC {}
 impl crate::Writable for ENABLE_4_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets enable_4_4 to value 0"]
+impl crate::Resettable for ENABLE_4_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/pending_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/pending_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_0_SPEC>;
 #[doc = "Register `pending_0` writer"]
 pub type W = crate::W<PENDING_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_0_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 31 to 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_0_SPEC;
 impl crate::RegisterSpec for PENDING_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_0_SPEC {}
 impl crate::Writable for PENDING_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_0 to value 0"]
+impl crate::Resettable for PENDING_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/pending_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/pending_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_1_SPEC>;
 #[doc = "Register `pending_1` writer"]
 pub type W = crate::W<PENDING_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_1_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 63 to 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_1_SPEC;
 impl crate::RegisterSpec for PENDING_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_1_SPEC {}
 impl crate::Writable for PENDING_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_1 to value 0"]
+impl crate::Resettable for PENDING_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/pending_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/pending_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_2_SPEC>;
 #[doc = "Register `pending_2` writer"]
 pub type W = crate::W<PENDING_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_2_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 95 to 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_2_SPEC;
 impl crate::RegisterSpec for PENDING_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_2_SPEC {}
 impl crate::Writable for PENDING_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_2 to value 0"]
+impl crate::Resettable for PENDING_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/pending_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/pending_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_3_SPEC>;
 #[doc = "Register `pending_3` writer"]
 pub type W = crate::W<PENDING_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_3_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 127 to 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_3_SPEC;
 impl crate::RegisterSpec for PENDING_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_3_SPEC {}
 impl crate::Writable for PENDING_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_3 to value 0"]
+impl crate::Resettable for PENDING_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/pending_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/pending_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PENDING_4_SPEC>;
 #[doc = "Register `pending_4` writer"]
 pub type W = crate::W<PENDING_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PENDING_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `pending` reader - "]
+pub type PENDING_R = crate::FieldReader<u32>;
+#[doc = "Field `pending` writer - "]
+pub type PENDING_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn pending(&self) -> PENDING_R {
+        PENDING_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn pending(&mut self) -> PENDING_W<PENDING_4_SPEC> {
+        PENDING_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PENDING Register for interrupt ids 136 to 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`pending_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`pending_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PENDING_4_SPEC;
 impl crate::RegisterSpec for PENDING_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PENDING_4_SPEC {}
 impl crate::Writable for PENDING_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets pending_4 to value 0"]
+impl crate::Resettable for PENDING_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_1_SPEC>;
 #[doc = "Register `priority_1` writer"]
 pub type W = crate::W<PRIORITY_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_1_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_1_SPEC;
 impl crate::RegisterSpec for PRIORITY_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_1_SPEC {}
 impl crate::Writable for PRIORITY_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_1 to value 0"]
+impl crate::Resettable for PRIORITY_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_10.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_10.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_10_SPEC>;
 #[doc = "Register `priority_10` writer"]
 pub type W = crate::W<PRIORITY_10_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_10_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_10_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 10\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_10::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_10_SPEC;
 impl crate::RegisterSpec for PRIORITY_10_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_10_SPEC {}
 impl crate::Writable for PRIORITY_10_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_10 to value 0"]
+impl crate::Resettable for PRIORITY_10_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_100.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_100.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_100_SPEC>;
 #[doc = "Register `priority_100` writer"]
 pub type W = crate::W<PRIORITY_100_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_100_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_100_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 100\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_100::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_100::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_100_SPEC;
 impl crate::RegisterSpec for PRIORITY_100_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_100_SPEC {}
 impl crate::Writable for PRIORITY_100_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_100 to value 0"]
+impl crate::Resettable for PRIORITY_100_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_101.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_101.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_101_SPEC>;
 #[doc = "Register `priority_101` writer"]
 pub type W = crate::W<PRIORITY_101_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_101_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_101_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 101\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_101::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_101::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_101_SPEC;
 impl crate::RegisterSpec for PRIORITY_101_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_101_SPEC {}
 impl crate::Writable for PRIORITY_101_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_101 to value 0"]
+impl crate::Resettable for PRIORITY_101_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_102.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_102.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_102_SPEC>;
 #[doc = "Register `priority_102` writer"]
 pub type W = crate::W<PRIORITY_102_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_102_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_102_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 102\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_102::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_102::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_102_SPEC;
 impl crate::RegisterSpec for PRIORITY_102_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_102_SPEC {}
 impl crate::Writable for PRIORITY_102_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_102 to value 0"]
+impl crate::Resettable for PRIORITY_102_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_103.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_103.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_103_SPEC>;
 #[doc = "Register `priority_103` writer"]
 pub type W = crate::W<PRIORITY_103_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_103_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_103_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 103\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_103::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_103::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_103_SPEC;
 impl crate::RegisterSpec for PRIORITY_103_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_103_SPEC {}
 impl crate::Writable for PRIORITY_103_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_103 to value 0"]
+impl crate::Resettable for PRIORITY_103_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_104.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_104.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_104_SPEC>;
 #[doc = "Register `priority_104` writer"]
 pub type W = crate::W<PRIORITY_104_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_104_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_104_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 104\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_104::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_104::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_104_SPEC;
 impl crate::RegisterSpec for PRIORITY_104_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_104_SPEC {}
 impl crate::Writable for PRIORITY_104_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_104 to value 0"]
+impl crate::Resettable for PRIORITY_104_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_105.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_105.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_105_SPEC>;
 #[doc = "Register `priority_105` writer"]
 pub type W = crate::W<PRIORITY_105_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_105_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_105_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 105\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_105::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_105::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_105_SPEC;
 impl crate::RegisterSpec for PRIORITY_105_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_105_SPEC {}
 impl crate::Writable for PRIORITY_105_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_105 to value 0"]
+impl crate::Resettable for PRIORITY_105_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_106.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_106.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_106_SPEC>;
 #[doc = "Register `priority_106` writer"]
 pub type W = crate::W<PRIORITY_106_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_106_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_106_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 106\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_106::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_106::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_106_SPEC;
 impl crate::RegisterSpec for PRIORITY_106_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_106_SPEC {}
 impl crate::Writable for PRIORITY_106_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_106 to value 0"]
+impl crate::Resettable for PRIORITY_106_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_107.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_107.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_107_SPEC>;
 #[doc = "Register `priority_107` writer"]
 pub type W = crate::W<PRIORITY_107_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_107_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_107_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 107\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_107::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_107::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_107_SPEC;
 impl crate::RegisterSpec for PRIORITY_107_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_107_SPEC {}
 impl crate::Writable for PRIORITY_107_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_107 to value 0"]
+impl crate::Resettable for PRIORITY_107_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_108.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_108.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_108_SPEC>;
 #[doc = "Register `priority_108` writer"]
 pub type W = crate::W<PRIORITY_108_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_108_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_108_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 108\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_108::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_108::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_108_SPEC;
 impl crate::RegisterSpec for PRIORITY_108_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_108_SPEC {}
 impl crate::Writable for PRIORITY_108_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_108 to value 0"]
+impl crate::Resettable for PRIORITY_108_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_109.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_109.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_109_SPEC>;
 #[doc = "Register `priority_109` writer"]
 pub type W = crate::W<PRIORITY_109_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_109_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_109_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 109\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_109::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_109::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_109_SPEC;
 impl crate::RegisterSpec for PRIORITY_109_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_109_SPEC {}
 impl crate::Writable for PRIORITY_109_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_109 to value 0"]
+impl crate::Resettable for PRIORITY_109_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_11.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_11.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_11_SPEC>;
 #[doc = "Register `priority_11` writer"]
 pub type W = crate::W<PRIORITY_11_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_11_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_11_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 11\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_11::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_11_SPEC;
 impl crate::RegisterSpec for PRIORITY_11_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_11_SPEC {}
 impl crate::Writable for PRIORITY_11_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_11 to value 0"]
+impl crate::Resettable for PRIORITY_11_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_110.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_110.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_110_SPEC>;
 #[doc = "Register `priority_110` writer"]
 pub type W = crate::W<PRIORITY_110_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_110_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_110_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 110\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_110::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_110::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_110_SPEC;
 impl crate::RegisterSpec for PRIORITY_110_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_110_SPEC {}
 impl crate::Writable for PRIORITY_110_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_110 to value 0"]
+impl crate::Resettable for PRIORITY_110_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_111.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_111.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_111_SPEC>;
 #[doc = "Register `priority_111` writer"]
 pub type W = crate::W<PRIORITY_111_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_111_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_111_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 111\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_111::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_111::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_111_SPEC;
 impl crate::RegisterSpec for PRIORITY_111_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_111_SPEC {}
 impl crate::Writable for PRIORITY_111_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_111 to value 0"]
+impl crate::Resettable for PRIORITY_111_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_112.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_112.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_112_SPEC>;
 #[doc = "Register `priority_112` writer"]
 pub type W = crate::W<PRIORITY_112_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_112_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_112_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 112\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_112::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_112::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_112_SPEC;
 impl crate::RegisterSpec for PRIORITY_112_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_112_SPEC {}
 impl crate::Writable for PRIORITY_112_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_112 to value 0"]
+impl crate::Resettable for PRIORITY_112_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_113.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_113.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_113_SPEC>;
 #[doc = "Register `priority_113` writer"]
 pub type W = crate::W<PRIORITY_113_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_113_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_113_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 113\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_113::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_113::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_113_SPEC;
 impl crate::RegisterSpec for PRIORITY_113_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_113_SPEC {}
 impl crate::Writable for PRIORITY_113_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_113 to value 0"]
+impl crate::Resettable for PRIORITY_113_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_114.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_114.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_114_SPEC>;
 #[doc = "Register `priority_114` writer"]
 pub type W = crate::W<PRIORITY_114_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_114_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_114_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 114\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_114::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_114::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_114_SPEC;
 impl crate::RegisterSpec for PRIORITY_114_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_114_SPEC {}
 impl crate::Writable for PRIORITY_114_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_114 to value 0"]
+impl crate::Resettable for PRIORITY_114_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_115.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_115.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_115_SPEC>;
 #[doc = "Register `priority_115` writer"]
 pub type W = crate::W<PRIORITY_115_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_115_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_115_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 115\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_115::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_115::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_115_SPEC;
 impl crate::RegisterSpec for PRIORITY_115_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_115_SPEC {}
 impl crate::Writable for PRIORITY_115_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_115 to value 0"]
+impl crate::Resettable for PRIORITY_115_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_116.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_116.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_116_SPEC>;
 #[doc = "Register `priority_116` writer"]
 pub type W = crate::W<PRIORITY_116_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_116_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_116_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 116\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_116::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_116::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_116_SPEC;
 impl crate::RegisterSpec for PRIORITY_116_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_116_SPEC {}
 impl crate::Writable for PRIORITY_116_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_116 to value 0"]
+impl crate::Resettable for PRIORITY_116_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_117.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_117.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_117_SPEC>;
 #[doc = "Register `priority_117` writer"]
 pub type W = crate::W<PRIORITY_117_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_117_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_117_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 117\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_117::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_117::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_117_SPEC;
 impl crate::RegisterSpec for PRIORITY_117_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_117_SPEC {}
 impl crate::Writable for PRIORITY_117_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_117 to value 0"]
+impl crate::Resettable for PRIORITY_117_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_118.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_118.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_118_SPEC>;
 #[doc = "Register `priority_118` writer"]
 pub type W = crate::W<PRIORITY_118_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_118_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_118_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 118\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_118::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_118::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_118_SPEC;
 impl crate::RegisterSpec for PRIORITY_118_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_118_SPEC {}
 impl crate::Writable for PRIORITY_118_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_118 to value 0"]
+impl crate::Resettable for PRIORITY_118_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_119.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_119.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_119_SPEC>;
 #[doc = "Register `priority_119` writer"]
 pub type W = crate::W<PRIORITY_119_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_119_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_119_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 119\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_119::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_119::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_119_SPEC;
 impl crate::RegisterSpec for PRIORITY_119_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_119_SPEC {}
 impl crate::Writable for PRIORITY_119_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_119 to value 0"]
+impl crate::Resettable for PRIORITY_119_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_12.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_12.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_12_SPEC>;
 #[doc = "Register `priority_12` writer"]
 pub type W = crate::W<PRIORITY_12_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_12_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_12_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 12\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_12::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_12_SPEC;
 impl crate::RegisterSpec for PRIORITY_12_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_12_SPEC {}
 impl crate::Writable for PRIORITY_12_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_12 to value 0"]
+impl crate::Resettable for PRIORITY_12_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_120.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_120.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_120_SPEC>;
 #[doc = "Register `priority_120` writer"]
 pub type W = crate::W<PRIORITY_120_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_120_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_120_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 120\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_120::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_120::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_120_SPEC;
 impl crate::RegisterSpec for PRIORITY_120_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_120_SPEC {}
 impl crate::Writable for PRIORITY_120_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_120 to value 0"]
+impl crate::Resettable for PRIORITY_120_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_121.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_121.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_121_SPEC>;
 #[doc = "Register `priority_121` writer"]
 pub type W = crate::W<PRIORITY_121_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_121_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_121_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 121\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_121::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_121::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_121_SPEC;
 impl crate::RegisterSpec for PRIORITY_121_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_121_SPEC {}
 impl crate::Writable for PRIORITY_121_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_121 to value 0"]
+impl crate::Resettable for PRIORITY_121_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_122.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_122.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_122_SPEC>;
 #[doc = "Register `priority_122` writer"]
 pub type W = crate::W<PRIORITY_122_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_122_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_122_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 122\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_122::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_122::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_122_SPEC;
 impl crate::RegisterSpec for PRIORITY_122_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_122_SPEC {}
 impl crate::Writable for PRIORITY_122_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_122 to value 0"]
+impl crate::Resettable for PRIORITY_122_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_123.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_123.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_123_SPEC>;
 #[doc = "Register `priority_123` writer"]
 pub type W = crate::W<PRIORITY_123_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_123_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_123_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 123\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_123::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_123::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_123_SPEC;
 impl crate::RegisterSpec for PRIORITY_123_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_123_SPEC {}
 impl crate::Writable for PRIORITY_123_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_123 to value 0"]
+impl crate::Resettable for PRIORITY_123_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_124.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_124.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_124_SPEC>;
 #[doc = "Register `priority_124` writer"]
 pub type W = crate::W<PRIORITY_124_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_124_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_124_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 124\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_124::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_124::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_124_SPEC;
 impl crate::RegisterSpec for PRIORITY_124_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_124_SPEC {}
 impl crate::Writable for PRIORITY_124_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_124 to value 0"]
+impl crate::Resettable for PRIORITY_124_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_125.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_125.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_125_SPEC>;
 #[doc = "Register `priority_125` writer"]
 pub type W = crate::W<PRIORITY_125_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_125_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_125_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_125::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_125_SPEC;
 impl crate::RegisterSpec for PRIORITY_125_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_125_SPEC {}
 impl crate::Writable for PRIORITY_125_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_125 to value 0"]
+impl crate::Resettable for PRIORITY_125_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_126.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_126.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_126_SPEC>;
 #[doc = "Register `priority_126` writer"]
 pub type W = crate::W<PRIORITY_126_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_126_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_126_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 126\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_126::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_126::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_126_SPEC;
 impl crate::RegisterSpec for PRIORITY_126_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_126_SPEC {}
 impl crate::Writable for PRIORITY_126_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_126 to value 0"]
+impl crate::Resettable for PRIORITY_126_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_127.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_127.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_127_SPEC>;
 #[doc = "Register `priority_127` writer"]
 pub type W = crate::W<PRIORITY_127_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_127_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_127_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 127\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_127::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_127::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_127_SPEC;
 impl crate::RegisterSpec for PRIORITY_127_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_127_SPEC {}
 impl crate::Writable for PRIORITY_127_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_127 to value 0"]
+impl crate::Resettable for PRIORITY_127_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_128.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_128.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_128_SPEC>;
 #[doc = "Register `priority_128` writer"]
 pub type W = crate::W<PRIORITY_128_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_128_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_128_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 128\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_128::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_128::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_128_SPEC;
 impl crate::RegisterSpec for PRIORITY_128_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_128_SPEC {}
 impl crate::Writable for PRIORITY_128_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_128 to value 0"]
+impl crate::Resettable for PRIORITY_128_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_129.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_129.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_129_SPEC>;
 #[doc = "Register `priority_129` writer"]
 pub type W = crate::W<PRIORITY_129_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_129_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_129_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 129\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_129::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_129::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_129_SPEC;
 impl crate::RegisterSpec for PRIORITY_129_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_129_SPEC {}
 impl crate::Writable for PRIORITY_129_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_129 to value 0"]
+impl crate::Resettable for PRIORITY_129_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_13.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_13.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_13_SPEC>;
 #[doc = "Register `priority_13` writer"]
 pub type W = crate::W<PRIORITY_13_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_13_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_13_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 13\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_13::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_13_SPEC;
 impl crate::RegisterSpec for PRIORITY_13_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_13_SPEC {}
 impl crate::Writable for PRIORITY_13_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_13 to value 0"]
+impl crate::Resettable for PRIORITY_13_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_130.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_130.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_130_SPEC>;
 #[doc = "Register `priority_130` writer"]
 pub type W = crate::W<PRIORITY_130_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_130_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_130_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 130\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_130::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_130::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_130_SPEC;
 impl crate::RegisterSpec for PRIORITY_130_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_130_SPEC {}
 impl crate::Writable for PRIORITY_130_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_130 to value 0"]
+impl crate::Resettable for PRIORITY_130_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_131.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_131.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_131_SPEC>;
 #[doc = "Register `priority_131` writer"]
 pub type W = crate::W<PRIORITY_131_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_131_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_131_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 131\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_131::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_131::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_131_SPEC;
 impl crate::RegisterSpec for PRIORITY_131_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_131_SPEC {}
 impl crate::Writable for PRIORITY_131_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_131 to value 0"]
+impl crate::Resettable for PRIORITY_131_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_132.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_132.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_132_SPEC>;
 #[doc = "Register `priority_132` writer"]
 pub type W = crate::W<PRIORITY_132_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_132_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_132_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 132\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_132::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_132::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_132_SPEC;
 impl crate::RegisterSpec for PRIORITY_132_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_132_SPEC {}
 impl crate::Writable for PRIORITY_132_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_132 to value 0"]
+impl crate::Resettable for PRIORITY_132_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_133.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_133.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_133_SPEC>;
 #[doc = "Register `priority_133` writer"]
 pub type W = crate::W<PRIORITY_133_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_133_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_133_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 133\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_133::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_133::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_133_SPEC;
 impl crate::RegisterSpec for PRIORITY_133_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_133_SPEC {}
 impl crate::Writable for PRIORITY_133_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_133 to value 0"]
+impl crate::Resettable for PRIORITY_133_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_134.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_134.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_134_SPEC>;
 #[doc = "Register `priority_134` writer"]
 pub type W = crate::W<PRIORITY_134_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_134_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_134_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 134\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_134::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_134::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_134_SPEC;
 impl crate::RegisterSpec for PRIORITY_134_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_134_SPEC {}
 impl crate::Writable for PRIORITY_134_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_134 to value 0"]
+impl crate::Resettable for PRIORITY_134_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_135.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_135.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_135_SPEC>;
 #[doc = "Register `priority_135` writer"]
 pub type W = crate::W<PRIORITY_135_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_135_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_135_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 135\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_135::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_135::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_135_SPEC;
 impl crate::RegisterSpec for PRIORITY_135_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_135_SPEC {}
 impl crate::Writable for PRIORITY_135_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_135 to value 0"]
+impl crate::Resettable for PRIORITY_135_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_136.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_136.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_136_SPEC>;
 #[doc = "Register `priority_136` writer"]
 pub type W = crate::W<PRIORITY_136_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_136_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_136_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 136\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_136::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_136::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_136_SPEC;
 impl crate::RegisterSpec for PRIORITY_136_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_136_SPEC {}
 impl crate::Writable for PRIORITY_136_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_136 to value 0"]
+impl crate::Resettable for PRIORITY_136_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_14.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_14.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_14_SPEC>;
 #[doc = "Register `priority_14` writer"]
 pub type W = crate::W<PRIORITY_14_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_14_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_14_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 14\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_14::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_14_SPEC;
 impl crate::RegisterSpec for PRIORITY_14_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_14_SPEC {}
 impl crate::Writable for PRIORITY_14_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_14 to value 0"]
+impl crate::Resettable for PRIORITY_14_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_15.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_15.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_15_SPEC>;
 #[doc = "Register `priority_15` writer"]
 pub type W = crate::W<PRIORITY_15_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_15_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_15_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 15\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_15::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_15_SPEC;
 impl crate::RegisterSpec for PRIORITY_15_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_15_SPEC {}
 impl crate::Writable for PRIORITY_15_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_15 to value 0"]
+impl crate::Resettable for PRIORITY_15_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_16.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_16.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_16_SPEC>;
 #[doc = "Register `priority_16` writer"]
 pub type W = crate::W<PRIORITY_16_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_16_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_16_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 16\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_16::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_16::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_16_SPEC;
 impl crate::RegisterSpec for PRIORITY_16_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_16_SPEC {}
 impl crate::Writable for PRIORITY_16_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_16 to value 0"]
+impl crate::Resettable for PRIORITY_16_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_17.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_17.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_17_SPEC>;
 #[doc = "Register `priority_17` writer"]
 pub type W = crate::W<PRIORITY_17_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_17_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_17_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 17\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_17::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_17::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_17_SPEC;
 impl crate::RegisterSpec for PRIORITY_17_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_17_SPEC {}
 impl crate::Writable for PRIORITY_17_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_17 to value 0"]
+impl crate::Resettable for PRIORITY_17_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_18.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_18.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_18_SPEC>;
 #[doc = "Register `priority_18` writer"]
 pub type W = crate::W<PRIORITY_18_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_18_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_18_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 18\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_18::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_18::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_18_SPEC;
 impl crate::RegisterSpec for PRIORITY_18_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_18_SPEC {}
 impl crate::Writable for PRIORITY_18_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_18 to value 0"]
+impl crate::Resettable for PRIORITY_18_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_19.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_19.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_19_SPEC>;
 #[doc = "Register `priority_19` writer"]
 pub type W = crate::W<PRIORITY_19_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_19_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_19_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 19\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_19::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_19::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_19_SPEC;
 impl crate::RegisterSpec for PRIORITY_19_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_19_SPEC {}
 impl crate::Writable for PRIORITY_19_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_19 to value 0"]
+impl crate::Resettable for PRIORITY_19_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_2_SPEC>;
 #[doc = "Register `priority_2` writer"]
 pub type W = crate::W<PRIORITY_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_2_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_2_SPEC;
 impl crate::RegisterSpec for PRIORITY_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_2_SPEC {}
 impl crate::Writable for PRIORITY_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_2 to value 0"]
+impl crate::Resettable for PRIORITY_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_20.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_20.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_20_SPEC>;
 #[doc = "Register `priority_20` writer"]
 pub type W = crate::W<PRIORITY_20_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_20_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_20_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 20\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_20::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_20::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_20_SPEC;
 impl crate::RegisterSpec for PRIORITY_20_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_20_SPEC {}
 impl crate::Writable for PRIORITY_20_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_20 to value 0"]
+impl crate::Resettable for PRIORITY_20_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_21.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_21.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_21_SPEC>;
 #[doc = "Register `priority_21` writer"]
 pub type W = crate::W<PRIORITY_21_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_21_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_21_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 21\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_21::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_21::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_21_SPEC;
 impl crate::RegisterSpec for PRIORITY_21_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_21_SPEC {}
 impl crate::Writable for PRIORITY_21_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_21 to value 0"]
+impl crate::Resettable for PRIORITY_21_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_22.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_22.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_22_SPEC>;
 #[doc = "Register `priority_22` writer"]
 pub type W = crate::W<PRIORITY_22_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_22_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_22_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 22\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_22::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_22::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_22_SPEC;
 impl crate::RegisterSpec for PRIORITY_22_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_22_SPEC {}
 impl crate::Writable for PRIORITY_22_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_22 to value 0"]
+impl crate::Resettable for PRIORITY_22_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_23.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_23.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_23_SPEC>;
 #[doc = "Register `priority_23` writer"]
 pub type W = crate::W<PRIORITY_23_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_23_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_23_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 23\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_23::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_23::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_23_SPEC;
 impl crate::RegisterSpec for PRIORITY_23_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_23_SPEC {}
 impl crate::Writable for PRIORITY_23_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_23 to value 0"]
+impl crate::Resettable for PRIORITY_23_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_24.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_24.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_24_SPEC>;
 #[doc = "Register `priority_24` writer"]
 pub type W = crate::W<PRIORITY_24_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_24_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_24_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 24\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_24::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_24::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_24_SPEC;
 impl crate::RegisterSpec for PRIORITY_24_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_24_SPEC {}
 impl crate::Writable for PRIORITY_24_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_24 to value 0"]
+impl crate::Resettable for PRIORITY_24_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_25.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_25.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_25_SPEC>;
 #[doc = "Register `priority_25` writer"]
 pub type W = crate::W<PRIORITY_25_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_25_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_25_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 25\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_25::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_25::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_25_SPEC;
 impl crate::RegisterSpec for PRIORITY_25_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_25_SPEC {}
 impl crate::Writable for PRIORITY_25_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_25 to value 0"]
+impl crate::Resettable for PRIORITY_25_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_26.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_26.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_26_SPEC>;
 #[doc = "Register `priority_26` writer"]
 pub type W = crate::W<PRIORITY_26_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_26_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_26_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 26\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_26::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_26::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_26_SPEC;
 impl crate::RegisterSpec for PRIORITY_26_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_26_SPEC {}
 impl crate::Writable for PRIORITY_26_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_26 to value 0"]
+impl crate::Resettable for PRIORITY_26_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_27.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_27.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_27_SPEC>;
 #[doc = "Register `priority_27` writer"]
 pub type W = crate::W<PRIORITY_27_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_27_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_27_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 27\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_27::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_27::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_27_SPEC;
 impl crate::RegisterSpec for PRIORITY_27_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_27_SPEC {}
 impl crate::Writable for PRIORITY_27_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_27 to value 0"]
+impl crate::Resettable for PRIORITY_27_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_28.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_28.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_28_SPEC>;
 #[doc = "Register `priority_28` writer"]
 pub type W = crate::W<PRIORITY_28_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_28_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_28_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 28\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_28::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_28::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_28_SPEC;
 impl crate::RegisterSpec for PRIORITY_28_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_28_SPEC {}
 impl crate::Writable for PRIORITY_28_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_28 to value 0"]
+impl crate::Resettable for PRIORITY_28_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_29.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_29.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_29_SPEC>;
 #[doc = "Register `priority_29` writer"]
 pub type W = crate::W<PRIORITY_29_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_29_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_29_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 29\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_29::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_29::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_29_SPEC;
 impl crate::RegisterSpec for PRIORITY_29_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_29_SPEC {}
 impl crate::Writable for PRIORITY_29_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_29 to value 0"]
+impl crate::Resettable for PRIORITY_29_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_3_SPEC>;
 #[doc = "Register `priority_3` writer"]
 pub type W = crate::W<PRIORITY_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_3_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_3_SPEC;
 impl crate::RegisterSpec for PRIORITY_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_3_SPEC {}
 impl crate::Writable for PRIORITY_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_3 to value 0"]
+impl crate::Resettable for PRIORITY_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_30.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_30.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_30_SPEC>;
 #[doc = "Register `priority_30` writer"]
 pub type W = crate::W<PRIORITY_30_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_30_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_30_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 30\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_30::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_30::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_30_SPEC;
 impl crate::RegisterSpec for PRIORITY_30_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_30_SPEC {}
 impl crate::Writable for PRIORITY_30_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_30 to value 0"]
+impl crate::Resettable for PRIORITY_30_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_31.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_31.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_31_SPEC>;
 #[doc = "Register `priority_31` writer"]
 pub type W = crate::W<PRIORITY_31_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_31_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_31_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 31\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_31::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_31::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_31_SPEC;
 impl crate::RegisterSpec for PRIORITY_31_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_31_SPEC {}
 impl crate::Writable for PRIORITY_31_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_31 to value 0"]
+impl crate::Resettable for PRIORITY_31_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_32.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_32.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_32_SPEC>;
 #[doc = "Register `priority_32` writer"]
 pub type W = crate::W<PRIORITY_32_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_32_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_32_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 32\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_32::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_32::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_32_SPEC;
 impl crate::RegisterSpec for PRIORITY_32_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_32_SPEC {}
 impl crate::Writable for PRIORITY_32_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_32 to value 0"]
+impl crate::Resettable for PRIORITY_32_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_33.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_33.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_33_SPEC>;
 #[doc = "Register `priority_33` writer"]
 pub type W = crate::W<PRIORITY_33_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_33_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_33_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 33\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_33::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_33::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_33_SPEC;
 impl crate::RegisterSpec for PRIORITY_33_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_33_SPEC {}
 impl crate::Writable for PRIORITY_33_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_33 to value 0"]
+impl crate::Resettable for PRIORITY_33_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_34.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_34.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_34_SPEC>;
 #[doc = "Register `priority_34` writer"]
 pub type W = crate::W<PRIORITY_34_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_34_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_34_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 34\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_34::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_34::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_34_SPEC;
 impl crate::RegisterSpec for PRIORITY_34_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_34_SPEC {}
 impl crate::Writable for PRIORITY_34_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_34 to value 0"]
+impl crate::Resettable for PRIORITY_34_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_35.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_35.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_35_SPEC>;
 #[doc = "Register `priority_35` writer"]
 pub type W = crate::W<PRIORITY_35_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_35_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_35_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 35\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_35::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_35::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_35_SPEC;
 impl crate::RegisterSpec for PRIORITY_35_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_35_SPEC {}
 impl crate::Writable for PRIORITY_35_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_35 to value 0"]
+impl crate::Resettable for PRIORITY_35_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_36.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_36.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_36_SPEC>;
 #[doc = "Register `priority_36` writer"]
 pub type W = crate::W<PRIORITY_36_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_36_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_36_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 36\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_36::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_36::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_36_SPEC;
 impl crate::RegisterSpec for PRIORITY_36_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_36_SPEC {}
 impl crate::Writable for PRIORITY_36_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_36 to value 0"]
+impl crate::Resettable for PRIORITY_36_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_37.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_37.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_37_SPEC>;
 #[doc = "Register `priority_37` writer"]
 pub type W = crate::W<PRIORITY_37_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_37_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_37_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 37\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_37::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_37::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_37_SPEC;
 impl crate::RegisterSpec for PRIORITY_37_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_37_SPEC {}
 impl crate::Writable for PRIORITY_37_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_37 to value 0"]
+impl crate::Resettable for PRIORITY_37_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_38.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_38.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_38_SPEC>;
 #[doc = "Register `priority_38` writer"]
 pub type W = crate::W<PRIORITY_38_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_38_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_38_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 38\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_38::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_38::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_38_SPEC;
 impl crate::RegisterSpec for PRIORITY_38_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_38_SPEC {}
 impl crate::Writable for PRIORITY_38_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_38 to value 0"]
+impl crate::Resettable for PRIORITY_38_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_39.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_39.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_39_SPEC>;
 #[doc = "Register `priority_39` writer"]
 pub type W = crate::W<PRIORITY_39_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_39_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_39_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 39\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_39::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_39::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_39_SPEC;
 impl crate::RegisterSpec for PRIORITY_39_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_39_SPEC {}
 impl crate::Writable for PRIORITY_39_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_39 to value 0"]
+impl crate::Resettable for PRIORITY_39_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_4_SPEC>;
 #[doc = "Register `priority_4` writer"]
 pub type W = crate::W<PRIORITY_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_4_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_4_SPEC;
 impl crate::RegisterSpec for PRIORITY_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_4_SPEC {}
 impl crate::Writable for PRIORITY_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_4 to value 0"]
+impl crate::Resettable for PRIORITY_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_40.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_40.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_40_SPEC>;
 #[doc = "Register `priority_40` writer"]
 pub type W = crate::W<PRIORITY_40_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_40_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_40_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 40\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_40::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_40::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_40_SPEC;
 impl crate::RegisterSpec for PRIORITY_40_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_40_SPEC {}
 impl crate::Writable for PRIORITY_40_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_40 to value 0"]
+impl crate::Resettable for PRIORITY_40_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_41.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_41.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_41_SPEC>;
 #[doc = "Register `priority_41` writer"]
 pub type W = crate::W<PRIORITY_41_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_41_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_41_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 41\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_41::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_41::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_41_SPEC;
 impl crate::RegisterSpec for PRIORITY_41_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_41_SPEC {}
 impl crate::Writable for PRIORITY_41_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_41 to value 0"]
+impl crate::Resettable for PRIORITY_41_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_42.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_42.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_42_SPEC>;
 #[doc = "Register `priority_42` writer"]
 pub type W = crate::W<PRIORITY_42_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_42_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_42_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 42\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_42::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_42::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_42_SPEC;
 impl crate::RegisterSpec for PRIORITY_42_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_42_SPEC {}
 impl crate::Writable for PRIORITY_42_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_42 to value 0"]
+impl crate::Resettable for PRIORITY_42_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_43.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_43.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_43_SPEC>;
 #[doc = "Register `priority_43` writer"]
 pub type W = crate::W<PRIORITY_43_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_43_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_43_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 43\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_43::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_43::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_43_SPEC;
 impl crate::RegisterSpec for PRIORITY_43_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_43_SPEC {}
 impl crate::Writable for PRIORITY_43_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_43 to value 0"]
+impl crate::Resettable for PRIORITY_43_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_44.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_44.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_44_SPEC>;
 #[doc = "Register `priority_44` writer"]
 pub type W = crate::W<PRIORITY_44_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_44_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_44_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 44\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_44::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_44::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_44_SPEC;
 impl crate::RegisterSpec for PRIORITY_44_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_44_SPEC {}
 impl crate::Writable for PRIORITY_44_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_44 to value 0"]
+impl crate::Resettable for PRIORITY_44_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_45.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_45.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_45_SPEC>;
 #[doc = "Register `priority_45` writer"]
 pub type W = crate::W<PRIORITY_45_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_45_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_45_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 45\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_45::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_45::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_45_SPEC;
 impl crate::RegisterSpec for PRIORITY_45_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_45_SPEC {}
 impl crate::Writable for PRIORITY_45_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_45 to value 0"]
+impl crate::Resettable for PRIORITY_45_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_46.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_46.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_46_SPEC>;
 #[doc = "Register `priority_46` writer"]
 pub type W = crate::W<PRIORITY_46_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_46_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_46_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 46\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_46::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_46::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_46_SPEC;
 impl crate::RegisterSpec for PRIORITY_46_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_46_SPEC {}
 impl crate::Writable for PRIORITY_46_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_46 to value 0"]
+impl crate::Resettable for PRIORITY_46_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_47.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_47.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_47_SPEC>;
 #[doc = "Register `priority_47` writer"]
 pub type W = crate::W<PRIORITY_47_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_47_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_47_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 47\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_47::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_47::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_47_SPEC;
 impl crate::RegisterSpec for PRIORITY_47_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_47_SPEC {}
 impl crate::Writable for PRIORITY_47_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_47 to value 0"]
+impl crate::Resettable for PRIORITY_47_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_48.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_48.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_48_SPEC>;
 #[doc = "Register `priority_48` writer"]
 pub type W = crate::W<PRIORITY_48_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_48_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_48_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 48\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_48::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_48::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_48_SPEC;
 impl crate::RegisterSpec for PRIORITY_48_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_48_SPEC {}
 impl crate::Writable for PRIORITY_48_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_48 to value 0"]
+impl crate::Resettable for PRIORITY_48_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_49.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_49.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_49_SPEC>;
 #[doc = "Register `priority_49` writer"]
 pub type W = crate::W<PRIORITY_49_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_49_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_49_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 49\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_49::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_49::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_49_SPEC;
 impl crate::RegisterSpec for PRIORITY_49_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_49_SPEC {}
 impl crate::Writable for PRIORITY_49_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_49 to value 0"]
+impl crate::Resettable for PRIORITY_49_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_5.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_5.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_5_SPEC>;
 #[doc = "Register `priority_5` writer"]
 pub type W = crate::W<PRIORITY_5_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_5_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_5_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 5\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_5_SPEC;
 impl crate::RegisterSpec for PRIORITY_5_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_5_SPEC {}
 impl crate::Writable for PRIORITY_5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_5 to value 0"]
+impl crate::Resettable for PRIORITY_5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_50.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_50.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_50_SPEC>;
 #[doc = "Register `priority_50` writer"]
 pub type W = crate::W<PRIORITY_50_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_50_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_50_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 50\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_50::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_50::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_50_SPEC;
 impl crate::RegisterSpec for PRIORITY_50_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_50_SPEC {}
 impl crate::Writable for PRIORITY_50_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_50 to value 0"]
+impl crate::Resettable for PRIORITY_50_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_51.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_51.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_51_SPEC>;
 #[doc = "Register `priority_51` writer"]
 pub type W = crate::W<PRIORITY_51_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_51_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_51_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 51\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_51::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_51::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_51_SPEC;
 impl crate::RegisterSpec for PRIORITY_51_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_51_SPEC {}
 impl crate::Writable for PRIORITY_51_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_51 to value 0"]
+impl crate::Resettable for PRIORITY_51_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_52.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_52.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_52_SPEC>;
 #[doc = "Register `priority_52` writer"]
 pub type W = crate::W<PRIORITY_52_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_52_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_52_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 52\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_52::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_52::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_52_SPEC;
 impl crate::RegisterSpec for PRIORITY_52_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_52_SPEC {}
 impl crate::Writable for PRIORITY_52_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_52 to value 0"]
+impl crate::Resettable for PRIORITY_52_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_53.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_53.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_53_SPEC>;
 #[doc = "Register `priority_53` writer"]
 pub type W = crate::W<PRIORITY_53_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_53_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_53_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 53\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_53::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_53::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_53_SPEC;
 impl crate::RegisterSpec for PRIORITY_53_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_53_SPEC {}
 impl crate::Writable for PRIORITY_53_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_53 to value 0"]
+impl crate::Resettable for PRIORITY_53_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_54.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_54.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_54_SPEC>;
 #[doc = "Register `priority_54` writer"]
 pub type W = crate::W<PRIORITY_54_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_54_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_54_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 54\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_54::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_54::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_54_SPEC;
 impl crate::RegisterSpec for PRIORITY_54_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_54_SPEC {}
 impl crate::Writable for PRIORITY_54_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_54 to value 0"]
+impl crate::Resettable for PRIORITY_54_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_55.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_55.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_55_SPEC>;
 #[doc = "Register `priority_55` writer"]
 pub type W = crate::W<PRIORITY_55_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_55_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_55_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 55\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_55::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_55::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_55_SPEC;
 impl crate::RegisterSpec for PRIORITY_55_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_55_SPEC {}
 impl crate::Writable for PRIORITY_55_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_55 to value 0"]
+impl crate::Resettable for PRIORITY_55_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_56.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_56.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_56_SPEC>;
 #[doc = "Register `priority_56` writer"]
 pub type W = crate::W<PRIORITY_56_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_56_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_56_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 56\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_56::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_56::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_56_SPEC;
 impl crate::RegisterSpec for PRIORITY_56_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_56_SPEC {}
 impl crate::Writable for PRIORITY_56_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_56 to value 0"]
+impl crate::Resettable for PRIORITY_56_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_57.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_57.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_57_SPEC>;
 #[doc = "Register `priority_57` writer"]
 pub type W = crate::W<PRIORITY_57_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_57_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_57_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 57\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_57::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_57::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_57_SPEC;
 impl crate::RegisterSpec for PRIORITY_57_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_57_SPEC {}
 impl crate::Writable for PRIORITY_57_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_57 to value 0"]
+impl crate::Resettable for PRIORITY_57_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_58.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_58.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_58_SPEC>;
 #[doc = "Register `priority_58` writer"]
 pub type W = crate::W<PRIORITY_58_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_58_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_58_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 58\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_58::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_58::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_58_SPEC;
 impl crate::RegisterSpec for PRIORITY_58_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_58_SPEC {}
 impl crate::Writable for PRIORITY_58_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_58 to value 0"]
+impl crate::Resettable for PRIORITY_58_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_59.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_59.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_59_SPEC>;
 #[doc = "Register `priority_59` writer"]
 pub type W = crate::W<PRIORITY_59_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_59_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_59_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 59\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_59::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_59::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_59_SPEC;
 impl crate::RegisterSpec for PRIORITY_59_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_59_SPEC {}
 impl crate::Writable for PRIORITY_59_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_59 to value 0"]
+impl crate::Resettable for PRIORITY_59_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_6.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_6.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_6_SPEC>;
 #[doc = "Register `priority_6` writer"]
 pub type W = crate::W<PRIORITY_6_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_6_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_6_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 6\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_6::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_6_SPEC;
 impl crate::RegisterSpec for PRIORITY_6_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_6_SPEC {}
 impl crate::Writable for PRIORITY_6_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_6 to value 0"]
+impl crate::Resettable for PRIORITY_6_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_60.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_60.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_60_SPEC>;
 #[doc = "Register `priority_60` writer"]
 pub type W = crate::W<PRIORITY_60_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_60_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_60_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 60\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_60::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_60::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_60_SPEC;
 impl crate::RegisterSpec for PRIORITY_60_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_60_SPEC {}
 impl crate::Writable for PRIORITY_60_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_60 to value 0"]
+impl crate::Resettable for PRIORITY_60_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_61.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_61.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_61_SPEC>;
 #[doc = "Register `priority_61` writer"]
 pub type W = crate::W<PRIORITY_61_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_61_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_61_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 61\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_61::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_61::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_61_SPEC;
 impl crate::RegisterSpec for PRIORITY_61_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_61_SPEC {}
 impl crate::Writable for PRIORITY_61_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_61 to value 0"]
+impl crate::Resettable for PRIORITY_61_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_62.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_62.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_62_SPEC>;
 #[doc = "Register `priority_62` writer"]
 pub type W = crate::W<PRIORITY_62_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_62_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_62_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 62\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_62::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_62::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_62_SPEC;
 impl crate::RegisterSpec for PRIORITY_62_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_62_SPEC {}
 impl crate::Writable for PRIORITY_62_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_62 to value 0"]
+impl crate::Resettable for PRIORITY_62_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_63.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_63.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_63_SPEC>;
 #[doc = "Register `priority_63` writer"]
 pub type W = crate::W<PRIORITY_63_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_63_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_63_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 63\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_63::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_63::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_63_SPEC;
 impl crate::RegisterSpec for PRIORITY_63_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_63_SPEC {}
 impl crate::Writable for PRIORITY_63_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_63 to value 0"]
+impl crate::Resettable for PRIORITY_63_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_64.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_64.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_64_SPEC>;
 #[doc = "Register `priority_64` writer"]
 pub type W = crate::W<PRIORITY_64_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_64_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_64_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 64\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_64::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_64::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_64_SPEC;
 impl crate::RegisterSpec for PRIORITY_64_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_64_SPEC {}
 impl crate::Writable for PRIORITY_64_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_64 to value 0"]
+impl crate::Resettable for PRIORITY_64_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_65.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_65.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_65_SPEC>;
 #[doc = "Register `priority_65` writer"]
 pub type W = crate::W<PRIORITY_65_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_65_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_65_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 65\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_65::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_65::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_65_SPEC;
 impl crate::RegisterSpec for PRIORITY_65_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_65_SPEC {}
 impl crate::Writable for PRIORITY_65_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_65 to value 0"]
+impl crate::Resettable for PRIORITY_65_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_66.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_66.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_66_SPEC>;
 #[doc = "Register `priority_66` writer"]
 pub type W = crate::W<PRIORITY_66_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_66_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_66_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 66\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_66::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_66::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_66_SPEC;
 impl crate::RegisterSpec for PRIORITY_66_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_66_SPEC {}
 impl crate::Writable for PRIORITY_66_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_66 to value 0"]
+impl crate::Resettable for PRIORITY_66_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_67.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_67.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_67_SPEC>;
 #[doc = "Register `priority_67` writer"]
 pub type W = crate::W<PRIORITY_67_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_67_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_67_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 67\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_67::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_67::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_67_SPEC;
 impl crate::RegisterSpec for PRIORITY_67_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_67_SPEC {}
 impl crate::Writable for PRIORITY_67_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_67 to value 0"]
+impl crate::Resettable for PRIORITY_67_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_68.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_68.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_68_SPEC>;
 #[doc = "Register `priority_68` writer"]
 pub type W = crate::W<PRIORITY_68_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_68_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_68_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 68\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_68::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_68::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_68_SPEC;
 impl crate::RegisterSpec for PRIORITY_68_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_68_SPEC {}
 impl crate::Writable for PRIORITY_68_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_68 to value 0"]
+impl crate::Resettable for PRIORITY_68_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_69.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_69.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_69_SPEC>;
 #[doc = "Register `priority_69` writer"]
 pub type W = crate::W<PRIORITY_69_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_69_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_69_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 69\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_69::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_69::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_69_SPEC;
 impl crate::RegisterSpec for PRIORITY_69_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_69_SPEC {}
 impl crate::Writable for PRIORITY_69_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_69 to value 0"]
+impl crate::Resettable for PRIORITY_69_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_7.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_7.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_7_SPEC>;
 #[doc = "Register `priority_7` writer"]
 pub type W = crate::W<PRIORITY_7_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_7_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_7_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 7\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_7_SPEC;
 impl crate::RegisterSpec for PRIORITY_7_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_7_SPEC {}
 impl crate::Writable for PRIORITY_7_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_7 to value 0"]
+impl crate::Resettable for PRIORITY_7_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_70.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_70.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_70_SPEC>;
 #[doc = "Register `priority_70` writer"]
 pub type W = crate::W<PRIORITY_70_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_70_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_70_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 70\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_70::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_70::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_70_SPEC;
 impl crate::RegisterSpec for PRIORITY_70_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_70_SPEC {}
 impl crate::Writable for PRIORITY_70_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_70 to value 0"]
+impl crate::Resettable for PRIORITY_70_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_71.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_71.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_71_SPEC>;
 #[doc = "Register `priority_71` writer"]
 pub type W = crate::W<PRIORITY_71_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_71_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_71_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 71\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_71::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_71::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_71_SPEC;
 impl crate::RegisterSpec for PRIORITY_71_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_71_SPEC {}
 impl crate::Writable for PRIORITY_71_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_71 to value 0"]
+impl crate::Resettable for PRIORITY_71_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_72.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_72.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_72_SPEC>;
 #[doc = "Register `priority_72` writer"]
 pub type W = crate::W<PRIORITY_72_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_72_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_72_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 72\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_72::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_72::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_72_SPEC;
 impl crate::RegisterSpec for PRIORITY_72_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_72_SPEC {}
 impl crate::Writable for PRIORITY_72_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_72 to value 0"]
+impl crate::Resettable for PRIORITY_72_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_73.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_73.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_73_SPEC>;
 #[doc = "Register `priority_73` writer"]
 pub type W = crate::W<PRIORITY_73_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_73_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_73_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 73\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_73::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_73::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_73_SPEC;
 impl crate::RegisterSpec for PRIORITY_73_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_73_SPEC {}
 impl crate::Writable for PRIORITY_73_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_73 to value 0"]
+impl crate::Resettable for PRIORITY_73_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_74.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_74.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_74_SPEC>;
 #[doc = "Register `priority_74` writer"]
 pub type W = crate::W<PRIORITY_74_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_74_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_74_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 74\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_74::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_74::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_74_SPEC;
 impl crate::RegisterSpec for PRIORITY_74_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_74_SPEC {}
 impl crate::Writable for PRIORITY_74_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_74 to value 0"]
+impl crate::Resettable for PRIORITY_74_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_75.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_75.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_75_SPEC>;
 #[doc = "Register `priority_75` writer"]
 pub type W = crate::W<PRIORITY_75_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_75_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_75_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 75\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_75::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_75::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_75_SPEC;
 impl crate::RegisterSpec for PRIORITY_75_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_75_SPEC {}
 impl crate::Writable for PRIORITY_75_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_75 to value 0"]
+impl crate::Resettable for PRIORITY_75_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_76.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_76.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_76_SPEC>;
 #[doc = "Register `priority_76` writer"]
 pub type W = crate::W<PRIORITY_76_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_76_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_76_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 76\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_76::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_76::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_76_SPEC;
 impl crate::RegisterSpec for PRIORITY_76_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_76_SPEC {}
 impl crate::Writable for PRIORITY_76_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_76 to value 0"]
+impl crate::Resettable for PRIORITY_76_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_77.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_77.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_77_SPEC>;
 #[doc = "Register `priority_77` writer"]
 pub type W = crate::W<PRIORITY_77_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_77_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_77_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 77\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_77::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_77::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_77_SPEC;
 impl crate::RegisterSpec for PRIORITY_77_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_77_SPEC {}
 impl crate::Writable for PRIORITY_77_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_77 to value 0"]
+impl crate::Resettable for PRIORITY_77_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_78.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_78.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_78_SPEC>;
 #[doc = "Register `priority_78` writer"]
 pub type W = crate::W<PRIORITY_78_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_78_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_78_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 78\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_78::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_78::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_78_SPEC;
 impl crate::RegisterSpec for PRIORITY_78_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_78_SPEC {}
 impl crate::Writable for PRIORITY_78_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_78 to value 0"]
+impl crate::Resettable for PRIORITY_78_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_79.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_79.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_79_SPEC>;
 #[doc = "Register `priority_79` writer"]
 pub type W = crate::W<PRIORITY_79_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_79_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_79_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 79\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_79::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_79::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_79_SPEC;
 impl crate::RegisterSpec for PRIORITY_79_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_79_SPEC {}
 impl crate::Writable for PRIORITY_79_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_79 to value 0"]
+impl crate::Resettable for PRIORITY_79_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_8.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_8.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_8_SPEC>;
 #[doc = "Register `priority_8` writer"]
 pub type W = crate::W<PRIORITY_8_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_8_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_8_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_8_SPEC;
 impl crate::RegisterSpec for PRIORITY_8_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_8_SPEC {}
 impl crate::Writable for PRIORITY_8_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_8 to value 0"]
+impl crate::Resettable for PRIORITY_8_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_80.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_80.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_80_SPEC>;
 #[doc = "Register `priority_80` writer"]
 pub type W = crate::W<PRIORITY_80_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_80_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_80_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 80\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_80::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_80::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_80_SPEC;
 impl crate::RegisterSpec for PRIORITY_80_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_80_SPEC {}
 impl crate::Writable for PRIORITY_80_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_80 to value 0"]
+impl crate::Resettable for PRIORITY_80_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_81.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_81.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_81_SPEC>;
 #[doc = "Register `priority_81` writer"]
 pub type W = crate::W<PRIORITY_81_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_81_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_81_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 81\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_81::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_81::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_81_SPEC;
 impl crate::RegisterSpec for PRIORITY_81_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_81_SPEC {}
 impl crate::Writable for PRIORITY_81_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_81 to value 0"]
+impl crate::Resettable for PRIORITY_81_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_82.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_82.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_82_SPEC>;
 #[doc = "Register `priority_82` writer"]
 pub type W = crate::W<PRIORITY_82_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_82_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_82_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 82\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_82::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_82::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_82_SPEC;
 impl crate::RegisterSpec for PRIORITY_82_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_82_SPEC {}
 impl crate::Writable for PRIORITY_82_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_82 to value 0"]
+impl crate::Resettable for PRIORITY_82_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_83.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_83.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_83_SPEC>;
 #[doc = "Register `priority_83` writer"]
 pub type W = crate::W<PRIORITY_83_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_83_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_83_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 83\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_83::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_83::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_83_SPEC;
 impl crate::RegisterSpec for PRIORITY_83_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_83_SPEC {}
 impl crate::Writable for PRIORITY_83_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_83 to value 0"]
+impl crate::Resettable for PRIORITY_83_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_84.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_84.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_84_SPEC>;
 #[doc = "Register `priority_84` writer"]
 pub type W = crate::W<PRIORITY_84_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_84_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_84_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 84\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_84::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_84::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_84_SPEC;
 impl crate::RegisterSpec for PRIORITY_84_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_84_SPEC {}
 impl crate::Writable for PRIORITY_84_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_84 to value 0"]
+impl crate::Resettable for PRIORITY_84_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_85.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_85.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_85_SPEC>;
 #[doc = "Register `priority_85` writer"]
 pub type W = crate::W<PRIORITY_85_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_85_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_85_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 85\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_85::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_85::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_85_SPEC;
 impl crate::RegisterSpec for PRIORITY_85_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_85_SPEC {}
 impl crate::Writable for PRIORITY_85_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_85 to value 0"]
+impl crate::Resettable for PRIORITY_85_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_86.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_86.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_86_SPEC>;
 #[doc = "Register `priority_86` writer"]
 pub type W = crate::W<PRIORITY_86_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_86_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_86_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 86\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_86::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_86::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_86_SPEC;
 impl crate::RegisterSpec for PRIORITY_86_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_86_SPEC {}
 impl crate::Writable for PRIORITY_86_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_86 to value 0"]
+impl crate::Resettable for PRIORITY_86_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_87.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_87.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_87_SPEC>;
 #[doc = "Register `priority_87` writer"]
 pub type W = crate::W<PRIORITY_87_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_87_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_87_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 87\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_87::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_87::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_87_SPEC;
 impl crate::RegisterSpec for PRIORITY_87_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_87_SPEC {}
 impl crate::Writable for PRIORITY_87_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_87 to value 0"]
+impl crate::Resettable for PRIORITY_87_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_88.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_88.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_88_SPEC>;
 #[doc = "Register `priority_88` writer"]
 pub type W = crate::W<PRIORITY_88_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_88_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_88_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 88\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_88::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_88::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_88_SPEC;
 impl crate::RegisterSpec for PRIORITY_88_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_88_SPEC {}
 impl crate::Writable for PRIORITY_88_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_88 to value 0"]
+impl crate::Resettable for PRIORITY_88_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_89.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_89.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_89_SPEC>;
 #[doc = "Register `priority_89` writer"]
 pub type W = crate::W<PRIORITY_89_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_89_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_89_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 89\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_89::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_89::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_89_SPEC;
 impl crate::RegisterSpec for PRIORITY_89_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_89_SPEC {}
 impl crate::Writable for PRIORITY_89_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_89 to value 0"]
+impl crate::Resettable for PRIORITY_89_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_9.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_9.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_9_SPEC>;
 #[doc = "Register `priority_9` writer"]
 pub type W = crate::W<PRIORITY_9_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_9_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_9_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 9\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_9::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_9_SPEC;
 impl crate::RegisterSpec for PRIORITY_9_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_9_SPEC {}
 impl crate::Writable for PRIORITY_9_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_9 to value 0"]
+impl crate::Resettable for PRIORITY_9_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_90.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_90.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_90_SPEC>;
 #[doc = "Register `priority_90` writer"]
 pub type W = crate::W<PRIORITY_90_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_90_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_90_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 90\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_90::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_90::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_90_SPEC;
 impl crate::RegisterSpec for PRIORITY_90_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_90_SPEC {}
 impl crate::Writable for PRIORITY_90_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_90 to value 0"]
+impl crate::Resettable for PRIORITY_90_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_91.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_91.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_91_SPEC>;
 #[doc = "Register `priority_91` writer"]
 pub type W = crate::W<PRIORITY_91_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_91_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_91_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 91\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_91::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_91::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_91_SPEC;
 impl crate::RegisterSpec for PRIORITY_91_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_91_SPEC {}
 impl crate::Writable for PRIORITY_91_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_91 to value 0"]
+impl crate::Resettable for PRIORITY_91_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_92.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_92.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_92_SPEC>;
 #[doc = "Register `priority_92` writer"]
 pub type W = crate::W<PRIORITY_92_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_92_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_92_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 92\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_92::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_92::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_92_SPEC;
 impl crate::RegisterSpec for PRIORITY_92_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_92_SPEC {}
 impl crate::Writable for PRIORITY_92_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_92 to value 0"]
+impl crate::Resettable for PRIORITY_92_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_93.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_93.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_93_SPEC>;
 #[doc = "Register `priority_93` writer"]
 pub type W = crate::W<PRIORITY_93_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_93_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_93_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 93\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_93::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_93::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_93_SPEC;
 impl crate::RegisterSpec for PRIORITY_93_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_93_SPEC {}
 impl crate::Writable for PRIORITY_93_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_93 to value 0"]
+impl crate::Resettable for PRIORITY_93_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_94.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_94.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_94_SPEC>;
 #[doc = "Register `priority_94` writer"]
 pub type W = crate::W<PRIORITY_94_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_94_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_94_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 94\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_94::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_94::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_94_SPEC;
 impl crate::RegisterSpec for PRIORITY_94_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_94_SPEC {}
 impl crate::Writable for PRIORITY_94_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_94 to value 0"]
+impl crate::Resettable for PRIORITY_94_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_95.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_95.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_95_SPEC>;
 #[doc = "Register `priority_95` writer"]
 pub type W = crate::W<PRIORITY_95_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_95_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_95_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 95\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_95::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_95::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_95_SPEC;
 impl crate::RegisterSpec for PRIORITY_95_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_95_SPEC {}
 impl crate::Writable for PRIORITY_95_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_95 to value 0"]
+impl crate::Resettable for PRIORITY_95_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_96.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_96.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_96_SPEC>;
 #[doc = "Register `priority_96` writer"]
 pub type W = crate::W<PRIORITY_96_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_96_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_96_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 96\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_96::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_96::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_96_SPEC;
 impl crate::RegisterSpec for PRIORITY_96_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_96_SPEC {}
 impl crate::Writable for PRIORITY_96_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_96 to value 0"]
+impl crate::Resettable for PRIORITY_96_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_97.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_97.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_97_SPEC>;
 #[doc = "Register `priority_97` writer"]
 pub type W = crate::W<PRIORITY_97_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_97_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_97_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 97\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_97::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_97::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_97_SPEC;
 impl crate::RegisterSpec for PRIORITY_97_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_97_SPEC {}
 impl crate::Writable for PRIORITY_97_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_97 to value 0"]
+impl crate::Resettable for PRIORITY_97_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_98.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_98.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_98_SPEC>;
 #[doc = "Register `priority_98` writer"]
 pub type W = crate::W<PRIORITY_98_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_98_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_98_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 98\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_98::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_98::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_98_SPEC;
 impl crate::RegisterSpec for PRIORITY_98_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_98_SPEC {}
 impl crate::Writable for PRIORITY_98_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_98 to value 0"]
+impl crate::Resettable for PRIORITY_98_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/priority_99.rs
+++ b/jh7110-vf2-13b-pac/src/plic/priority_99.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<PRIORITY_99_SPEC>;
 #[doc = "Register `priority_99` writer"]
 pub type W = crate::W<PRIORITY_99_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<PRIORITY_99_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<PRIORITY_99_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY Register for interrupt id 99\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`priority_99::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`priority_99::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct PRIORITY_99_SPEC;
 impl crate::RegisterSpec for PRIORITY_99_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for PRIORITY_99_SPEC {}
 impl crate::Writable for PRIORITY_99_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets priority_99 to value 0"]
+impl crate::Resettable for PRIORITY_99_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/threshold_0.rs
+++ b/jh7110-vf2-13b-pac/src/plic/threshold_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_0_SPEC>;
 #[doc = "Register `threshold_0` writer"]
 pub type W = crate::W<THRESHOLD_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_0_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_0_SPEC;
 impl crate::RegisterSpec for THRESHOLD_0_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_0_SPEC {}
 impl crate::Writable for THRESHOLD_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_0 to value 0"]
+impl crate::Resettable for THRESHOLD_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/threshold_1.rs
+++ b/jh7110-vf2-13b-pac/src/plic/threshold_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_1_SPEC>;
 #[doc = "Register `threshold_1` writer"]
 pub type W = crate::W<THRESHOLD_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_1_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_1_SPEC;
 impl crate::RegisterSpec for THRESHOLD_1_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_1_SPEC {}
 impl crate::Writable for THRESHOLD_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_1 to value 0"]
+impl crate::Resettable for THRESHOLD_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/threshold_2.rs
+++ b/jh7110-vf2-13b-pac/src/plic/threshold_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_2_SPEC>;
 #[doc = "Register `threshold_2` writer"]
 pub type W = crate::W<THRESHOLD_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_2_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_2_SPEC;
 impl crate::RegisterSpec for THRESHOLD_2_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_2_SPEC {}
 impl crate::Writable for THRESHOLD_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_2 to value 0"]
+impl crate::Resettable for THRESHOLD_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/threshold_3.rs
+++ b/jh7110-vf2-13b-pac/src/plic/threshold_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_3_SPEC>;
 #[doc = "Register `threshold_3` writer"]
 pub type W = crate::W<THRESHOLD_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_3_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_3_SPEC;
 impl crate::RegisterSpec for THRESHOLD_3_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_3_SPEC {}
 impl crate::Writable for THRESHOLD_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_3 to value 0"]
+impl crate::Resettable for THRESHOLD_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/plic/threshold_4.rs
+++ b/jh7110-vf2-13b-pac/src/plic/threshold_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<THRESHOLD_4_SPEC>;
 #[doc = "Register `threshold_4` writer"]
 pub type W = crate::W<THRESHOLD_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<THRESHOLD_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `priority` reader - "]
+pub type PRIORITY_R = crate::FieldReader<u32>;
+#[doc = "Field `priority` writer - "]
+pub type PRIORITY_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+impl R {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    pub fn priority(&self) -> PRIORITY_R {
+        PRIORITY_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:31"]
+    #[inline(always)]
+    #[must_use]
+    pub fn priority(&mut self) -> PRIORITY_W<THRESHOLD_4_SPEC> {
+        PRIORITY_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "PRIORITY THRESHOLD Register for hart 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`threshold_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`threshold_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct THRESHOLD_4_SPEC;
 impl crate::RegisterSpec for THRESHOLD_4_SPEC {
     type Ux = u32;
@@ -35,4 +42,8 @@ impl crate::Readable for THRESHOLD_4_SPEC {}
 impl crate::Writable for THRESHOLD_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets threshold_4 to value 0"]
+impl crate::Resettable for THRESHOLD_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }


### PR DESCRIPTION
Adds the `resetValue` to the SVD file to enable the `Resettable` trait implementation.