### PR TITLE
fixup: common: use `generate_register` in common registers

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -11302,6 +11302,7 @@
           <description>Clock HIFI4 Core</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11316,6 +11317,7 @@
           <description>Clock USB APB</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11330,6 +11332,7 @@
           <description>Clock USB UTMI APB</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11344,6 +11347,7 @@
           <description>Clock USB AXI</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11358,6 +11362,7 @@
           <description>Clock USB AXI</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11378,6 +11383,7 @@
           <description>Clock USB STB</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11398,6 +11404,7 @@
           <description>Clock USB APP 125</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11412,6 +11419,7 @@
           <description>Clock USB Reference Clock</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -11426,6 +11434,7 @@
           <description>U0 Clock PCIe AXI MST 0</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11440,6 +11449,7 @@
           <description>U0 Clock PCIe APB</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11454,6 +11464,7 @@
           <description>U0 Clock PCIe TL</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11468,6 +11479,7 @@
           <description>U1 Clock PCIe AXI MST 0</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11482,6 +11494,7 @@
           <description>U1 Clock PCIe APB</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11496,6 +11509,7 @@
           <description>U1 Clock PCIe TL</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11510,6 +11524,7 @@
           <description>Clock PCIe 01 SLV DEC Main</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11524,6 +11539,7 @@
           <description>Clock Security HCLK</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11538,6 +11554,7 @@
           <description>Clock Security Miscellaneous AHB</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11552,6 +11569,7 @@
           <description>Clock STG MTRX Group 0 Main</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11566,6 +11584,7 @@
           <description>Clock STG MTRX Group 0 Bus</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11580,6 +11599,7 @@
           <description>Clock STG MTRX Group 0 STG</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11594,6 +11614,7 @@
           <description>Clock STG MTRX Group 1 Main</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11608,6 +11629,7 @@
           <description>Clock STG MTRX Group 1 Bus</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11622,6 +11644,7 @@
           <description>Clock STG MTRX Group 1 STG</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11636,6 +11659,7 @@
           <description>Clock STG MTRX Group 1 HIFI</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11650,6 +11674,7 @@
           <description>Clock E2 RTC</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11670,6 +11695,7 @@
           <description>Clock E2 Core</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11684,6 +11710,7 @@
           <description>Clock E2 DBG</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11698,6 +11725,7 @@
           <description>Clock DMA AXI</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11712,6 +11740,7 @@
           <description>Clock DMA AHB</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11726,6 +11755,7 @@
           <description>Software RESET Address Selector</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_stg_syscon_presetn</name>
@@ -11872,6 +11902,7 @@
           <description>STGCRG RESET Status</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_stg_syscon_presetn</name>
@@ -27837,6 +27868,7 @@
           <description>Clock CPU Root</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27851,6 +27883,7 @@
           <description>Clock CPU Core</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27865,6 +27898,7 @@
           <description>Clock CPU Bus</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27879,6 +27913,7 @@
           <description>Clock GPU Root</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27893,6 +27928,7 @@
           <description>Clock Peripheral Root</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27913,6 +27949,7 @@
           <description>Clock Bus Root</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27927,6 +27964,7 @@
           <description>Clock NOCSTG Bus</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27941,6 +27979,7 @@
           <description>Clock AXI Configuration 0</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27955,6 +27994,7 @@
           <description>Clock STG AXI AHB</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27969,6 +28009,7 @@
           <description>Clock AHB 0</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -27983,6 +28024,7 @@
           <description>Clock AHB 1</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -27997,6 +28039,7 @@
           <description>Clock APB Bus</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28011,6 +28054,7 @@
           <description>Clock APB 0</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28025,6 +28069,7 @@
           <description>Clock PLL 0 Divider 2</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28039,6 +28084,7 @@
           <description>Clock PLL 1 Divider 2</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28053,6 +28099,7 @@
           <description>Clock PLL 2 Divider 2</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28067,6 +28114,7 @@
           <description>Clock Audio Root</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28081,6 +28129,7 @@
           <description>Clock MCLK Inner</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28095,6 +28144,7 @@
           <description>Clock MCLK</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28109,6 +28159,7 @@
           <description>Clock MCLK Out</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28123,6 +28174,7 @@
           <description>Clock ISP 2x</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28143,6 +28195,7 @@
           <description>Clock ISP AXI</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28157,6 +28210,7 @@
           <description>Clock GCLK 0</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28177,6 +28231,7 @@
           <description>Clock GCLK 1</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28197,6 +28252,7 @@
           <description>Clock GCLK 2</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28217,6 +28273,7 @@
           <description>U7MC Core Clock 0</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28231,6 +28288,7 @@
           <description>U7MC Core Clock 1</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28245,6 +28303,7 @@
           <description>U7MC Core Clock 2</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28259,6 +28318,7 @@
           <description>U7MC Core Clock 3</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28273,6 +28333,7 @@
           <description>U7MC Core Clock 4</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28287,6 +28348,7 @@
           <description>U7MC Debug Clock</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28301,6 +28363,7 @@
           <description>U7MC RTC Toggle</description>
           <addressOffset>0x7c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28315,6 +28378,7 @@
           <description>U7MC Trace Clock 0</description>
           <addressOffset>0x80</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28329,6 +28393,7 @@
           <description>U7MC Trace Clock 1</description>
           <addressOffset>0x84</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28343,6 +28408,7 @@
           <description>U7MC Trace Clock 2</description>
           <addressOffset>0x88</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28357,6 +28423,7 @@
           <description>U7MC Trace Clock 3</description>
           <addressOffset>0x8c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28371,6 +28438,7 @@
           <description>U7MC Trace Clock 4</description>
           <addressOffset>0x90</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28385,6 +28453,7 @@
           <description>U7MC Trace Clock COM</description>
           <addressOffset>0x94</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28399,6 +28468,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_cpu_axi</description>
           <addressOffset>0x98</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28413,6 +28483,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_axicfg0_axi</description>
           <addressOffset>0x9c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28427,6 +28498,7 @@
           <description>clk_osc_div2</description>
           <addressOffset>0xa0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28441,6 +28513,7 @@
           <description>clk_pll1_div4</description>
           <addressOffset>0xa4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28455,6 +28528,7 @@
           <description>clk_pll1_div8</description>
           <addressOffset>0xa8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28469,6 +28543,7 @@
           <description>clk_ddr_bus</description>
           <addressOffset>0xac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28483,6 +28558,7 @@
           <description>clk_u0_ddr_sfft7110_clk_axi</description>
           <addressOffset>0xb0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28497,6 +28573,7 @@
           <description>clk_gpu_core</description>
           <addressOffset>0xb4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28511,6 +28588,7 @@
           <description>clk_u0_img_gpu_core_clk</description>
           <addressOffset>0xb8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28525,6 +28603,7 @@
           <description>clk_u0_img_gpu_sys_clk</description>
           <addressOffset>0xbc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28539,6 +28618,7 @@
           <description>clk_u0_img_gpu_clk_apb</description>
           <addressOffset>0xc0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28553,6 +28633,7 @@
           <description>clk_u0_gpu_rtc_toggle</description>
           <addressOffset>0xc4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28573,6 +28654,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_gpu_axi</description>
           <addressOffset>0xc8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28587,6 +28669,7 @@
           <description>clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x</description>
           <addressOffset>0xcc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28601,6 +28684,7 @@
           <description>clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi</description>
           <addressOffset>0xd0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28615,6 +28699,7 @@
           <description>clk_u0_sft7110_noc_bux_clk_isp_axi</description>
           <addressOffset>0xd4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28629,6 +28714,7 @@
           <description>clk_hifi4_core</description>
           <addressOffset>0xd8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28643,6 +28729,7 @@
           <description>clk_hifi4_axi</description>
           <addressOffset>0xdc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28657,6 +28744,7 @@
           <description>clk_u0_axi_cfg1_dec_clk_main</description>
           <addressOffset>0xe0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28671,6 +28759,7 @@
           <description>clk_u0_axi_cfg1_dec_clk_ahb</description>
           <addressOffset>0xe4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28685,6 +28774,7 @@
           <description>clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src</description>
           <addressOffset>0xe8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28699,6 +28789,7 @@
           <description>Clock Video Output AXI DIVCFG</description>
           <addressOffset>0xec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28713,6 +28804,7 @@
           <description>Clock NOC Display AXI</description>
           <addressOffset>0xf0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28727,6 +28819,7 @@
           <description>Clock Video Output AHB</description>
           <addressOffset>0xf4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28741,6 +28834,7 @@
           <description>Clock Video Output AXI ICG</description>
           <addressOffset>0xf8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28755,6 +28849,7 @@
           <description>Clock Video Output HDMI TX0 MCLK</description>
           <addressOffset>0xfc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28769,6 +28864,7 @@
           <description>Clock Video Output MIPI PHY Reference</description>
           <addressOffset>0x100</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28783,6 +28879,7 @@
           <description>Clock JPEG Codec AXI</description>
           <addressOffset>0x104</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28797,6 +28894,7 @@
           <description>CODAJ12 Clock AXI</description>
           <addressOffset>0x108</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28811,6 +28909,7 @@
           <description>CODAJ12 Clock Core</description>
           <addressOffset>0x10c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28831,6 +28930,7 @@
           <description>CODAJ12 Clock APB</description>
           <addressOffset>0x110</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28845,6 +28945,7 @@
           <description>Clock Video Decoder AXI</description>
           <addressOffset>0x114</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28859,6 +28960,7 @@
           <description>Clock WAVE511 AXI</description>
           <addressOffset>0x118</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28873,6 +28975,7 @@
           <description>Clock WAVE511 BPU</description>
           <addressOffset>0x11c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28893,6 +28996,7 @@
           <description>Clock WAVE511 VCE</description>
           <addressOffset>0x120</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28913,6 +29017,7 @@
           <description>Clock WAVE511 APB</description>
           <addressOffset>0x124</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28927,6 +29032,7 @@
           <description>Clock WAVE511 JPG ARB</description>
           <addressOffset>0x128</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28941,6 +29047,7 @@
           <description>Clock WAVE511 JPG Main</description>
           <addressOffset>0x12c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28955,6 +29062,7 @@
           <description>Clock NOC Video Decoder AXI</description>
           <addressOffset>0x130</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28969,6 +29077,7 @@
           <description>Clock Video Encoder AXI</description>
           <addressOffset>0x134</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28983,6 +29092,7 @@
           <description>Clock WAVE420L AXI</description>
           <addressOffset>0x138</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28997,6 +29107,7 @@
           <description>Clock WAVE420L BPU</description>
           <addressOffset>0x13c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29017,6 +29128,7 @@
           <description>Clock WAVE420L VCE</description>
           <addressOffset>0x140</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29037,6 +29149,7 @@
           <description>Clock WAVE420L APB</description>
           <addressOffset>0x144</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29051,6 +29164,7 @@
           <description>Clock NOC Video Encoder AXI</description>
           <addressOffset>0x148</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29065,6 +29179,7 @@
           <description>Clock AXI Config 0 DEC Main Divider</description>
           <addressOffset>0x14c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29079,6 +29194,7 @@
           <description>Clock AXI Config 0 DEC Main</description>
           <addressOffset>0x150</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29093,6 +29209,7 @@
           <description>Clock AXI Config 0 DEC HIFI4</description>
           <addressOffset>0x154</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29107,6 +29224,7 @@
           <description>Clock AXIMEM 128B AXI</description>
           <addressOffset>0x158</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29121,6 +29239,7 @@
           <description>Clock QSPI AHB</description>
           <addressOffset>0x15c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29135,6 +29254,7 @@
           <description>Clock QSPI APB</description>
           <addressOffset>0x160</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29149,6 +29269,7 @@
           <description>Clock QSPI Reference Source</description>
           <addressOffset>0x164</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29163,6 +29284,7 @@
           <description>Clock QSPI Reference</description>
           <addressOffset>0x168</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29183,6 +29305,7 @@
           <description>U0 SD Clock AHB</description>
           <addressOffset>0x16c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29197,6 +29320,7 @@
           <description>U1 SD Clock AHB</description>
           <addressOffset>0x170</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29211,6 +29335,7 @@
           <description>U0 SD Card Clock</description>
           <addressOffset>0x174</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29231,6 +29356,7 @@
           <description>U1 SD Card Clock</description>
           <addressOffset>0x178</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29251,6 +29377,7 @@
           <description>Clock USB 125M</description>
           <addressOffset>0x17c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29265,6 +29392,7 @@
           <description>Clock NOC STG AXI</description>
           <addressOffset>0x180</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29279,6 +29407,7 @@
           <description>Clock GMAC 5 AXI 64 AHB</description>
           <addressOffset>0x184</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29293,6 +29422,7 @@
           <description>Clock GMAC 5 AXI 64 AXI</description>
           <addressOffset>0x188</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29307,6 +29437,7 @@
           <description>Clock GMAC Source</description>
           <addressOffset>0x18c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29321,6 +29452,7 @@
           <description>Clock GMAC 1 GTX</description>
           <addressOffset>0x190</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29335,6 +29467,7 @@
           <description>Clock GMAC 1 RMII RTX</description>
           <addressOffset>0x194</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29349,6 +29482,7 @@
           <description>Clock GMAC 5 AXI 64 PTP</description>
           <addressOffset>0x198</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29369,6 +29503,7 @@
           <description>Clock GMAC 5 AXI 64 RX</description>
           <addressOffset>0x19c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29383,6 +29518,7 @@
           <description>Clock GMAC 5 AXI 64 RX Inverter</description>
           <addressOffset>0x1a0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -29397,6 +29533,7 @@
           <description>Clock GMAC 5 AXI 64 TX</description>
           <addressOffset>0x1a4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29417,6 +29554,7 @@
           <description>Clock GMAC 5 AXI 64 TX Inverter</description>
           <addressOffset>0x1a8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -29431,6 +29569,7 @@
           <description>Clock GMAC 1 GTXC</description>
           <addressOffset>0x1ac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29445,6 +29584,7 @@
           <description>Clock GMAC 0 GTX</description>
           <addressOffset>0x1b0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29465,6 +29605,7 @@
           <description>Clock GMAC 0 PTP</description>
           <addressOffset>0x1b4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29485,6 +29626,7 @@
           <description>Clock GMAC PHY</description>
           <addressOffset>0x1b8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29505,6 +29647,7 @@
           <description>Clock GMAC 0 GTXC</description>
           <addressOffset>0x1bc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29519,6 +29662,7 @@
           <description>Clock SYS IOMUX PCLK</description>
           <addressOffset>0x1c0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29533,6 +29677,7 @@
           <description>Clock Mailbox APB</description>
           <addressOffset>0x1c4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29547,6 +29692,7 @@
           <description>Clock Internal Controller APB</description>
           <addressOffset>0x1c8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29561,6 +29707,7 @@
           <description>U0 Clock CAN Controller APB</description>
           <addressOffset>0x1cc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29575,6 +29722,7 @@
           <description>U0 Clock CAN Controller Timer</description>
           <addressOffset>0x1d0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29595,6 +29743,7 @@
           <description>U0 Clock CAN Controller CAN</description>
           <addressOffset>0x1d4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29615,6 +29764,7 @@
           <description>U1 Clock CAN Controller APB</description>
           <addressOffset>0x1d8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29629,6 +29779,7 @@
           <description>U1 Clock CAN Controller Timer</description>
           <addressOffset>0x1dc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29649,6 +29800,7 @@
           <description>U1 Clock CAN Controller CAN</description>
           <addressOffset>0x1e0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29669,6 +29821,7 @@
           <description>Clock PWM APB</description>
           <addressOffset>0x1e4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29683,6 +29836,7 @@
           <description>Clock WDT APB</description>
           <addressOffset>0x1e8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29697,6 +29851,7 @@
           <description>Clock WDT</description>
           <addressOffset>0x1ec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29711,6 +29866,7 @@
           <description>Clock Timer APB</description>
           <addressOffset>0x1f0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29725,6 +29881,7 @@
           <description>Clock Timer 0</description>
           <addressOffset>0x1f4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29739,6 +29896,7 @@
           <description>Clock Timer 1</description>
           <addressOffset>0x1f8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29753,6 +29911,7 @@
           <description>Clock Timer 2</description>
           <addressOffset>0x1fc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29767,6 +29926,7 @@
           <description>Clock Timer 3</description>
           <addressOffset>0x200</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29781,6 +29941,7 @@
           <description>Clock Temperature Sensor APB</description>
           <addressOffset>0x204</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29795,6 +29956,7 @@
           <description>Clock Temperature Sensor</description>
           <addressOffset>0x208</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29815,6 +29977,7 @@
           <description>U0 Clock SPI APB</description>
           <addressOffset>0x20c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29829,6 +29992,7 @@
           <description>U1 Clock SPI APB</description>
           <addressOffset>0x210</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29843,6 +30007,7 @@
           <description>U2 Clock SPI APB</description>
           <addressOffset>0x214</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29857,6 +30022,7 @@
           <description>U3 Clock SPI APB</description>
           <addressOffset>0x218</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29871,6 +30037,7 @@
           <description>U4 Clock SPI APB</description>
           <addressOffset>0x21c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29885,6 +30052,7 @@
           <description>U5 Clock SPI APB</description>
           <addressOffset>0x220</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29899,6 +30067,7 @@
           <description>U6 Clock SPI APB</description>
           <addressOffset>0x224</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29913,6 +30082,7 @@
           <description>U0 Clock I2C APB</description>
           <addressOffset>0x228</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29927,6 +30097,7 @@
           <description>U1 Clock I2C APB</description>
           <addressOffset>0x22c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29941,6 +30112,7 @@
           <description>U2 Clock I2C APB</description>
           <addressOffset>0x230</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29955,6 +30127,7 @@
           <description>U3 Clock I2C APB</description>
           <addressOffset>0x234</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29969,6 +30142,7 @@
           <description>U4 Clock I2C APB</description>
           <addressOffset>0x238</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29983,6 +30157,7 @@
           <description>U5 Clock I2C APB</description>
           <addressOffset>0x23c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29997,6 +30172,7 @@
           <description>U6 Clock I2C APB</description>
           <addressOffset>0x240</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30011,6 +30187,7 @@
           <description>U0 Clock UART APB</description>
           <addressOffset>0x244</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30025,6 +30202,7 @@
           <description>U0 Clock UART Core</description>
           <addressOffset>0x248</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30039,6 +30217,7 @@
           <description>U1 Clock UART APB</description>
           <addressOffset>0x24c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30053,6 +30232,7 @@
           <description>U1 Clock UART Core</description>
           <addressOffset>0x250</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30067,6 +30247,7 @@
           <description>U2 Clock UART APB</description>
           <addressOffset>0x254</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30081,6 +30262,7 @@
           <description>U2 Clock UART Core</description>
           <addressOffset>0x258</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30095,6 +30277,7 @@
           <description>U3 Clock UART APB</description>
           <addressOffset>0x25c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30109,6 +30292,7 @@
           <description>U3 Clock UART Core</description>
           <addressOffset>0x260</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30129,6 +30313,7 @@
           <description>U4 Clock UART APB</description>
           <addressOffset>0x264</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30143,6 +30328,7 @@
           <description>U4 Clock UART Core</description>
           <addressOffset>0x268</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30163,6 +30349,7 @@
           <description>U5 Clock UART APB</description>
           <addressOffset>0x26c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30177,6 +30364,7 @@
           <description>U5 Clock UART Core</description>
           <addressOffset>0x270</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30197,6 +30385,7 @@
           <description>Clock PWMDAC APB</description>
           <addressOffset>0x274</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30211,6 +30400,7 @@
           <description>Clock PWMDAC Core</description>
           <addressOffset>0x278</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30231,6 +30421,7 @@
           <description>Clock SPDIF APB</description>
           <addressOffset>0x27c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30245,6 +30436,7 @@
           <description>Clock SPDIF Core</description>
           <addressOffset>0x280</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30259,6 +30451,7 @@
           <description>U0 Clock I2S TX APB</description>
           <addressOffset>0x284</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30273,6 +30466,7 @@
           <description>U0 Clock I2S TX 0 BCLK MST</description>
           <addressOffset>0x288</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30293,6 +30487,7 @@
           <description>U0 Clock I2S TX 0 BCLK MST Inverter</description>
           <addressOffset>0x28c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30307,6 +30502,7 @@
           <description>Clock I2S TX 0 LRCK MST</description>
           <addressOffset>0x290</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30327,6 +30523,7 @@
           <description>U0 Clock I2S TX BCLK</description>
           <addressOffset>0x294</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30341,6 +30538,7 @@
           <description>U0 Clock I2S TX BCLK Negative</description>
           <addressOffset>0x298</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30355,6 +30553,7 @@
           <description>U0 Clock I2S TX LRCK</description>
           <addressOffset>0x29c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30369,6 +30568,7 @@
           <description>U1 Clock I2S TX APB</description>
           <addressOffset>0x2a0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30383,6 +30583,7 @@
           <description>U1 Clock I2S TX 1 BCLK MST</description>
           <addressOffset>0x2a4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30403,6 +30604,7 @@
           <description>U1 Clock I2S TX 1 BCLK MST Inverter</description>
           <addressOffset>0x2a8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30417,6 +30619,7 @@
           <description>Clock I2S TX 1 LRCK MST</description>
           <addressOffset>0x2ac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30437,6 +30640,7 @@
           <description>U1 Clock I2S TX BCLK</description>
           <addressOffset>0x2b0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30451,6 +30655,7 @@
           <description>U1 Clock I2S TX BCLK Negative</description>
           <addressOffset>0x2b4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30465,6 +30670,7 @@
           <description>U1 Clock I2S TX LRCK</description>
           <addressOffset>0x2b8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30479,6 +30685,7 @@
           <description>Clock I2S APB</description>
           <addressOffset>0x2bc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30493,6 +30700,7 @@
           <description>Clock I2S BCLK MST</description>
           <addressOffset>0x2c0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30513,6 +30721,7 @@
           <description>Clock I2S BCLK MST Inverter</description>
           <addressOffset>0x2c4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30527,6 +30736,7 @@
           <description>Clock I2S LRCK MST</description>
           <addressOffset>0x2c8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30547,6 +30757,7 @@
           <description>Clock I2S BCLK</description>
           <addressOffset>0x2cc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30561,6 +30772,7 @@
           <description>Clock I2S BCLK Negative</description>
           <addressOffset>0x2d0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30575,6 +30787,7 @@
           <description>Clock I2S LRCK</description>
           <addressOffset>0x2d4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30589,6 +30802,7 @@
           <description>Clock PDM DMIC</description>
           <addressOffset>0x2d8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30609,6 +30823,7 @@
           <description>Clock PDM APB</description>
           <addressOffset>0x2dc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30623,6 +30838,7 @@
           <description>Clock TDM AHB</description>
           <addressOffset>0x2e0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30637,6 +30853,7 @@
           <description>Clock TDM APB</description>
           <addressOffset>0x2e4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30651,6 +30868,7 @@
           <description>Clock TDM Internal</description>
           <addressOffset>0x2e8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30671,6 +30889,7 @@
           <description>Clock TDM</description>
           <addressOffset>0x2ec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30685,6 +30904,7 @@
           <description>Clock TDM Negative</description>
           <addressOffset>0x2f0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30699,6 +30919,7 @@
           <description>Clock JTAG Certification TRNG</description>
           <addressOffset>0x2f4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -30713,6 +30934,7 @@
           <description>Software RESET 0 Address Selector</description>
           <addressOffset>0x2f8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_jtag2apb_presetn</name>
@@ -30913,6 +31135,7 @@
           <description>Software RESET 1 Address Selector</description>
           <addressOffset>0x2fc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
@@ -31113,6 +31336,7 @@
           <description>Software RESET 2 Address Selector</description>
           <addressOffset>0x300</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sdio_rstn_ahb</name>
@@ -31313,6 +31537,7 @@
           <description>Software RESET 3 Address Selector</description>
           <addressOffset>0x304</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_pwmdac_rstn_apb</name>
@@ -31501,6 +31726,7 @@
           <description>SYSCRG RESET Status 0</description>
           <addressOffset>0x308</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_jtag2apb_presetn</name>
@@ -31701,6 +31927,7 @@
           <description>SYSCRG RESET Status 1</description>
           <addressOffset>0x30c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
@@ -31901,6 +32128,7 @@
           <description>SYSCRG RESET Status 2</description>
           <addressOffset>0x310</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sdio_rstn_ahb</name>
@@ -32101,6 +32329,7 @@
           <description>SYSCRG RESET Status 3</description>
           <addressOffset>0x314</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_pwmdac_rstn_apb</name>
@@ -42289,6 +42518,7 @@
           <description>Oscillator Clock</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42303,6 +42533,7 @@
           <description>AON APB Function Clock</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42317,6 +42548,7 @@
           <description>AHB GMAC5 Clock</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42331,6 +42563,7 @@
           <description>AXI GMAC5 Clock</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42345,6 +42578,7 @@
           <description>GMAC0 RMII RTX Clock</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42359,6 +42593,7 @@
           <description>GMAC5 AXI64 Clock Transmitter</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42373,6 +42608,7 @@
           <description>GMAC5 AXI64 Clock Transmission Inverter</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -42387,6 +42623,7 @@
           <description>GMAC5 AXI64 Clock Receiver</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -42401,6 +42638,7 @@
           <description>GMAC5 AXI64 Clock Receiving Inverter</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -42415,6 +42653,7 @@
           <description>OPTC APB Clock</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42429,6 +42668,7 @@
           <description>RTC HMS APB Clock</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42443,6 +42683,7 @@
           <description>RTC Internal Clock</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42457,6 +42698,7 @@
           <description>RTC HMS Clock Oscillator 32K</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42471,6 +42713,7 @@
           <description>RTC HMS Clock Calculator</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42485,6 +42728,7 @@
           <description>Software RESET Address Selector</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>gmac5_axi64_rstn_axi</name>
@@ -42541,6 +42785,7 @@
           <description>AONCRG RESET Status</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>gmac5_axi64_rstn_axi</name>

--- a/jh7110-vf2-12a-pac/src/aoncrg.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg.rs
@@ -100,82 +100,82 @@ impl RegisterBlock {
         &self.aoncrg_rst_status
     }
 }
-#[doc = "clk_osc (rw) register accessor: Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc`]
+#[doc = "clk_osc (rw) register accessor: Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc`]
 module"]
 pub type CLK_OSC = crate::Reg<clk_osc::CLK_OSC_SPEC>;
 #[doc = "Oscillator Clock"]
 pub mod clk_osc;
-#[doc = "clk_aon_apb (rw) register accessor: AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aon_apb`]
+#[doc = "clk_aon_apb (rw) register accessor: AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aon_apb`]
 module"]
 pub type CLK_AON_APB = crate::Reg<clk_aon_apb::CLK_AON_APB_SPEC>;
 #[doc = "AON APB Function Clock"]
 pub mod clk_aon_apb;
-#[doc = "clk_ahb_gmac5 (rw) register accessor: AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb_gmac5`]
+#[doc = "clk_ahb_gmac5 (rw) register accessor: AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb_gmac5`]
 module"]
 pub type CLK_AHB_GMAC5 = crate::Reg<clk_ahb_gmac5::CLK_AHB_GMAC5_SPEC>;
 #[doc = "AHB GMAC5 Clock"]
 pub mod clk_ahb_gmac5;
-#[doc = "clk_axi_gmac5 (rw) register accessor: AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_gmac5`]
+#[doc = "clk_axi_gmac5 (rw) register accessor: AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_gmac5`]
 module"]
 pub type CLK_AXI_GMAC5 = crate::Reg<clk_axi_gmac5::CLK_AXI_GMAC5_SPEC>;
 #[doc = "AXI GMAC5 Clock"]
 pub mod clk_axi_gmac5;
-#[doc = "clk_gmac0_rmii_rtx (rw) register accessor: GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_rmii_rtx`]
+#[doc = "clk_gmac0_rmii_rtx (rw) register accessor: GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_rmii_rtx`]
 module"]
 pub type CLK_GMAC0_RMII_RTX = crate::Reg<clk_gmac0_rmii_rtx::CLK_GMAC0_RMII_RTX_SPEC>;
 #[doc = "GMAC0 RMII RTX Clock"]
 pub mod clk_gmac0_rmii_rtx;
-#[doc = "clk_gmac5_axi64_tx (rw) register accessor: GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
+#[doc = "clk_gmac5_axi64_tx (rw) register accessor: GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
 module"]
 pub type CLK_GMAC5_AXI64_TX = crate::Reg<clk_gmac5_axi64_tx::CLK_GMAC5_AXI64_TX_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Transmitter"]
 pub mod clk_gmac5_axi64_tx;
-#[doc = "clk_gmac5_axi64_txi (rw) register accessor: GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
+#[doc = "clk_gmac5_axi64_txi (rw) register accessor: GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
 module"]
 pub type CLK_GMAC5_AXI64_TXI = crate::Reg<clk_gmac5_axi64_txi::CLK_GMAC5_AXI64_TXI_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Transmission Inverter"]
 pub mod clk_gmac5_axi64_txi;
-#[doc = "clk_gmac5_axi64_rx (rw) register accessor: GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
+#[doc = "clk_gmac5_axi64_rx (rw) register accessor: GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
 module"]
 pub type CLK_GMAC5_AXI64_RX = crate::Reg<clk_gmac5_axi64_rx::CLK_GMAC5_AXI64_RX_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Receiver"]
 pub mod clk_gmac5_axi64_rx;
-#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
+#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
 module"]
 pub type CLK_GMAC5_AXI64_RXI = crate::Reg<clk_gmac5_axi64_rxi::CLK_GMAC5_AXI64_RXI_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Receiving Inverter"]
 pub mod clk_gmac5_axi64_rxi;
-#[doc = "clk_optc_apb (rw) register accessor: OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_optc_apb`]
+#[doc = "clk_optc_apb (rw) register accessor: OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_optc_apb`]
 module"]
 pub type CLK_OPTC_APB = crate::Reg<clk_optc_apb::CLK_OPTC_APB_SPEC>;
 #[doc = "OPTC APB Clock"]
 pub mod clk_optc_apb;
-#[doc = "clk_rtc_hms_apb (rw) register accessor: RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_apb`]
+#[doc = "clk_rtc_hms_apb (rw) register accessor: RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_apb`]
 module"]
 pub type CLK_RTC_HMS_APB = crate::Reg<clk_rtc_hms_apb::CLK_RTC_HMS_APB_SPEC>;
 #[doc = "RTC HMS APB Clock"]
 pub mod clk_rtc_hms_apb;
-#[doc = "clk_rtc_internal (rw) register accessor: RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_internal`]
+#[doc = "clk_rtc_internal (rw) register accessor: RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_internal`]
 module"]
 pub type CLK_RTC_INTERNAL = crate::Reg<clk_rtc_internal::CLK_RTC_INTERNAL_SPEC>;
 #[doc = "RTC Internal Clock"]
 pub mod clk_rtc_internal;
-#[doc = "clk_rtc_hms_osc32k (rw) register accessor: RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_osc32k`]
+#[doc = "clk_rtc_hms_osc32k (rw) register accessor: RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_osc32k`]
 module"]
 pub type CLK_RTC_HMS_OSC32K = crate::Reg<clk_rtc_hms_osc32k::CLK_RTC_HMS_OSC32K_SPEC>;
 #[doc = "RTC HMS Clock Oscillator 32K"]
 pub mod clk_rtc_hms_osc32k;
-#[doc = "clk_rtc_hms_cal (rw) register accessor: RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_cal`]
+#[doc = "clk_rtc_hms_cal (rw) register accessor: RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_cal`]
 module"]
 pub type CLK_RTC_HMS_CAL = crate::Reg<clk_rtc_hms_cal::CLK_RTC_HMS_CAL_SPEC>;
 #[doc = "RTC HMS Clock Calculator"]
 pub mod clk_rtc_hms_cal;
-#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
+#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
 module"]
 pub type SOFT_RST_ADDR_SEL = crate::Reg<soft_rst_addr_sel::SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Software RESET Address Selector"]
 pub mod soft_rst_addr_sel;
-#[doc = "aoncrg_rst_status (rw) register accessor: AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@aoncrg_rst_status`]
+#[doc = "aoncrg_rst_status (rw) register accessor: AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@aoncrg_rst_status`]
 module"]
 pub type AONCRG_RST_STATUS = crate::Reg<aoncrg_rst_status::AONCRG_RST_STATUS_SPEC>;
 #[doc = "AONCRG RESET Status"]

--- a/jh7110-vf2-12a-pac/src/aoncrg/aoncrg_rst_status.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/aoncrg_rst_status.rs
@@ -136,7 +136,7 @@ impl W {
         self
     }
 }
-#[doc = "AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct AONCRG_RST_STATUS_SPEC;
 impl crate::RegisterSpec for AONCRG_RST_STATUS_SPEC {
     type Ux = u32;
@@ -147,4 +147,8 @@ impl crate::Readable for AONCRG_RST_STATUS_SPEC {}
 impl crate::Writable for AONCRG_RST_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets aoncrg_rst_status to value 0"]
+impl crate::Resettable for AONCRG_RST_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_ahb_gmac5.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_ahb_gmac5.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB_GMAC5_SPEC;
 impl crate::RegisterSpec for CLK_AHB_GMAC5_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB_GMAC5_SPEC {}
 impl crate::Writable for CLK_AHB_GMAC5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb_gmac5 to value 0"]
+impl crate::Resettable for CLK_AHB_GMAC5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_aon_apb.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_aon_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AON_APB_SPEC;
 impl crate::RegisterSpec for CLK_AON_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AON_APB_SPEC {}
 impl crate::Writable for CLK_AON_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_aon_apb to value 0"]
+impl crate::Resettable for CLK_AON_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_axi_gmac5.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_axi_gmac5.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_GMAC5_SPEC;
 impl crate::RegisterSpec for CLK_AXI_GMAC5_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_GMAC5_SPEC {}
 impl crate::Writable for CLK_AXI_GMAC5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_gmac5 to value 0"]
+impl crate::Resettable for CLK_AXI_GMAC5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac0_rmii_rtx.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac0_rmii_rtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_RMII_RTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_RMII_RTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC0_RMII_RTX_SPEC {}
 impl crate::Writable for CLK_GMAC0_RMII_RTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_rmii_rtx to value 0"]
+impl crate::Resettable for CLK_GMAC0_RMII_RTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_rx.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_rx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_rxi.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_rxi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rxi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_tx.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_tx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_tx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_txi.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_gmac5_axi64_txi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_txi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_optc_apb.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_optc_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OPTC_APB_SPEC;
 impl crate::RegisterSpec for CLK_OPTC_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OPTC_APB_SPEC {}
 impl crate::Writable for CLK_OPTC_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_optc_apb to value 0"]
+impl crate::Resettable for CLK_OPTC_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_osc.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_osc.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OSC_SPEC;
 impl crate::RegisterSpec for CLK_OSC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OSC_SPEC {}
 impl crate::Writable for CLK_OSC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_osc to value 0"]
+impl crate::Resettable for CLK_OSC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_apb.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_APB_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_APB_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_apb to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_cal.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_cal.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_CAL_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_CAL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_CAL_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_CAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_cal to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_CAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_osc32k.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_hms_osc32k.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_OSC32K_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_OSC32K_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_OSC32K_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_OSC32K_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_osc32k to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_OSC32K_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_internal.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/clk_rtc_internal.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_INTERNAL_SPEC;
 impl crate::RegisterSpec for CLK_RTC_INTERNAL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_INTERNAL_SPEC {}
 impl crate::Writable for CLK_RTC_INTERNAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_internal to value 0"]
+impl crate::Resettable for CLK_RTC_INTERNAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/aoncrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/soft_rst_addr_sel.rs
@@ -136,7 +136,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -147,4 +147,8 @@ impl crate::Readable for SOFT_RST_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg.rs
@@ -190,165 +190,165 @@ impl RegisterBlock {
         &self.stgcrg_rst_stat
     }
 }
-#[doc = "clk_hifi4_core (rw) register accessor: Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
+#[doc = "clk_hifi4_core (rw) register accessor: Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
 module"]
 pub type CLK_HIFI4_CORE = crate::Reg<clk_hifi4_core::CLK_HIFI4_CORE_SPEC>;
 #[doc = "Clock HIFI4 Core"]
 pub mod clk_hifi4_core;
-#[doc = "clk_usb_apb (rw) register accessor: Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_apb`]
+#[doc = "clk_usb_apb (rw) register accessor: Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_apb`]
 module"]
 pub type CLK_USB_APB = crate::Reg<clk_usb_apb::CLK_USB_APB_SPEC>;
 #[doc = "Clock USB APB"]
 pub mod clk_usb_apb;
-#[doc = "clk_usb_utmi_apb (rw) register accessor: Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_utmi_apb`]
+#[doc = "clk_usb_utmi_apb (rw) register accessor: Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_utmi_apb`]
 module"]
 pub type CLK_USB_UTMI_APB = crate::Reg<clk_usb_utmi_apb::CLK_USB_UTMI_APB_SPEC>;
 #[doc = "Clock USB UTMI APB"]
 pub mod clk_usb_utmi_apb;
-#[doc = "clk_usb_axi (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_axi`]
+#[doc = "clk_usb_axi (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_axi`]
 module"]
 pub type CLK_USB_AXI = crate::Reg<clk_usb_axi::CLK_USB_AXI_SPEC>;
 #[doc = "Clock USB AXI"]
 pub mod clk_usb_axi;
-#[doc = "clk_usb_ipm (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_ipm`]
+#[doc = "clk_usb_ipm (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_ipm`]
 module"]
 pub type CLK_USB_IPM = crate::Reg<clk_usb_ipm::CLK_USB_IPM_SPEC>;
 #[doc = "Clock USB AXI"]
 pub mod clk_usb_ipm;
-#[doc = "clk_usb_stb (rw) register accessor: Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_stb`]
+#[doc = "clk_usb_stb (rw) register accessor: Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_stb`]
 module"]
 pub type CLK_USB_STB = crate::Reg<clk_usb_stb::CLK_USB_STB_SPEC>;
 #[doc = "Clock USB STB"]
 pub mod clk_usb_stb;
-#[doc = "clk_usb_app125 (rw) register accessor: Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_app125`]
+#[doc = "clk_usb_app125 (rw) register accessor: Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_app125`]
 module"]
 pub type CLK_USB_APP125 = crate::Reg<clk_usb_app125::CLK_USB_APP125_SPEC>;
 #[doc = "Clock USB APP 125"]
 pub mod clk_usb_app125;
-#[doc = "clk_usb_refclk (rw) register accessor: Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_refclk`]
+#[doc = "clk_usb_refclk (rw) register accessor: Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_refclk`]
 module"]
 pub type CLK_USB_REFCLK = crate::Reg<clk_usb_refclk::CLK_USB_REFCLK_SPEC>;
 #[doc = "Clock USB Reference Clock"]
 pub mod clk_usb_refclk;
-#[doc = "clk_u0_pcie_axi_mst0 (rw) register accessor: U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_axi_mst0`]
+#[doc = "clk_u0_pcie_axi_mst0 (rw) register accessor: U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_axi_mst0`]
 module"]
 pub type CLK_U0_PCIE_AXI_MST0 = crate::Reg<clk_u0_pcie_axi_mst0::CLK_U0_PCIE_AXI_MST0_SPEC>;
 #[doc = "U0 Clock PCIe AXI MST 0"]
 pub mod clk_u0_pcie_axi_mst0;
-#[doc = "clk_u0_pcie_apb (rw) register accessor: U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_apb`]
+#[doc = "clk_u0_pcie_apb (rw) register accessor: U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_apb`]
 module"]
 pub type CLK_U0_PCIE_APB = crate::Reg<clk_u0_pcie_apb::CLK_U0_PCIE_APB_SPEC>;
 #[doc = "U0 Clock PCIe APB"]
 pub mod clk_u0_pcie_apb;
-#[doc = "clk_u0_pcie_tl (rw) register accessor: U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_tl`]
+#[doc = "clk_u0_pcie_tl (rw) register accessor: U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_tl`]
 module"]
 pub type CLK_U0_PCIE_TL = crate::Reg<clk_u0_pcie_tl::CLK_U0_PCIE_TL_SPEC>;
 #[doc = "U0 Clock PCIe TL"]
 pub mod clk_u0_pcie_tl;
-#[doc = "clk_u1_pcie_axi_mst0 (rw) register accessor: U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_axi_mst0`]
+#[doc = "clk_u1_pcie_axi_mst0 (rw) register accessor: U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_axi_mst0`]
 module"]
 pub type CLK_U1_PCIE_AXI_MST0 = crate::Reg<clk_u1_pcie_axi_mst0::CLK_U1_PCIE_AXI_MST0_SPEC>;
 #[doc = "U1 Clock PCIe AXI MST 0"]
 pub mod clk_u1_pcie_axi_mst0;
-#[doc = "clk_u1_pcie_apb (rw) register accessor: U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_apb`]
+#[doc = "clk_u1_pcie_apb (rw) register accessor: U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_apb`]
 module"]
 pub type CLK_U1_PCIE_APB = crate::Reg<clk_u1_pcie_apb::CLK_U1_PCIE_APB_SPEC>;
 #[doc = "U1 Clock PCIe APB"]
 pub mod clk_u1_pcie_apb;
-#[doc = "clk_u1_pcie_tl (rw) register accessor: U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_tl`]
+#[doc = "clk_u1_pcie_tl (rw) register accessor: U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_tl`]
 module"]
 pub type CLK_U1_PCIE_TL = crate::Reg<clk_u1_pcie_tl::CLK_U1_PCIE_TL_SPEC>;
 #[doc = "U1 Clock PCIe TL"]
 pub mod clk_u1_pcie_tl;
-#[doc = "clk_pcie01_slv_dec_main (rw) register accessor: Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pcie01_slv_dec_main`]
+#[doc = "clk_pcie01_slv_dec_main (rw) register accessor: Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pcie01_slv_dec_main`]
 module"]
 pub type CLK_PCIE01_SLV_DEC_MAIN =
     crate::Reg<clk_pcie01_slv_dec_main::CLK_PCIE01_SLV_DEC_MAIN_SPEC>;
 #[doc = "Clock PCIe 01 SLV DEC Main"]
 pub mod clk_pcie01_slv_dec_main;
-#[doc = "clk_sec_hclk (rw) register accessor: Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_hclk`]
+#[doc = "clk_sec_hclk (rw) register accessor: Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_hclk`]
 module"]
 pub type CLK_SEC_HCLK = crate::Reg<clk_sec_hclk::CLK_SEC_HCLK_SPEC>;
 #[doc = "Clock Security HCLK"]
 pub mod clk_sec_hclk;
-#[doc = "clk_sec_misc_ahb (rw) register accessor: Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_misc_ahb`]
+#[doc = "clk_sec_misc_ahb (rw) register accessor: Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_misc_ahb`]
 module"]
 pub type CLK_SEC_MISC_AHB = crate::Reg<clk_sec_misc_ahb::CLK_SEC_MISC_AHB_SPEC>;
 #[doc = "Clock Security Miscellaneous AHB"]
 pub mod clk_sec_misc_ahb;
-#[doc = "clk_stg_mtrx_group0_main (rw) register accessor: Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_main`]
+#[doc = "clk_stg_mtrx_group0_main (rw) register accessor: Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_main`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_MAIN =
     crate::Reg<clk_stg_mtrx_group0_main::CLK_STG_MTRX_GROUP0_MAIN_SPEC>;
 #[doc = "Clock STG MTRX Group 0 Main"]
 pub mod clk_stg_mtrx_group0_main;
-#[doc = "clk_stg_mtrx_group0_bus (rw) register accessor: Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_bus`]
+#[doc = "clk_stg_mtrx_group0_bus (rw) register accessor: Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_bus`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_BUS =
     crate::Reg<clk_stg_mtrx_group0_bus::CLK_STG_MTRX_GROUP0_BUS_SPEC>;
 #[doc = "Clock STG MTRX Group 0 Bus"]
 pub mod clk_stg_mtrx_group0_bus;
-#[doc = "clk_stg_mtrx_group0_stg (rw) register accessor: Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_stg`]
+#[doc = "clk_stg_mtrx_group0_stg (rw) register accessor: Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_stg`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_STG =
     crate::Reg<clk_stg_mtrx_group0_stg::CLK_STG_MTRX_GROUP0_STG_SPEC>;
 #[doc = "Clock STG MTRX Group 0 STG"]
 pub mod clk_stg_mtrx_group0_stg;
-#[doc = "clk_stg_mtrx_group1_main (rw) register accessor: Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_main`]
+#[doc = "clk_stg_mtrx_group1_main (rw) register accessor: Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_main`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_MAIN =
     crate::Reg<clk_stg_mtrx_group1_main::CLK_STG_MTRX_GROUP1_MAIN_SPEC>;
 #[doc = "Clock STG MTRX Group 1 Main"]
 pub mod clk_stg_mtrx_group1_main;
-#[doc = "clk_stg_mtrx_group1_bus (rw) register accessor: Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_bus`]
+#[doc = "clk_stg_mtrx_group1_bus (rw) register accessor: Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_bus`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_BUS =
     crate::Reg<clk_stg_mtrx_group1_bus::CLK_STG_MTRX_GROUP1_BUS_SPEC>;
 #[doc = "Clock STG MTRX Group 1 Bus"]
 pub mod clk_stg_mtrx_group1_bus;
-#[doc = "clk_stg_mtrx_group1_stg (rw) register accessor: Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_stg`]
+#[doc = "clk_stg_mtrx_group1_stg (rw) register accessor: Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_stg`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_STG =
     crate::Reg<clk_stg_mtrx_group1_stg::CLK_STG_MTRX_GROUP1_STG_SPEC>;
 #[doc = "Clock STG MTRX Group 1 STG"]
 pub mod clk_stg_mtrx_group1_stg;
-#[doc = "clk_stg_mtrx_group1_hifi (rw) register accessor: Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_hifi`]
+#[doc = "clk_stg_mtrx_group1_hifi (rw) register accessor: Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_hifi`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_HIFI =
     crate::Reg<clk_stg_mtrx_group1_hifi::CLK_STG_MTRX_GROUP1_HIFI_SPEC>;
 #[doc = "Clock STG MTRX Group 1 HIFI"]
 pub mod clk_stg_mtrx_group1_hifi;
-#[doc = "clk_e2_rtc (rw) register accessor: Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_rtc`]
+#[doc = "clk_e2_rtc (rw) register accessor: Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_rtc`]
 module"]
 pub type CLK_E2_RTC = crate::Reg<clk_e2_rtc::CLK_E2_RTC_SPEC>;
 #[doc = "Clock E2 RTC"]
 pub mod clk_e2_rtc;
-#[doc = "clk_e2_core (rw) register accessor: Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_core`]
+#[doc = "clk_e2_core (rw) register accessor: Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_core`]
 module"]
 pub type CLK_E2_CORE = crate::Reg<clk_e2_core::CLK_E2_CORE_SPEC>;
 #[doc = "Clock E2 Core"]
 pub mod clk_e2_core;
-#[doc = "clk_e2_dbg (rw) register accessor: Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_dbg`]
+#[doc = "clk_e2_dbg (rw) register accessor: Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_dbg`]
 module"]
 pub type CLK_E2_DBG = crate::Reg<clk_e2_dbg::CLK_E2_DBG_SPEC>;
 #[doc = "Clock E2 DBG"]
 pub mod clk_e2_dbg;
-#[doc = "clk_dma_axi (rw) register accessor: Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_axi`]
+#[doc = "clk_dma_axi (rw) register accessor: Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_axi`]
 module"]
 pub type CLK_DMA_AXI = crate::Reg<clk_dma_axi::CLK_DMA_AXI_SPEC>;
 #[doc = "Clock DMA AXI"]
 pub mod clk_dma_axi;
-#[doc = "clk_dma_ahb (rw) register accessor: Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_ahb`]
+#[doc = "clk_dma_ahb (rw) register accessor: Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_ahb`]
 module"]
 pub type CLK_DMA_AHB = crate::Reg<clk_dma_ahb::CLK_DMA_AHB_SPEC>;
 #[doc = "Clock DMA AHB"]
 pub mod clk_dma_ahb;
-#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
+#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
 module"]
 pub type SOFT_RST_ADDR_SEL = crate::Reg<soft_rst_addr_sel::SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Software RESET Address Selector"]
 pub mod soft_rst_addr_sel;
-#[doc = "stgcrg_rst_stat (rw) register accessor: STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stgcrg_rst_stat`]
+#[doc = "stgcrg_rst_stat (rw) register accessor: STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stgcrg_rst_stat`]
 module"]
 pub type STGCRG_RST_STAT = crate::Reg<stgcrg_rst_stat::STGCRG_RST_STAT_SPEC>;
 #[doc = "STGCRG RESET Status"]

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_dma_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_dma_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DMA_AHB_SPEC;
 impl crate::RegisterSpec for CLK_DMA_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DMA_AHB_SPEC {}
 impl crate::Writable for CLK_DMA_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_dma_ahb to value 0"]
+impl crate::Resettable for CLK_DMA_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_dma_axi.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_dma_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DMA_AXI_SPEC;
 impl crate::RegisterSpec for CLK_DMA_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DMA_AXI_SPEC {}
 impl crate::Writable for CLK_DMA_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_dma_axi to value 0"]
+impl crate::Resettable for CLK_DMA_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_core.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_CORE_SPEC;
 impl crate::RegisterSpec for CLK_E2_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_E2_CORE_SPEC {}
 impl crate::Writable for CLK_E2_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_core to value 0"]
+impl crate::Resettable for CLK_E2_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_dbg.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_dbg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_DBG_SPEC;
 impl crate::RegisterSpec for CLK_E2_DBG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_E2_DBG_SPEC {}
 impl crate::Writable for CLK_E2_DBG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_dbg to value 0"]
+impl crate::Resettable for CLK_E2_DBG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_rtc.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_e2_rtc.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_RTC_SPEC;
 impl crate::RegisterSpec for CLK_E2_RTC_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_E2_RTC_SPEC {}
 impl crate::Writable for CLK_E2_RTC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_rtc to value 0"]
+impl crate::Resettable for CLK_E2_RTC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_hifi4_core.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_hifi4_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_CORE_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_CORE_SPEC {}
 impl crate::Writable for CLK_HIFI4_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_core to value 0"]
+impl crate::Resettable for CLK_HIFI4_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_pcie01_slv_dec_main.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_pcie01_slv_dec_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PCIE01_SLV_DEC_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {}
 impl crate::Writable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pcie01_slv_dec_main to value 0"]
+impl crate::Resettable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_sec_hclk.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_sec_hclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SEC_HCLK_SPEC;
 impl crate::RegisterSpec for CLK_SEC_HCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SEC_HCLK_SPEC {}
 impl crate::Writable for CLK_SEC_HCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sec_hclk to value 0"]
+impl crate::Resettable for CLK_SEC_HCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_sec_misc_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_sec_misc_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SEC_MISC_AHB_SPEC;
 impl crate::RegisterSpec for CLK_SEC_MISC_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SEC_MISC_AHB_SPEC {}
 impl crate::Writable for CLK_SEC_MISC_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sec_misc_ahb to value 0"]
+impl crate::Resettable for CLK_SEC_MISC_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_bus.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_BUS_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_BUS_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_bus to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_main.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_main to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_stg.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group0_stg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_STG_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_STG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_STG_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_STG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_stg to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_STG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_bus.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_BUS_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_BUS_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_bus to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_hifi.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_hifi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_HIFI_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_hifi to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_main.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_main to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_stg.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_stg_mtrx_group1_stg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_STG_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_STG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_STG_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_STG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_stg to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_STG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_apb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_APB_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_apb to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_axi_mst0.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_axi_mst0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_AXI_MST0_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_AXI_MST0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_AXI_MST0_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_AXI_MST0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_axi_mst0 to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_AXI_MST0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_tl.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u0_pcie_tl.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_TL_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_TL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_TL_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_TL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_tl to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_TL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_apb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_APB_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_apb to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_axi_mst0.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_axi_mst0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_AXI_MST0_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_AXI_MST0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_AXI_MST0_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_AXI_MST0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_axi_mst0 to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_AXI_MST0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_tl.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_u1_pcie_tl.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_TL_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_TL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_TL_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_TL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_tl to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_TL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_apb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_APB_SPEC;
 impl crate::RegisterSpec for CLK_USB_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_APB_SPEC {}
 impl crate::Writable for CLK_USB_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_apb to value 0"]
+impl crate::Resettable for CLK_USB_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_app125.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_app125.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_APP125_SPEC;
 impl crate::RegisterSpec for CLK_USB_APP125_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_APP125_SPEC {}
 impl crate::Writable for CLK_USB_APP125_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_app125 to value 0"]
+impl crate::Resettable for CLK_USB_APP125_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_axi.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_AXI_SPEC;
 impl crate::RegisterSpec for CLK_USB_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_AXI_SPEC {}
 impl crate::Writable for CLK_USB_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_axi to value 0"]
+impl crate::Resettable for CLK_USB_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_ipm.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_ipm.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_IPM_SPEC;
 impl crate::RegisterSpec for CLK_USB_IPM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_USB_IPM_SPEC {}
 impl crate::Writable for CLK_USB_IPM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_ipm to value 0"]
+impl crate::Resettable for CLK_USB_IPM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_refclk.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_refclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_REFCLK_SPEC;
 impl crate::RegisterSpec for CLK_USB_REFCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_REFCLK_SPEC {}
 impl crate::Writable for CLK_USB_REFCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_refclk to value 0"]
+impl crate::Resettable for CLK_USB_REFCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_stb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_stb.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_STB_SPEC;
 impl crate::RegisterSpec for CLK_USB_STB_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_USB_STB_SPEC {}
 impl crate::Writable for CLK_USB_STB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_stb to value 0"]
+impl crate::Resettable for CLK_USB_STB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_utmi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/clk_usb_utmi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_UTMI_APB_SPEC;
 impl crate::RegisterSpec for CLK_USB_UTMI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_UTMI_APB_SPEC {}
 impl crate::Writable for CLK_USB_UTMI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_utmi_apb to value 0"]
+impl crate::Resettable for CLK_USB_UTMI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/soft_rst_addr_sel.rs
@@ -403,7 +403,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -414,4 +414,8 @@ impl crate::Readable for SOFT_RST_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/stgcrg/stgcrg_rst_stat.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/stgcrg_rst_stat.rs
@@ -399,7 +399,7 @@ impl W {
         self
     }
 }
-#[doc = "STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct STGCRG_RST_STAT_SPEC;
 impl crate::RegisterSpec for STGCRG_RST_STAT_SPEC {
     type Ux = u32;
@@ -410,4 +410,8 @@ impl crate::Readable for STGCRG_RST_STAT_SPEC {}
 impl crate::Writable for STGCRG_RST_STAT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets stgcrg_rst_stat to value 0"]
+impl crate::Resettable for STGCRG_RST_STAT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg.rs
@@ -1202,1005 +1202,1005 @@ impl RegisterBlock {
         &self.syscrg_rst3_status
     }
 }
-#[doc = "clk_cpu_root (rw) register accessor: Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_root`]
+#[doc = "clk_cpu_root (rw) register accessor: Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_root`]
 module"]
 pub type CLK_CPU_ROOT = crate::Reg<clk_cpu_root::CLK_CPU_ROOT_SPEC>;
 #[doc = "Clock CPU Root"]
 pub mod clk_cpu_root;
-#[doc = "clk_cpu_core (rw) register accessor: Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_core`]
+#[doc = "clk_cpu_core (rw) register accessor: Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_core`]
 module"]
 pub type CLK_CPU_CORE = crate::Reg<clk_cpu_core::CLK_CPU_CORE_SPEC>;
 #[doc = "Clock CPU Core"]
 pub mod clk_cpu_core;
-#[doc = "clk_cpu_bus (rw) register accessor: Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_bus`]
+#[doc = "clk_cpu_bus (rw) register accessor: Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_bus`]
 module"]
 pub type CLK_CPU_BUS = crate::Reg<clk_cpu_bus::CLK_CPU_BUS_SPEC>;
 #[doc = "Clock CPU Bus"]
 pub mod clk_cpu_bus;
-#[doc = "clk_gpu_root (rw) register accessor: Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_root`]
+#[doc = "clk_gpu_root (rw) register accessor: Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_root`]
 module"]
 pub type CLK_GPU_ROOT = crate::Reg<clk_gpu_root::CLK_GPU_ROOT_SPEC>;
 #[doc = "Clock GPU Root"]
 pub mod clk_gpu_root;
-#[doc = "clk_peripheral_root (rw) register accessor: Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_peripheral_root`]
+#[doc = "clk_peripheral_root (rw) register accessor: Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_peripheral_root`]
 module"]
 pub type CLK_PERIPHERAL_ROOT = crate::Reg<clk_peripheral_root::CLK_PERIPHERAL_ROOT_SPEC>;
 #[doc = "Clock Peripheral Root"]
 pub mod clk_peripheral_root;
-#[doc = "clk_bus_root (rw) register accessor: Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_bus_root`]
+#[doc = "clk_bus_root (rw) register accessor: Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_bus_root`]
 module"]
 pub type CLK_BUS_ROOT = crate::Reg<clk_bus_root::CLK_BUS_ROOT_SPEC>;
 #[doc = "Clock Bus Root"]
 pub mod clk_bus_root;
-#[doc = "clk_nocstg_bus (rw) register accessor: Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_nocstg_bus`]
+#[doc = "clk_nocstg_bus (rw) register accessor: Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_nocstg_bus`]
 module"]
 pub type CLK_NOCSTG_BUS = crate::Reg<clk_nocstg_bus::CLK_NOCSTG_BUS_SPEC>;
 #[doc = "Clock NOCSTG Bus"]
 pub mod clk_nocstg_bus;
-#[doc = "clk_axi_cfg0 (rw) register accessor: Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0`]
+#[doc = "clk_axi_cfg0 (rw) register accessor: Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0`]
 module"]
 pub type CLK_AXI_CFG0 = crate::Reg<clk_axi_cfg0::CLK_AXI_CFG0_SPEC>;
 #[doc = "Clock AXI Configuration 0"]
 pub mod clk_axi_cfg0;
-#[doc = "clk_stg_axiahb (rw) register accessor: Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_axiahb`]
+#[doc = "clk_stg_axiahb (rw) register accessor: Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_axiahb`]
 module"]
 pub type CLK_STG_AXIAHB = crate::Reg<clk_stg_axiahb::CLK_STG_AXIAHB_SPEC>;
 #[doc = "Clock STG AXI AHB"]
 pub mod clk_stg_axiahb;
-#[doc = "clk_ahb0 (rw) register accessor: Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb0`]
+#[doc = "clk_ahb0 (rw) register accessor: Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb0`]
 module"]
 pub type CLK_AHB0 = crate::Reg<clk_ahb0::CLK_AHB0_SPEC>;
 #[doc = "Clock AHB 0"]
 pub mod clk_ahb0;
-#[doc = "clk_ahb1 (rw) register accessor: Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb1`]
+#[doc = "clk_ahb1 (rw) register accessor: Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb1`]
 module"]
 pub type CLK_AHB1 = crate::Reg<clk_ahb1::CLK_AHB1_SPEC>;
 #[doc = "Clock AHB 1"]
 pub mod clk_ahb1;
-#[doc = "clk_apb_bus (rw) register accessor: Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb_bus`]
+#[doc = "clk_apb_bus (rw) register accessor: Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb_bus`]
 module"]
 pub type CLK_APB_BUS = crate::Reg<clk_apb_bus::CLK_APB_BUS_SPEC>;
 #[doc = "Clock APB Bus"]
 pub mod clk_apb_bus;
-#[doc = "clk_apb0 (rw) register accessor: Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb0`]
+#[doc = "clk_apb0 (rw) register accessor: Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb0`]
 module"]
 pub type CLK_APB0 = crate::Reg<clk_apb0::CLK_APB0_SPEC>;
 #[doc = "Clock APB 0"]
 pub mod clk_apb0;
-#[doc = "clk_pll0_div2 (rw) register accessor: Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll0_div2`]
+#[doc = "clk_pll0_div2 (rw) register accessor: Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll0_div2`]
 module"]
 pub type CLK_PLL0_DIV2 = crate::Reg<clk_pll0_div2::CLK_PLL0_DIV2_SPEC>;
 #[doc = "Clock PLL 0 Divider 2"]
 pub mod clk_pll0_div2;
-#[doc = "clk_pll1_div2 (rw) register accessor: Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div2`]
+#[doc = "clk_pll1_div2 (rw) register accessor: Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div2`]
 module"]
 pub type CLK_PLL1_DIV2 = crate::Reg<clk_pll1_div2::CLK_PLL1_DIV2_SPEC>;
 #[doc = "Clock PLL 1 Divider 2"]
 pub mod clk_pll1_div2;
-#[doc = "clk_pll2_div2 (rw) register accessor: Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll2_div2`]
+#[doc = "clk_pll2_div2 (rw) register accessor: Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll2_div2`]
 module"]
 pub type CLK_PLL2_DIV2 = crate::Reg<clk_pll2_div2::CLK_PLL2_DIV2_SPEC>;
 #[doc = "Clock PLL 2 Divider 2"]
 pub mod clk_pll2_div2;
-#[doc = "clk_audio_root (rw) register accessor: Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_audio_root`]
+#[doc = "clk_audio_root (rw) register accessor: Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_audio_root`]
 module"]
 pub type CLK_AUDIO_ROOT = crate::Reg<clk_audio_root::CLK_AUDIO_ROOT_SPEC>;
 #[doc = "Clock Audio Root"]
 pub mod clk_audio_root;
-#[doc = "clk_mclk_inner (rw) register accessor: Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_inner`]
+#[doc = "clk_mclk_inner (rw) register accessor: Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_inner`]
 module"]
 pub type CLK_MCLK_INNER = crate::Reg<clk_mclk_inner::CLK_MCLK_INNER_SPEC>;
 #[doc = "Clock MCLK Inner"]
 pub mod clk_mclk_inner;
-#[doc = "clk_mclk (rw) register accessor: Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk`]
+#[doc = "clk_mclk (rw) register accessor: Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk`]
 module"]
 pub type CLK_MCLK = crate::Reg<clk_mclk::CLK_MCLK_SPEC>;
 #[doc = "Clock MCLK"]
 pub mod clk_mclk;
-#[doc = "clk_mclk_out (rw) register accessor: Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_out`]
+#[doc = "clk_mclk_out (rw) register accessor: Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_out`]
 module"]
 pub type CLK_MCLK_OUT = crate::Reg<clk_mclk_out::CLK_MCLK_OUT_SPEC>;
 #[doc = "Clock MCLK Out"]
 pub mod clk_mclk_out;
-#[doc = "clk_isp_2x (rw) register accessor: Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_2x`]
+#[doc = "clk_isp_2x (rw) register accessor: Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_2x`]
 module"]
 pub type CLK_ISP_2X = crate::Reg<clk_isp_2x::CLK_ISP_2X_SPEC>;
 #[doc = "Clock ISP 2x"]
 pub mod clk_isp_2x;
-#[doc = "clk_isp_axi (rw) register accessor: Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_axi`]
+#[doc = "clk_isp_axi (rw) register accessor: Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_axi`]
 module"]
 pub type CLK_ISP_AXI = crate::Reg<clk_isp_axi::CLK_ISP_AXI_SPEC>;
 #[doc = "Clock ISP AXI"]
 pub mod clk_isp_axi;
-#[doc = "clk_gclk0 (rw) register accessor: Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk0`]
+#[doc = "clk_gclk0 (rw) register accessor: Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk0`]
 module"]
 pub type CLK_GCLK0 = crate::Reg<clk_gclk0::CLK_GCLK0_SPEC>;
 #[doc = "Clock GCLK 0"]
 pub mod clk_gclk0;
-#[doc = "clk_gclk1 (rw) register accessor: Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk1`]
+#[doc = "clk_gclk1 (rw) register accessor: Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk1`]
 module"]
 pub type CLK_GCLK1 = crate::Reg<clk_gclk1::CLK_GCLK1_SPEC>;
 #[doc = "Clock GCLK 1"]
 pub mod clk_gclk1;
-#[doc = "clk_gclk2 (rw) register accessor: Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk2`]
+#[doc = "clk_gclk2 (rw) register accessor: Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk2`]
 module"]
 pub type CLK_GCLK2 = crate::Reg<clk_gclk2::CLK_GCLK2_SPEC>;
 #[doc = "Clock GCLK 2"]
 pub mod clk_gclk2;
-#[doc = "clk_u7mc_core0 (rw) register accessor: U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core0`]
+#[doc = "clk_u7mc_core0 (rw) register accessor: U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core0`]
 module"]
 pub type CLK_U7MC_CORE0 = crate::Reg<clk_u7mc_core0::CLK_U7MC_CORE0_SPEC>;
 #[doc = "U7MC Core Clock 0"]
 pub mod clk_u7mc_core0;
-#[doc = "clk_u7mc_core1 (rw) register accessor: U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core1`]
+#[doc = "clk_u7mc_core1 (rw) register accessor: U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core1`]
 module"]
 pub type CLK_U7MC_CORE1 = crate::Reg<clk_u7mc_core1::CLK_U7MC_CORE1_SPEC>;
 #[doc = "U7MC Core Clock 1"]
 pub mod clk_u7mc_core1;
-#[doc = "clk_u7mc_core2 (rw) register accessor: U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core2`]
+#[doc = "clk_u7mc_core2 (rw) register accessor: U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core2`]
 module"]
 pub type CLK_U7MC_CORE2 = crate::Reg<clk_u7mc_core2::CLK_U7MC_CORE2_SPEC>;
 #[doc = "U7MC Core Clock 2"]
 pub mod clk_u7mc_core2;
-#[doc = "clk_u7mc_core3 (rw) register accessor: U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core3`]
+#[doc = "clk_u7mc_core3 (rw) register accessor: U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core3`]
 module"]
 pub type CLK_U7MC_CORE3 = crate::Reg<clk_u7mc_core3::CLK_U7MC_CORE3_SPEC>;
 #[doc = "U7MC Core Clock 3"]
 pub mod clk_u7mc_core3;
-#[doc = "clk_u7mc_core4 (rw) register accessor: U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core4`]
+#[doc = "clk_u7mc_core4 (rw) register accessor: U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core4`]
 module"]
 pub type CLK_U7MC_CORE4 = crate::Reg<clk_u7mc_core4::CLK_U7MC_CORE4_SPEC>;
 #[doc = "U7MC Core Clock 4"]
 pub mod clk_u7mc_core4;
-#[doc = "clk_u7mc_debug (rw) register accessor: U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_debug`]
+#[doc = "clk_u7mc_debug (rw) register accessor: U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_debug`]
 module"]
 pub type CLK_U7MC_DEBUG = crate::Reg<clk_u7mc_debug::CLK_U7MC_DEBUG_SPEC>;
 #[doc = "U7MC Debug Clock"]
 pub mod clk_u7mc_debug;
-#[doc = "u7mc_rtc_toggle (rw) register accessor: U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@u7mc_rtc_toggle`]
+#[doc = "u7mc_rtc_toggle (rw) register accessor: U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@u7mc_rtc_toggle`]
 module"]
 pub type U7MC_RTC_TOGGLE = crate::Reg<u7mc_rtc_toggle::U7MC_RTC_TOGGLE_SPEC>;
 #[doc = "U7MC RTC Toggle"]
 pub mod u7mc_rtc_toggle;
-#[doc = "clk_u7mc_trace0 (rw) register accessor: U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace0`]
+#[doc = "clk_u7mc_trace0 (rw) register accessor: U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace0`]
 module"]
 pub type CLK_U7MC_TRACE0 = crate::Reg<clk_u7mc_trace0::CLK_U7MC_TRACE0_SPEC>;
 #[doc = "U7MC Trace Clock 0"]
 pub mod clk_u7mc_trace0;
-#[doc = "clk_u7mc_trace1 (rw) register accessor: U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace1`]
+#[doc = "clk_u7mc_trace1 (rw) register accessor: U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace1`]
 module"]
 pub type CLK_U7MC_TRACE1 = crate::Reg<clk_u7mc_trace1::CLK_U7MC_TRACE1_SPEC>;
 #[doc = "U7MC Trace Clock 1"]
 pub mod clk_u7mc_trace1;
-#[doc = "clk_u7mc_trace2 (rw) register accessor: U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace2`]
+#[doc = "clk_u7mc_trace2 (rw) register accessor: U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace2`]
 module"]
 pub type CLK_U7MC_TRACE2 = crate::Reg<clk_u7mc_trace2::CLK_U7MC_TRACE2_SPEC>;
 #[doc = "U7MC Trace Clock 2"]
 pub mod clk_u7mc_trace2;
-#[doc = "clk_u7mc_trace3 (rw) register accessor: U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace3`]
+#[doc = "clk_u7mc_trace3 (rw) register accessor: U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace3`]
 module"]
 pub type CLK_U7MC_TRACE3 = crate::Reg<clk_u7mc_trace3::CLK_U7MC_TRACE3_SPEC>;
 #[doc = "U7MC Trace Clock 3"]
 pub mod clk_u7mc_trace3;
-#[doc = "clk_u7mc_trace4 (rw) register accessor: U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace4`]
+#[doc = "clk_u7mc_trace4 (rw) register accessor: U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace4`]
 module"]
 pub type CLK_U7MC_TRACE4 = crate::Reg<clk_u7mc_trace4::CLK_U7MC_TRACE4_SPEC>;
 #[doc = "U7MC Trace Clock 4"]
 pub mod clk_u7mc_trace4;
-#[doc = "clk_u7mc_trace_com (rw) register accessor: U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace_com`]
+#[doc = "clk_u7mc_trace_com (rw) register accessor: U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace_com`]
 module"]
 pub type CLK_U7MC_TRACE_COM = crate::Reg<clk_u7mc_trace_com::CLK_U7MC_TRACE_COM_SPEC>;
 #[doc = "U7MC Trace Clock COM"]
 pub mod clk_u7mc_trace_com;
-#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_cpu_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_cpu_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_cpu_axi::CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_cpu_axi;
-#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_axicfg0_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_axicfg0_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_axicfg0_axi::CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_axicfg0_axi;
-#[doc = "clk_osc_div2 (rw) register accessor: clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc_div2`]
+#[doc = "clk_osc_div2 (rw) register accessor: clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc_div2`]
 module"]
 pub type CLK_OSC_DIV2 = crate::Reg<clk_osc_div2::CLK_OSC_DIV2_SPEC>;
 #[doc = "clk_osc_div2"]
 pub mod clk_osc_div2;
-#[doc = "clk_pll1_div4 (rw) register accessor: clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div4`]
+#[doc = "clk_pll1_div4 (rw) register accessor: clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div4`]
 module"]
 pub type CLK_PLL1_DIV4 = crate::Reg<clk_pll1_div4::CLK_PLL1_DIV4_SPEC>;
 #[doc = "clk_pll1_div4"]
 pub mod clk_pll1_div4;
-#[doc = "clk_pll1_div8 (rw) register accessor: clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div8`]
+#[doc = "clk_pll1_div8 (rw) register accessor: clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div8`]
 module"]
 pub type CLK_PLL1_DIV8 = crate::Reg<clk_pll1_div8::CLK_PLL1_DIV8_SPEC>;
 #[doc = "clk_pll1_div8"]
 pub mod clk_pll1_div8;
-#[doc = "clk_ddr_bus (rw) register accessor: clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ddr_bus`]
+#[doc = "clk_ddr_bus (rw) register accessor: clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ddr_bus`]
 module"]
 pub type CLK_DDR_BUS = crate::Reg<clk_ddr_bus::CLK_DDR_BUS_SPEC>;
 #[doc = "clk_ddr_bus"]
 pub mod clk_ddr_bus;
-#[doc = "clk_u0_ddr_sft7110_clk_axi (rw) register accessor: clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_ddr_sft7110_clk_axi`]
+#[doc = "clk_u0_ddr_sft7110_clk_axi (rw) register accessor: clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_ddr_sft7110_clk_axi`]
 module"]
 pub type CLK_U0_DDR_SFT7110_CLK_AXI =
     crate::Reg<clk_u0_ddr_sft7110_clk_axi::CLK_U0_DDR_SFT7110_CLK_AXI_SPEC>;
 #[doc = "clk_u0_ddr_sfft7110_clk_axi"]
 pub mod clk_u0_ddr_sft7110_clk_axi;
-#[doc = "clk_gpu_core (rw) register accessor: clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_core`]
+#[doc = "clk_gpu_core (rw) register accessor: clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_core`]
 module"]
 pub type CLK_GPU_CORE = crate::Reg<clk_gpu_core::CLK_GPU_CORE_SPEC>;
 #[doc = "clk_gpu_core"]
 pub mod clk_gpu_core;
-#[doc = "clk_u0_img_gpu_core_clk (rw) register accessor: clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_core_clk`]
+#[doc = "clk_u0_img_gpu_core_clk (rw) register accessor: clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_core_clk`]
 module"]
 pub type CLK_U0_IMG_GPU_CORE_CLK =
     crate::Reg<clk_u0_img_gpu_core_clk::CLK_U0_IMG_GPU_CORE_CLK_SPEC>;
 #[doc = "clk_u0_img_gpu_core_clk"]
 pub mod clk_u0_img_gpu_core_clk;
-#[doc = "clk_u0_img_gpu_sys_clk (rw) register accessor: clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_sys_clk`]
+#[doc = "clk_u0_img_gpu_sys_clk (rw) register accessor: clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_sys_clk`]
 module"]
 pub type CLK_U0_IMG_GPU_SYS_CLK = crate::Reg<clk_u0_img_gpu_sys_clk::CLK_U0_IMG_GPU_SYS_CLK_SPEC>;
 #[doc = "clk_u0_img_gpu_sys_clk"]
 pub mod clk_u0_img_gpu_sys_clk;
-#[doc = "clk_u0_img_gpu_clk_apb (rw) register accessor: clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_clk_apb`]
+#[doc = "clk_u0_img_gpu_clk_apb (rw) register accessor: clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_clk_apb`]
 module"]
 pub type CLK_U0_IMG_GPU_CLK_APB = crate::Reg<clk_u0_img_gpu_clk_apb::CLK_U0_IMG_GPU_CLK_APB_SPEC>;
 #[doc = "clk_u0_img_gpu_clk_apb"]
 pub mod clk_u0_img_gpu_clk_apb;
-#[doc = "clk_u0_gpu_rtc_toggle (rw) register accessor: clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_gpu_rtc_toggle`]
+#[doc = "clk_u0_gpu_rtc_toggle (rw) register accessor: clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_gpu_rtc_toggle`]
 module"]
 pub type CLK_U0_GPU_RTC_TOGGLE = crate::Reg<clk_u0_gpu_rtc_toggle::CLK_U0_GPU_RTC_TOGGLE_SPEC>;
 #[doc = "clk_u0_gpu_rtc_toggle"]
 pub mod clk_u0_gpu_rtc_toggle;
-#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_gpu_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_gpu_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_gpu_axi::CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_gpu_axi;
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x`]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x`]
 module"]
 pub type CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X = crate :: Reg < clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x :: CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC > ;
 #[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x"]
 pub mod clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x;
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi`]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi`]
 module"]
 pub type CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI = crate :: Reg < clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi :: CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC > ;
 #[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi"]
 pub mod clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi;
-#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi (rw) register accessor: clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bux_clk_isp_axi`]
+#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi (rw) register accessor: clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bux_clk_isp_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI =
     crate::Reg<clk_u0_sft7110_noc_bux_clk_isp_axi::CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi"]
 pub mod clk_u0_sft7110_noc_bux_clk_isp_axi;
-#[doc = "clk_hifi4_core (rw) register accessor: clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
+#[doc = "clk_hifi4_core (rw) register accessor: clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
 module"]
 pub type CLK_HIFI4_CORE = crate::Reg<clk_hifi4_core::CLK_HIFI4_CORE_SPEC>;
 #[doc = "clk_hifi4_core"]
 pub mod clk_hifi4_core;
-#[doc = "clk_hifi4_axi (rw) register accessor: clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_axi`]
+#[doc = "clk_hifi4_axi (rw) register accessor: clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_axi`]
 module"]
 pub type CLK_HIFI4_AXI = crate::Reg<clk_hifi4_axi::CLK_HIFI4_AXI_SPEC>;
 #[doc = "clk_hifi4_axi"]
 pub mod clk_hifi4_axi;
-#[doc = "clk_u0_axi_cfg1_dec_clk_main (rw) register accessor: clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_main`]
+#[doc = "clk_u0_axi_cfg1_dec_clk_main (rw) register accessor: clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_main`]
 module"]
 pub type CLK_U0_AXI_CFG1_DEC_CLK_MAIN =
     crate::Reg<clk_u0_axi_cfg1_dec_clk_main::CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC>;
 #[doc = "clk_u0_axi_cfg1_dec_clk_main"]
 pub mod clk_u0_axi_cfg1_dec_clk_main;
-#[doc = "clk_u0_axi_cfg1_dec_clk_ahb (rw) register accessor: clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_ahb`]
+#[doc = "clk_u0_axi_cfg1_dec_clk_ahb (rw) register accessor: clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_ahb`]
 module"]
 pub type CLK_U0_AXI_CFG1_DEC_CLK_AHB =
     crate::Reg<clk_u0_axi_cfg1_dec_clk_ahb::CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC>;
 #[doc = "clk_u0_axi_cfg1_dec_clk_ahb"]
 pub mod clk_u0_axi_cfg1_dec_clk_ahb;
-#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src (rw) register accessor: clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src`]
+#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src (rw) register accessor: clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src`]
 module"]
 pub type CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC = crate :: Reg < clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src :: CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC > ;
 #[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src"]
 pub mod clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src;
-#[doc = "clk_vout_axi_divcfg (rw) register accessor: Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_divcfg`]
+#[doc = "clk_vout_axi_divcfg (rw) register accessor: Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_divcfg`]
 module"]
 pub type CLK_VOUT_AXI_DIVCFG = crate::Reg<clk_vout_axi_divcfg::CLK_VOUT_AXI_DIVCFG_SPEC>;
 #[doc = "Clock Video Output AXI DIVCFG"]
 pub mod clk_vout_axi_divcfg;
-#[doc = "clk_noc_display_axi (rw) register accessor: Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_display_axi`]
+#[doc = "clk_noc_display_axi (rw) register accessor: Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_display_axi`]
 module"]
 pub type CLK_NOC_DISPLAY_AXI = crate::Reg<clk_noc_display_axi::CLK_NOC_DISPLAY_AXI_SPEC>;
 #[doc = "Clock NOC Display AXI"]
 pub mod clk_noc_display_axi;
-#[doc = "clk_vout_ahb (rw) register accessor: Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_ahb`]
+#[doc = "clk_vout_ahb (rw) register accessor: Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_ahb`]
 module"]
 pub type CLK_VOUT_AHB = crate::Reg<clk_vout_ahb::CLK_VOUT_AHB_SPEC>;
 #[doc = "Clock Video Output AHB"]
 pub mod clk_vout_ahb;
-#[doc = "clk_vout_axi_icg (rw) register accessor: Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_icg`]
+#[doc = "clk_vout_axi_icg (rw) register accessor: Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_icg`]
 module"]
 pub type CLK_VOUT_AXI_ICG = crate::Reg<clk_vout_axi_icg::CLK_VOUT_AXI_ICG_SPEC>;
 #[doc = "Clock Video Output AXI ICG"]
 pub mod clk_vout_axi_icg;
-#[doc = "clk_vout_hdmi_tx0_mclk (rw) register accessor: Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_hdmi_tx0_mclk`]
+#[doc = "clk_vout_hdmi_tx0_mclk (rw) register accessor: Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_hdmi_tx0_mclk`]
 module"]
 pub type CLK_VOUT_HDMI_TX0_MCLK = crate::Reg<clk_vout_hdmi_tx0_mclk::CLK_VOUT_HDMI_TX0_MCLK_SPEC>;
 #[doc = "Clock Video Output HDMI TX0 MCLK"]
 pub mod clk_vout_hdmi_tx0_mclk;
-#[doc = "clk_vout_mipi_phy (rw) register accessor: Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_mipi_phy`]
+#[doc = "clk_vout_mipi_phy (rw) register accessor: Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_mipi_phy`]
 module"]
 pub type CLK_VOUT_MIPI_PHY = crate::Reg<clk_vout_mipi_phy::CLK_VOUT_MIPI_PHY_SPEC>;
 #[doc = "Clock Video Output MIPI PHY Reference"]
 pub mod clk_vout_mipi_phy;
-#[doc = "clk_jpeg_codec_axi (rw) register accessor: Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jpeg_codec_axi`]
+#[doc = "clk_jpeg_codec_axi (rw) register accessor: Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jpeg_codec_axi`]
 module"]
 pub type CLK_JPEG_CODEC_AXI = crate::Reg<clk_jpeg_codec_axi::CLK_JPEG_CODEC_AXI_SPEC>;
 #[doc = "Clock JPEG Codec AXI"]
 pub mod clk_jpeg_codec_axi;
-#[doc = "clk_codaj12_axi (rw) register accessor: CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_axi`]
+#[doc = "clk_codaj12_axi (rw) register accessor: CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_axi`]
 module"]
 pub type CLK_CODAJ12_AXI = crate::Reg<clk_codaj12_axi::CLK_CODAJ12_AXI_SPEC>;
 #[doc = "CODAJ12 Clock AXI"]
 pub mod clk_codaj12_axi;
-#[doc = "clk_codaj12_core (rw) register accessor: CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_core`]
+#[doc = "clk_codaj12_core (rw) register accessor: CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_core`]
 module"]
 pub type CLK_CODAJ12_CORE = crate::Reg<clk_codaj12_core::CLK_CODAJ12_CORE_SPEC>;
 #[doc = "CODAJ12 Clock Core"]
 pub mod clk_codaj12_core;
-#[doc = "clk_codaj12_apb (rw) register accessor: CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_apb`]
+#[doc = "clk_codaj12_apb (rw) register accessor: CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_apb`]
 module"]
 pub type CLK_CODAJ12_APB = crate::Reg<clk_codaj12_apb::CLK_CODAJ12_APB_SPEC>;
 #[doc = "CODAJ12 Clock APB"]
 pub mod clk_codaj12_apb;
-#[doc = "clk_vdec_axi (rw) register accessor: Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vdec_axi`]
+#[doc = "clk_vdec_axi (rw) register accessor: Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vdec_axi`]
 module"]
 pub type CLK_VDEC_AXI = crate::Reg<clk_vdec_axi::CLK_VDEC_AXI_SPEC>;
 #[doc = "Clock Video Decoder AXI"]
 pub mod clk_vdec_axi;
-#[doc = "clk_wave511_axi (rw) register accessor: Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_axi`]
+#[doc = "clk_wave511_axi (rw) register accessor: Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_axi`]
 module"]
 pub type CLK_WAVE511_AXI = crate::Reg<clk_wave511_axi::CLK_WAVE511_AXI_SPEC>;
 #[doc = "Clock WAVE511 AXI"]
 pub mod clk_wave511_axi;
-#[doc = "clk_wave511_bpu (rw) register accessor: Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_bpu`]
+#[doc = "clk_wave511_bpu (rw) register accessor: Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_bpu`]
 module"]
 pub type CLK_WAVE511_BPU = crate::Reg<clk_wave511_bpu::CLK_WAVE511_BPU_SPEC>;
 #[doc = "Clock WAVE511 BPU"]
 pub mod clk_wave511_bpu;
-#[doc = "clk_wave511_vce (rw) register accessor: Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_vce`]
+#[doc = "clk_wave511_vce (rw) register accessor: Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_vce`]
 module"]
 pub type CLK_WAVE511_VCE = crate::Reg<clk_wave511_vce::CLK_WAVE511_VCE_SPEC>;
 #[doc = "Clock WAVE511 VCE"]
 pub mod clk_wave511_vce;
-#[doc = "clk_wave511_apb (rw) register accessor: Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_apb`]
+#[doc = "clk_wave511_apb (rw) register accessor: Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_apb`]
 module"]
 pub type CLK_WAVE511_APB = crate::Reg<clk_wave511_apb::CLK_WAVE511_APB_SPEC>;
 #[doc = "Clock WAVE511 APB"]
 pub mod clk_wave511_apb;
-#[doc = "clk_wave511_jpg_arb (rw) register accessor: Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_arb`]
+#[doc = "clk_wave511_jpg_arb (rw) register accessor: Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_arb`]
 module"]
 pub type CLK_WAVE511_JPG_ARB = crate::Reg<clk_wave511_jpg_arb::CLK_WAVE511_JPG_ARB_SPEC>;
 #[doc = "Clock WAVE511 JPG ARB"]
 pub mod clk_wave511_jpg_arb;
-#[doc = "clk_wave511_jpg_main (rw) register accessor: Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_main`]
+#[doc = "clk_wave511_jpg_main (rw) register accessor: Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_main`]
 module"]
 pub type CLK_WAVE511_JPG_MAIN = crate::Reg<clk_wave511_jpg_main::CLK_WAVE511_JPG_MAIN_SPEC>;
 #[doc = "Clock WAVE511 JPG Main"]
 pub mod clk_wave511_jpg_main;
-#[doc = "clk_noc_vdec_axi (rw) register accessor: Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_vdec_axi`]
+#[doc = "clk_noc_vdec_axi (rw) register accessor: Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_vdec_axi`]
 module"]
 pub type CLK_NOC_VDEC_AXI = crate::Reg<clk_noc_vdec_axi::CLK_NOC_VDEC_AXI_SPEC>;
 #[doc = "Clock NOC Video Decoder AXI"]
 pub mod clk_noc_vdec_axi;
-#[doc = "clk_venc_axi (rw) register accessor: Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_venc_axi`]
+#[doc = "clk_venc_axi (rw) register accessor: Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_venc_axi`]
 module"]
 pub type CLK_VENC_AXI = crate::Reg<clk_venc_axi::CLK_VENC_AXI_SPEC>;
 #[doc = "Clock Video Encoder AXI"]
 pub mod clk_venc_axi;
-#[doc = "clk_wave420l_axi (rw) register accessor: Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_axi`]
+#[doc = "clk_wave420l_axi (rw) register accessor: Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_axi`]
 module"]
 pub type CLK_WAVE420L_AXI = crate::Reg<clk_wave420l_axi::CLK_WAVE420L_AXI_SPEC>;
 #[doc = "Clock WAVE420L AXI"]
 pub mod clk_wave420l_axi;
-#[doc = "clk_wave420l_bpu (rw) register accessor: Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_bpu`]
+#[doc = "clk_wave420l_bpu (rw) register accessor: Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_bpu`]
 module"]
 pub type CLK_WAVE420L_BPU = crate::Reg<clk_wave420l_bpu::CLK_WAVE420L_BPU_SPEC>;
 #[doc = "Clock WAVE420L BPU"]
 pub mod clk_wave420l_bpu;
-#[doc = "clk_wave420l_vce (rw) register accessor: Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_vce`]
+#[doc = "clk_wave420l_vce (rw) register accessor: Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_vce`]
 module"]
 pub type CLK_WAVE420L_VCE = crate::Reg<clk_wave420l_vce::CLK_WAVE420L_VCE_SPEC>;
 #[doc = "Clock WAVE420L VCE"]
 pub mod clk_wave420l_vce;
-#[doc = "clk_wave420l_apb (rw) register accessor: Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_apb`]
+#[doc = "clk_wave420l_apb (rw) register accessor: Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_apb`]
 module"]
 pub type CLK_WAVE420L_APB = crate::Reg<clk_wave420l_apb::CLK_WAVE420L_APB_SPEC>;
 #[doc = "Clock WAVE420L APB"]
 pub mod clk_wave420l_apb;
-#[doc = "clk_noc_venc_axi (rw) register accessor: Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_venc_axi`]
+#[doc = "clk_noc_venc_axi (rw) register accessor: Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_venc_axi`]
 module"]
 pub type CLK_NOC_VENC_AXI = crate::Reg<clk_noc_venc_axi::CLK_NOC_VENC_AXI_SPEC>;
 #[doc = "Clock NOC Video Encoder AXI"]
 pub mod clk_noc_venc_axi;
-#[doc = "clk_axi_cfg0_dec_main_div (rw) register accessor: Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main_div`]
+#[doc = "clk_axi_cfg0_dec_main_div (rw) register accessor: Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main_div`]
 module"]
 pub type CLK_AXI_CFG0_DEC_MAIN_DIV =
     crate::Reg<clk_axi_cfg0_dec_main_div::CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC>;
 #[doc = "Clock AXI Config 0 DEC Main Divider"]
 pub mod clk_axi_cfg0_dec_main_div;
-#[doc = "clk_axi_cfg0_dec_main (rw) register accessor: Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main`]
+#[doc = "clk_axi_cfg0_dec_main (rw) register accessor: Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main`]
 module"]
 pub type CLK_AXI_CFG0_DEC_MAIN = crate::Reg<clk_axi_cfg0_dec_main::CLK_AXI_CFG0_DEC_MAIN_SPEC>;
 #[doc = "Clock AXI Config 0 DEC Main"]
 pub mod clk_axi_cfg0_dec_main;
-#[doc = "clk_axi_cfg0_dec_hifi4 (rw) register accessor: Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_hifi4`]
+#[doc = "clk_axi_cfg0_dec_hifi4 (rw) register accessor: Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_hifi4`]
 module"]
 pub type CLK_AXI_CFG0_DEC_HIFI4 = crate::Reg<clk_axi_cfg0_dec_hifi4::CLK_AXI_CFG0_DEC_HIFI4_SPEC>;
 #[doc = "Clock AXI Config 0 DEC HIFI4"]
 pub mod clk_axi_cfg0_dec_hifi4;
-#[doc = "clk_aximem_128b_axi (rw) register accessor: Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aximem_128b_axi`]
+#[doc = "clk_aximem_128b_axi (rw) register accessor: Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aximem_128b_axi`]
 module"]
 pub type CLK_AXIMEM_128B_AXI = crate::Reg<clk_aximem_128b_axi::CLK_AXIMEM_128B_AXI_SPEC>;
 #[doc = "Clock AXIMEM 128B AXI"]
 pub mod clk_aximem_128b_axi;
-#[doc = "clk_qspi_ahb (rw) register accessor: Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ahb`]
+#[doc = "clk_qspi_ahb (rw) register accessor: Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ahb`]
 module"]
 pub type CLK_QSPI_AHB = crate::Reg<clk_qspi_ahb::CLK_QSPI_AHB_SPEC>;
 #[doc = "Clock QSPI AHB"]
 pub mod clk_qspi_ahb;
-#[doc = "clk_qspi_apb (rw) register accessor: Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_apb`]
+#[doc = "clk_qspi_apb (rw) register accessor: Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_apb`]
 module"]
 pub type CLK_QSPI_APB = crate::Reg<clk_qspi_apb::CLK_QSPI_APB_SPEC>;
 #[doc = "Clock QSPI APB"]
 pub mod clk_qspi_apb;
-#[doc = "clk_qspi_ref_src (rw) register accessor: Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref_src`]
+#[doc = "clk_qspi_ref_src (rw) register accessor: Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref_src`]
 module"]
 pub type CLK_QSPI_REF_SRC = crate::Reg<clk_qspi_ref_src::CLK_QSPI_REF_SRC_SPEC>;
 #[doc = "Clock QSPI Reference Source"]
 pub mod clk_qspi_ref_src;
-#[doc = "clk_qspi_ref (rw) register accessor: Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref`]
+#[doc = "clk_qspi_ref (rw) register accessor: Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref`]
 module"]
 pub type CLK_QSPI_REF = crate::Reg<clk_qspi_ref::CLK_QSPI_REF_SPEC>;
 #[doc = "Clock QSPI Reference"]
 pub mod clk_qspi_ref;
-#[doc = "clk_u0_sd_ahb (rw) register accessor: U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_ahb`]
+#[doc = "clk_u0_sd_ahb (rw) register accessor: U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_ahb`]
 module"]
 pub type CLK_U0_SD_AHB = crate::Reg<clk_u0_sd_ahb::CLK_U0_SD_AHB_SPEC>;
 #[doc = "U0 SD Clock AHB"]
 pub mod clk_u0_sd_ahb;
-#[doc = "clk_u1_sd_ahb (rw) register accessor: U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_ahb`]
+#[doc = "clk_u1_sd_ahb (rw) register accessor: U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_ahb`]
 module"]
 pub type CLK_U1_SD_AHB = crate::Reg<clk_u1_sd_ahb::CLK_U1_SD_AHB_SPEC>;
 #[doc = "U1 SD Clock AHB"]
 pub mod clk_u1_sd_ahb;
-#[doc = "clk_u0_sd_card (rw) register accessor: U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_card`]
+#[doc = "clk_u0_sd_card (rw) register accessor: U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_card`]
 module"]
 pub type CLK_U0_SD_CARD = crate::Reg<clk_u0_sd_card::CLK_U0_SD_CARD_SPEC>;
 #[doc = "U0 SD Card Clock"]
 pub mod clk_u0_sd_card;
-#[doc = "clk_u1_sd_card (rw) register accessor: U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_card`]
+#[doc = "clk_u1_sd_card (rw) register accessor: U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_card`]
 module"]
 pub type CLK_U1_SD_CARD = crate::Reg<clk_u1_sd_card::CLK_U1_SD_CARD_SPEC>;
 #[doc = "U1 SD Card Clock"]
 pub mod clk_u1_sd_card;
-#[doc = "clk_usb_125m (rw) register accessor: Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_125m`]
+#[doc = "clk_usb_125m (rw) register accessor: Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_125m`]
 module"]
 pub type CLK_USB_125M = crate::Reg<clk_usb_125m::CLK_USB_125M_SPEC>;
 #[doc = "Clock USB 125M"]
 pub mod clk_usb_125m;
-#[doc = "clk_noc_stg_axi (rw) register accessor: Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_stg_axi`]
+#[doc = "clk_noc_stg_axi (rw) register accessor: Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_stg_axi`]
 module"]
 pub type CLK_NOC_STG_AXI = crate::Reg<clk_noc_stg_axi::CLK_NOC_STG_AXI_SPEC>;
 #[doc = "Clock NOC STG AXI"]
 pub mod clk_noc_stg_axi;
-#[doc = "clk_gmac5_axi64_ahb (rw) register accessor: Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ahb`]
+#[doc = "clk_gmac5_axi64_ahb (rw) register accessor: Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ahb`]
 module"]
 pub type CLK_GMAC5_AXI64_AHB = crate::Reg<clk_gmac5_axi64_ahb::CLK_GMAC5_AXI64_AHB_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 AHB"]
 pub mod clk_gmac5_axi64_ahb;
-#[doc = "clk_gmac5_axi64_axi (rw) register accessor: Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_axi`]
+#[doc = "clk_gmac5_axi64_axi (rw) register accessor: Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_axi`]
 module"]
 pub type CLK_GMAC5_AXI64_AXI = crate::Reg<clk_gmac5_axi64_axi::CLK_GMAC5_AXI64_AXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 AXI"]
 pub mod clk_gmac5_axi64_axi;
-#[doc = "clk_gmac_src (rw) register accessor: Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_src`]
+#[doc = "clk_gmac_src (rw) register accessor: Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_src`]
 module"]
 pub type CLK_GMAC_SRC = crate::Reg<clk_gmac_src::CLK_GMAC_SRC_SPEC>;
 #[doc = "Clock GMAC Source"]
 pub mod clk_gmac_src;
-#[doc = "clk_gmac1_gtx (rw) register accessor: Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtx`]
+#[doc = "clk_gmac1_gtx (rw) register accessor: Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtx`]
 module"]
 pub type CLK_GMAC1_GTX = crate::Reg<clk_gmac1_gtx::CLK_GMAC1_GTX_SPEC>;
 #[doc = "Clock GMAC 1 GTX"]
 pub mod clk_gmac1_gtx;
-#[doc = "clk_gmac1_rmii_rtx (rw) register accessor: Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_rmii_rtx`]
+#[doc = "clk_gmac1_rmii_rtx (rw) register accessor: Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_rmii_rtx`]
 module"]
 pub type CLK_GMAC1_RMII_RTX = crate::Reg<clk_gmac1_rmii_rtx::CLK_GMAC1_RMII_RTX_SPEC>;
 #[doc = "Clock GMAC 1 RMII RTX"]
 pub mod clk_gmac1_rmii_rtx;
-#[doc = "clk_gmac5_axi64_ptp (rw) register accessor: Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ptp`]
+#[doc = "clk_gmac5_axi64_ptp (rw) register accessor: Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ptp`]
 module"]
 pub type CLK_GMAC5_AXI64_PTP = crate::Reg<clk_gmac5_axi64_ptp::CLK_GMAC5_AXI64_PTP_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 PTP"]
 pub mod clk_gmac5_axi64_ptp;
-#[doc = "clk_gmac5_axi64_rx (rw) register accessor: Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
+#[doc = "clk_gmac5_axi64_rx (rw) register accessor: Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
 module"]
 pub type CLK_GMAC5_AXI64_RX = crate::Reg<clk_gmac5_axi64_rx::CLK_GMAC5_AXI64_RX_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 RX"]
 pub mod clk_gmac5_axi64_rx;
-#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
+#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
 module"]
 pub type CLK_GMAC5_AXI64_RXI = crate::Reg<clk_gmac5_axi64_rxi::CLK_GMAC5_AXI64_RXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 RX Inverter"]
 pub mod clk_gmac5_axi64_rxi;
-#[doc = "clk_gmac5_axi64_tx (rw) register accessor: Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
+#[doc = "clk_gmac5_axi64_tx (rw) register accessor: Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
 module"]
 pub type CLK_GMAC5_AXI64_TX = crate::Reg<clk_gmac5_axi64_tx::CLK_GMAC5_AXI64_TX_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 TX"]
 pub mod clk_gmac5_axi64_tx;
-#[doc = "clk_gmac5_axi64_txi (rw) register accessor: Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
+#[doc = "clk_gmac5_axi64_txi (rw) register accessor: Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
 module"]
 pub type CLK_GMAC5_AXI64_TXI = crate::Reg<clk_gmac5_axi64_txi::CLK_GMAC5_AXI64_TXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 TX Inverter"]
 pub mod clk_gmac5_axi64_txi;
-#[doc = "clk_gmac1_gtxclk (rw) register accessor: Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtxclk`]
+#[doc = "clk_gmac1_gtxclk (rw) register accessor: Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtxclk`]
 module"]
 pub type CLK_GMAC1_GTXCLK = crate::Reg<clk_gmac1_gtxclk::CLK_GMAC1_GTXCLK_SPEC>;
 #[doc = "Clock GMAC 1 GTXC"]
 pub mod clk_gmac1_gtxclk;
-#[doc = "clk_gmac0_gtx (rw) register accessor: Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtx`]
+#[doc = "clk_gmac0_gtx (rw) register accessor: Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtx`]
 module"]
 pub type CLK_GMAC0_GTX = crate::Reg<clk_gmac0_gtx::CLK_GMAC0_GTX_SPEC>;
 #[doc = "Clock GMAC 0 GTX"]
 pub mod clk_gmac0_gtx;
-#[doc = "clk_gmac0_ptp (rw) register accessor: Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_ptp`]
+#[doc = "clk_gmac0_ptp (rw) register accessor: Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_ptp`]
 module"]
 pub type CLK_GMAC0_PTP = crate::Reg<clk_gmac0_ptp::CLK_GMAC0_PTP_SPEC>;
 #[doc = "Clock GMAC 0 PTP"]
 pub mod clk_gmac0_ptp;
-#[doc = "clk_gmac_phy (rw) register accessor: Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_phy`]
+#[doc = "clk_gmac_phy (rw) register accessor: Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_phy`]
 module"]
 pub type CLK_GMAC_PHY = crate::Reg<clk_gmac_phy::CLK_GMAC_PHY_SPEC>;
 #[doc = "Clock GMAC PHY"]
 pub mod clk_gmac_phy;
-#[doc = "clk_gmac0_gtxclk (rw) register accessor: Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtxclk`]
+#[doc = "clk_gmac0_gtxclk (rw) register accessor: Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtxclk`]
 module"]
 pub type CLK_GMAC0_GTXCLK = crate::Reg<clk_gmac0_gtxclk::CLK_GMAC0_GTXCLK_SPEC>;
 #[doc = "Clock GMAC 0 GTXC"]
 pub mod clk_gmac0_gtxclk;
-#[doc = "clk_sys_iomux_pclk (rw) register accessor: Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sys_iomux_pclk`]
+#[doc = "clk_sys_iomux_pclk (rw) register accessor: Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sys_iomux_pclk`]
 module"]
 pub type CLK_SYS_IOMUX_PCLK = crate::Reg<clk_sys_iomux_pclk::CLK_SYS_IOMUX_PCLK_SPEC>;
 #[doc = "Clock SYS IOMUX PCLK"]
 pub mod clk_sys_iomux_pclk;
-#[doc = "clk_mbox_apb (rw) register accessor: Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mbox_apb`]
+#[doc = "clk_mbox_apb (rw) register accessor: Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mbox_apb`]
 module"]
 pub type CLK_MBOX_APB = crate::Reg<clk_mbox_apb::CLK_MBOX_APB_SPEC>;
 #[doc = "Clock Mailbox APB"]
 pub mod clk_mbox_apb;
-#[doc = "clk_internal_ctrl_apb (rw) register accessor: Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_internal_ctrl_apb`]
+#[doc = "clk_internal_ctrl_apb (rw) register accessor: Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_internal_ctrl_apb`]
 module"]
 pub type CLK_INTERNAL_CTRL_APB = crate::Reg<clk_internal_ctrl_apb::CLK_INTERNAL_CTRL_APB_SPEC>;
 #[doc = "Clock Internal Controller APB"]
 pub mod clk_internal_ctrl_apb;
-#[doc = "clk_u0_can_ctrl_apb (rw) register accessor: U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_apb`]
+#[doc = "clk_u0_can_ctrl_apb (rw) register accessor: U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_apb`]
 module"]
 pub type CLK_U0_CAN_CTRL_APB = crate::Reg<clk_u0_can_ctrl_apb::CLK_U0_CAN_CTRL_APB_SPEC>;
 #[doc = "U0 Clock CAN Controller APB"]
 pub mod clk_u0_can_ctrl_apb;
-#[doc = "clk_u0_can_ctrl_tim (rw) register accessor: U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_tim`]
+#[doc = "clk_u0_can_ctrl_tim (rw) register accessor: U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_tim`]
 module"]
 pub type CLK_U0_CAN_CTRL_TIM = crate::Reg<clk_u0_can_ctrl_tim::CLK_U0_CAN_CTRL_TIM_SPEC>;
 #[doc = "U0 Clock CAN Controller Timer"]
 pub mod clk_u0_can_ctrl_tim;
-#[doc = "clk_u0_can_ctrl_can (rw) register accessor: U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_can`]
+#[doc = "clk_u0_can_ctrl_can (rw) register accessor: U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_can`]
 module"]
 pub type CLK_U0_CAN_CTRL_CAN = crate::Reg<clk_u0_can_ctrl_can::CLK_U0_CAN_CTRL_CAN_SPEC>;
 #[doc = "U0 Clock CAN Controller CAN"]
 pub mod clk_u0_can_ctrl_can;
-#[doc = "clk_u1_can_ctrl_apb (rw) register accessor: U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_apb`]
+#[doc = "clk_u1_can_ctrl_apb (rw) register accessor: U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_apb`]
 module"]
 pub type CLK_U1_CAN_CTRL_APB = crate::Reg<clk_u1_can_ctrl_apb::CLK_U1_CAN_CTRL_APB_SPEC>;
 #[doc = "U1 Clock CAN Controller APB"]
 pub mod clk_u1_can_ctrl_apb;
-#[doc = "clk_u1_can_ctrl_tim (rw) register accessor: U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_tim`]
+#[doc = "clk_u1_can_ctrl_tim (rw) register accessor: U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_tim`]
 module"]
 pub type CLK_U1_CAN_CTRL_TIM = crate::Reg<clk_u1_can_ctrl_tim::CLK_U1_CAN_CTRL_TIM_SPEC>;
 #[doc = "U1 Clock CAN Controller Timer"]
 pub mod clk_u1_can_ctrl_tim;
-#[doc = "clk_u1_can_ctrl_can (rw) register accessor: U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_can`]
+#[doc = "clk_u1_can_ctrl_can (rw) register accessor: U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_can`]
 module"]
 pub type CLK_U1_CAN_CTRL_CAN = crate::Reg<clk_u1_can_ctrl_can::CLK_U1_CAN_CTRL_CAN_SPEC>;
 #[doc = "U1 Clock CAN Controller CAN"]
 pub mod clk_u1_can_ctrl_can;
-#[doc = "clk_pwm_apb (rw) register accessor: Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwm_apb`]
+#[doc = "clk_pwm_apb (rw) register accessor: Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwm_apb`]
 module"]
 pub type CLK_PWM_APB = crate::Reg<clk_pwm_apb::CLK_PWM_APB_SPEC>;
 #[doc = "Clock PWM APB"]
 pub mod clk_pwm_apb;
-#[doc = "clk_wdt_apb (rw) register accessor: Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt_apb`]
+#[doc = "clk_wdt_apb (rw) register accessor: Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt_apb`]
 module"]
 pub type CLK_WDT_APB = crate::Reg<clk_wdt_apb::CLK_WDT_APB_SPEC>;
 #[doc = "Clock WDT APB"]
 pub mod clk_wdt_apb;
-#[doc = "clk_wdt (rw) register accessor: Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt`]
+#[doc = "clk_wdt (rw) register accessor: Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt`]
 module"]
 pub type CLK_WDT = crate::Reg<clk_wdt::CLK_WDT_SPEC>;
 #[doc = "Clock WDT"]
 pub mod clk_wdt;
-#[doc = "clk_tim_apb (rw) register accessor: Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim_apb`]
+#[doc = "clk_tim_apb (rw) register accessor: Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim_apb`]
 module"]
 pub type CLK_TIM_APB = crate::Reg<clk_tim_apb::CLK_TIM_APB_SPEC>;
 #[doc = "Clock Timer APB"]
 pub mod clk_tim_apb;
-#[doc = "clk_tim0 (rw) register accessor: Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim0`]
+#[doc = "clk_tim0 (rw) register accessor: Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim0`]
 module"]
 pub type CLK_TIM0 = crate::Reg<clk_tim0::CLK_TIM0_SPEC>;
 #[doc = "Clock Timer 0"]
 pub mod clk_tim0;
-#[doc = "clk_tim1 (rw) register accessor: Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim1`]
+#[doc = "clk_tim1 (rw) register accessor: Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim1`]
 module"]
 pub type CLK_TIM1 = crate::Reg<clk_tim1::CLK_TIM1_SPEC>;
 #[doc = "Clock Timer 1"]
 pub mod clk_tim1;
-#[doc = "clk_tim2 (rw) register accessor: Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim2`]
+#[doc = "clk_tim2 (rw) register accessor: Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim2`]
 module"]
 pub type CLK_TIM2 = crate::Reg<clk_tim2::CLK_TIM2_SPEC>;
 #[doc = "Clock Timer 2"]
 pub mod clk_tim2;
-#[doc = "clk_tim3 (rw) register accessor: Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim3`]
+#[doc = "clk_tim3 (rw) register accessor: Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim3`]
 module"]
 pub type CLK_TIM3 = crate::Reg<clk_tim3::CLK_TIM3_SPEC>;
 #[doc = "Clock Timer 3"]
 pub mod clk_tim3;
-#[doc = "clk_temp_sensor_apb (rw) register accessor: Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor_apb`]
+#[doc = "clk_temp_sensor_apb (rw) register accessor: Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor_apb`]
 module"]
 pub type CLK_TEMP_SENSOR_APB = crate::Reg<clk_temp_sensor_apb::CLK_TEMP_SENSOR_APB_SPEC>;
 #[doc = "Clock Temperature Sensor APB"]
 pub mod clk_temp_sensor_apb;
-#[doc = "clk_temp_sensor (rw) register accessor: Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor`]
+#[doc = "clk_temp_sensor (rw) register accessor: Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor`]
 module"]
 pub type CLK_TEMP_SENSOR = crate::Reg<clk_temp_sensor::CLK_TEMP_SENSOR_SPEC>;
 #[doc = "Clock Temperature Sensor"]
 pub mod clk_temp_sensor;
-#[doc = "clk_u0_spi_apb (rw) register accessor: U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_spi_apb`]
+#[doc = "clk_u0_spi_apb (rw) register accessor: U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_spi_apb`]
 module"]
 pub type CLK_U0_SPI_APB = crate::Reg<clk_u0_spi_apb::CLK_U0_SPI_APB_SPEC>;
 #[doc = "U0 Clock SPI APB"]
 pub mod clk_u0_spi_apb;
-#[doc = "clk_u1_spi_apb (rw) register accessor: U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_spi_apb`]
+#[doc = "clk_u1_spi_apb (rw) register accessor: U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_spi_apb`]
 module"]
 pub type CLK_U1_SPI_APB = crate::Reg<clk_u1_spi_apb::CLK_U1_SPI_APB_SPEC>;
 #[doc = "U1 Clock SPI APB"]
 pub mod clk_u1_spi_apb;
-#[doc = "clk_u2_spi_apb (rw) register accessor: U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_spi_apb`]
+#[doc = "clk_u2_spi_apb (rw) register accessor: U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_spi_apb`]
 module"]
 pub type CLK_U2_SPI_APB = crate::Reg<clk_u2_spi_apb::CLK_U2_SPI_APB_SPEC>;
 #[doc = "U2 Clock SPI APB"]
 pub mod clk_u2_spi_apb;
-#[doc = "clk_u3_spi_apb (rw) register accessor: U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_spi_apb`]
+#[doc = "clk_u3_spi_apb (rw) register accessor: U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_spi_apb`]
 module"]
 pub type CLK_U3_SPI_APB = crate::Reg<clk_u3_spi_apb::CLK_U3_SPI_APB_SPEC>;
 #[doc = "U3 Clock SPI APB"]
 pub mod clk_u3_spi_apb;
-#[doc = "clk_u4_spi_apb (rw) register accessor: U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_spi_apb`]
+#[doc = "clk_u4_spi_apb (rw) register accessor: U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_spi_apb`]
 module"]
 pub type CLK_U4_SPI_APB = crate::Reg<clk_u4_spi_apb::CLK_U4_SPI_APB_SPEC>;
 #[doc = "U4 Clock SPI APB"]
 pub mod clk_u4_spi_apb;
-#[doc = "clk_u5_spi_apb (rw) register accessor: U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_spi_apb`]
+#[doc = "clk_u5_spi_apb (rw) register accessor: U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_spi_apb`]
 module"]
 pub type CLK_U5_SPI_APB = crate::Reg<clk_u5_spi_apb::CLK_U5_SPI_APB_SPEC>;
 #[doc = "U5 Clock SPI APB"]
 pub mod clk_u5_spi_apb;
-#[doc = "clk_u6_spi_apb (rw) register accessor: U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_spi_apb`]
+#[doc = "clk_u6_spi_apb (rw) register accessor: U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_spi_apb`]
 module"]
 pub type CLK_U6_SPI_APB = crate::Reg<clk_u6_spi_apb::CLK_U6_SPI_APB_SPEC>;
 #[doc = "U6 Clock SPI APB"]
 pub mod clk_u6_spi_apb;
-#[doc = "clk_u0_i2c_apb (rw) register accessor: U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2c_apb`]
+#[doc = "clk_u0_i2c_apb (rw) register accessor: U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2c_apb`]
 module"]
 pub type CLK_U0_I2C_APB = crate::Reg<clk_u0_i2c_apb::CLK_U0_I2C_APB_SPEC>;
 #[doc = "U0 Clock I2C APB"]
 pub mod clk_u0_i2c_apb;
-#[doc = "clk_u1_i2c_apb (rw) register accessor: U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2c_apb`]
+#[doc = "clk_u1_i2c_apb (rw) register accessor: U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2c_apb`]
 module"]
 pub type CLK_U1_I2C_APB = crate::Reg<clk_u1_i2c_apb::CLK_U1_I2C_APB_SPEC>;
 #[doc = "U1 Clock I2C APB"]
 pub mod clk_u1_i2c_apb;
-#[doc = "clk_u2_i2c_apb (rw) register accessor: U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_i2c_apb`]
+#[doc = "clk_u2_i2c_apb (rw) register accessor: U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_i2c_apb`]
 module"]
 pub type CLK_U2_I2C_APB = crate::Reg<clk_u2_i2c_apb::CLK_U2_I2C_APB_SPEC>;
 #[doc = "U2 Clock I2C APB"]
 pub mod clk_u2_i2c_apb;
-#[doc = "clk_u3_i2c_apb (rw) register accessor: U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_i2c_apb`]
+#[doc = "clk_u3_i2c_apb (rw) register accessor: U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_i2c_apb`]
 module"]
 pub type CLK_U3_I2C_APB = crate::Reg<clk_u3_i2c_apb::CLK_U3_I2C_APB_SPEC>;
 #[doc = "U3 Clock I2C APB"]
 pub mod clk_u3_i2c_apb;
-#[doc = "clk_u4_i2c_apb (rw) register accessor: U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_i2c_apb`]
+#[doc = "clk_u4_i2c_apb (rw) register accessor: U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_i2c_apb`]
 module"]
 pub type CLK_U4_I2C_APB = crate::Reg<clk_u4_i2c_apb::CLK_U4_I2C_APB_SPEC>;
 #[doc = "U4 Clock I2C APB"]
 pub mod clk_u4_i2c_apb;
-#[doc = "clk_u5_i2c_apb (rw) register accessor: U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_i2c_apb`]
+#[doc = "clk_u5_i2c_apb (rw) register accessor: U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_i2c_apb`]
 module"]
 pub type CLK_U5_I2C_APB = crate::Reg<clk_u5_i2c_apb::CLK_U5_I2C_APB_SPEC>;
 #[doc = "U5 Clock I2C APB"]
 pub mod clk_u5_i2c_apb;
-#[doc = "clk_u6_i2c_apb (rw) register accessor: U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_i2c_apb`]
+#[doc = "clk_u6_i2c_apb (rw) register accessor: U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_i2c_apb`]
 module"]
 pub type CLK_U6_I2C_APB = crate::Reg<clk_u6_i2c_apb::CLK_U6_I2C_APB_SPEC>;
 #[doc = "U6 Clock I2C APB"]
 pub mod clk_u6_i2c_apb;
-#[doc = "clk_u0_uart_apb (rw) register accessor: U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_apb`]
+#[doc = "clk_u0_uart_apb (rw) register accessor: U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_apb`]
 module"]
 pub type CLK_U0_UART_APB = crate::Reg<clk_u0_uart_apb::CLK_U0_UART_APB_SPEC>;
 #[doc = "U0 Clock UART APB"]
 pub mod clk_u0_uart_apb;
-#[doc = "clk_u0_uart_core (rw) register accessor: U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_core`]
+#[doc = "clk_u0_uart_core (rw) register accessor: U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_core`]
 module"]
 pub type CLK_U0_UART_CORE = crate::Reg<clk_u0_uart_core::CLK_U0_UART_CORE_SPEC>;
 #[doc = "U0 Clock UART Core"]
 pub mod clk_u0_uart_core;
-#[doc = "clk_u1_uart_apb (rw) register accessor: U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_apb`]
+#[doc = "clk_u1_uart_apb (rw) register accessor: U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_apb`]
 module"]
 pub type CLK_U1_UART_APB = crate::Reg<clk_u1_uart_apb::CLK_U1_UART_APB_SPEC>;
 #[doc = "U1 Clock UART APB"]
 pub mod clk_u1_uart_apb;
-#[doc = "clk_u1_uart_core (rw) register accessor: U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_core`]
+#[doc = "clk_u1_uart_core (rw) register accessor: U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_core`]
 module"]
 pub type CLK_U1_UART_CORE = crate::Reg<clk_u1_uart_core::CLK_U1_UART_CORE_SPEC>;
 #[doc = "U1 Clock UART Core"]
 pub mod clk_u1_uart_core;
-#[doc = "clk_u2_uart_apb (rw) register accessor: U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_apb`]
+#[doc = "clk_u2_uart_apb (rw) register accessor: U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_apb`]
 module"]
 pub type CLK_U2_UART_APB = crate::Reg<clk_u2_uart_apb::CLK_U2_UART_APB_SPEC>;
 #[doc = "U2 Clock UART APB"]
 pub mod clk_u2_uart_apb;
-#[doc = "clk_u2_uart_core (rw) register accessor: U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_core`]
+#[doc = "clk_u2_uart_core (rw) register accessor: U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_core`]
 module"]
 pub type CLK_U2_UART_CORE = crate::Reg<clk_u2_uart_core::CLK_U2_UART_CORE_SPEC>;
 #[doc = "U2 Clock UART Core"]
 pub mod clk_u2_uart_core;
-#[doc = "clk_u3_uart_apb (rw) register accessor: U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_apb`]
+#[doc = "clk_u3_uart_apb (rw) register accessor: U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_apb`]
 module"]
 pub type CLK_U3_UART_APB = crate::Reg<clk_u3_uart_apb::CLK_U3_UART_APB_SPEC>;
 #[doc = "U3 Clock UART APB"]
 pub mod clk_u3_uart_apb;
-#[doc = "clk_u3_uart_core (rw) register accessor: U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_core`]
+#[doc = "clk_u3_uart_core (rw) register accessor: U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_core`]
 module"]
 pub type CLK_U3_UART_CORE = crate::Reg<clk_u3_uart_core::CLK_U3_UART_CORE_SPEC>;
 #[doc = "U3 Clock UART Core"]
 pub mod clk_u3_uart_core;
-#[doc = "clk_u4_uart_apb (rw) register accessor: U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_apb`]
+#[doc = "clk_u4_uart_apb (rw) register accessor: U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_apb`]
 module"]
 pub type CLK_U4_UART_APB = crate::Reg<clk_u4_uart_apb::CLK_U4_UART_APB_SPEC>;
 #[doc = "U4 Clock UART APB"]
 pub mod clk_u4_uart_apb;
-#[doc = "clk_u4_uart_core (rw) register accessor: U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_core`]
+#[doc = "clk_u4_uart_core (rw) register accessor: U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_core`]
 module"]
 pub type CLK_U4_UART_CORE = crate::Reg<clk_u4_uart_core::CLK_U4_UART_CORE_SPEC>;
 #[doc = "U4 Clock UART Core"]
 pub mod clk_u4_uart_core;
-#[doc = "clk_u5_uart_apb (rw) register accessor: U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_apb`]
+#[doc = "clk_u5_uart_apb (rw) register accessor: U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_apb`]
 module"]
 pub type CLK_U5_UART_APB = crate::Reg<clk_u5_uart_apb::CLK_U5_UART_APB_SPEC>;
 #[doc = "U5 Clock UART APB"]
 pub mod clk_u5_uart_apb;
-#[doc = "clk_u5_uart_core (rw) register accessor: U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_core`]
+#[doc = "clk_u5_uart_core (rw) register accessor: U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_core`]
 module"]
 pub type CLK_U5_UART_CORE = crate::Reg<clk_u5_uart_core::CLK_U5_UART_CORE_SPEC>;
 #[doc = "U5 Clock UART Core"]
 pub mod clk_u5_uart_core;
-#[doc = "clk_pwmdac_apb (rw) register accessor: Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_apb`]
+#[doc = "clk_pwmdac_apb (rw) register accessor: Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_apb`]
 module"]
 pub type CLK_PWMDAC_APB = crate::Reg<clk_pwmdac_apb::CLK_PWMDAC_APB_SPEC>;
 #[doc = "Clock PWMDAC APB"]
 pub mod clk_pwmdac_apb;
-#[doc = "clk_pwmdac_core (rw) register accessor: Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_core`]
+#[doc = "clk_pwmdac_core (rw) register accessor: Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_core`]
 module"]
 pub type CLK_PWMDAC_CORE = crate::Reg<clk_pwmdac_core::CLK_PWMDAC_CORE_SPEC>;
 #[doc = "Clock PWMDAC Core"]
 pub mod clk_pwmdac_core;
-#[doc = "clk_spdif_apb (rw) register accessor: Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_apb`]
+#[doc = "clk_spdif_apb (rw) register accessor: Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_apb`]
 module"]
 pub type CLK_SPDIF_APB = crate::Reg<clk_spdif_apb::CLK_SPDIF_APB_SPEC>;
 #[doc = "Clock SPDIF APB"]
 pub mod clk_spdif_apb;
-#[doc = "clk_spdif_core (rw) register accessor: Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_core`]
+#[doc = "clk_spdif_core (rw) register accessor: Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_core`]
 module"]
 pub type CLK_SPDIF_CORE = crate::Reg<clk_spdif_core::CLK_SPDIF_CORE_SPEC>;
 #[doc = "Clock SPDIF Core"]
 pub mod clk_spdif_core;
-#[doc = "clk_u0_i2s_tx_apb (rw) register accessor: U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2s_tx_apb`]
+#[doc = "clk_u0_i2s_tx_apb (rw) register accessor: U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2s_tx_apb`]
 module"]
 pub type CLK_U0_I2S_TX_APB = crate::Reg<clk_u0_i2s_tx_apb::CLK_U0_I2S_TX_APB_SPEC>;
 #[doc = "U0 Clock I2S TX APB"]
 pub mod clk_u0_i2s_tx_apb;
-#[doc = "clk_u0_i2stx_4ch0_bclk_mst (rw) register accessor: U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst`]
+#[doc = "clk_u0_i2stx_4ch0_bclk_mst (rw) register accessor: U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst`]
 module"]
 pub type CLK_U0_I2STX_4CH0_BCLK_MST =
     crate::Reg<clk_u0_i2stx_4ch0_bclk_mst::CLK_U0_I2STX_4CH0_BCLK_MST_SPEC>;
 #[doc = "U0 Clock I2S TX 0 BCLK MST"]
 pub mod clk_u0_i2stx_4ch0_bclk_mst;
-#[doc = "clk_u0_i2stx_4ch0_bclk_mst_inv (rw) register accessor: U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst_inv`]
+#[doc = "clk_u0_i2stx_4ch0_bclk_mst_inv (rw) register accessor: U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst_inv`]
 module"]
 pub type CLK_U0_I2STX_4CH0_BCLK_MST_INV =
     crate::Reg<clk_u0_i2stx_4ch0_bclk_mst_inv::CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC>;
 #[doc = "U0 Clock I2S TX 0 BCLK MST Inverter"]
 pub mod clk_u0_i2stx_4ch0_bclk_mst_inv;
-#[doc = "clk_i2stx0_lrck_mst (rw) register accessor: Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx0_lrck_mst`]
+#[doc = "clk_i2stx0_lrck_mst (rw) register accessor: Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx0_lrck_mst`]
 module"]
 pub type CLK_I2STX0_LRCK_MST = crate::Reg<clk_i2stx0_lrck_mst::CLK_I2STX0_LRCK_MST_SPEC>;
 #[doc = "Clock I2S TX 0 LRCK MST"]
 pub mod clk_i2stx0_lrck_mst;
-#[doc = "clk_u0_i2stx_bclk (rw) register accessor: U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk`]
+#[doc = "clk_u0_i2stx_bclk (rw) register accessor: U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk`]
 module"]
 pub type CLK_U0_I2STX_BCLK = crate::Reg<clk_u0_i2stx_bclk::CLK_U0_I2STX_BCLK_SPEC>;
 #[doc = "U0 Clock I2S TX BCLK"]
 pub mod clk_u0_i2stx_bclk;
-#[doc = "clk_u0_i2stx_bclk_neg (rw) register accessor: U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk_neg`]
+#[doc = "clk_u0_i2stx_bclk_neg (rw) register accessor: U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk_neg`]
 module"]
 pub type CLK_U0_I2STX_BCLK_NEG = crate::Reg<clk_u0_i2stx_bclk_neg::CLK_U0_I2STX_BCLK_NEG_SPEC>;
 #[doc = "U0 Clock I2S TX BCLK Negative"]
 pub mod clk_u0_i2stx_bclk_neg;
-#[doc = "clk_u0_i2stx_lrck (rw) register accessor: U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_lrck`]
+#[doc = "clk_u0_i2stx_lrck (rw) register accessor: U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_lrck`]
 module"]
 pub type CLK_U0_I2STX_LRCK = crate::Reg<clk_u0_i2stx_lrck::CLK_U0_I2STX_LRCK_SPEC>;
 #[doc = "U0 Clock I2S TX LRCK"]
 pub mod clk_u0_i2stx_lrck;
-#[doc = "clk_u1_i2s_tx_apb (rw) register accessor: U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2s_tx_apb`]
+#[doc = "clk_u1_i2s_tx_apb (rw) register accessor: U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2s_tx_apb`]
 module"]
 pub type CLK_U1_I2S_TX_APB = crate::Reg<clk_u1_i2s_tx_apb::CLK_U1_I2S_TX_APB_SPEC>;
 #[doc = "U1 Clock I2S TX APB"]
 pub mod clk_u1_i2s_tx_apb;
-#[doc = "clk_u1_i2stx_4ch1_bclk_mst (rw) register accessor: U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst`]
+#[doc = "clk_u1_i2stx_4ch1_bclk_mst (rw) register accessor: U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst`]
 module"]
 pub type CLK_U1_I2STX_4CH1_BCLK_MST =
     crate::Reg<clk_u1_i2stx_4ch1_bclk_mst::CLK_U1_I2STX_4CH1_BCLK_MST_SPEC>;
 #[doc = "U1 Clock I2S TX 1 BCLK MST"]
 pub mod clk_u1_i2stx_4ch1_bclk_mst;
-#[doc = "clk_u1_i2stx_4ch1_bclk_mst_inv (rw) register accessor: U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst_inv`]
+#[doc = "clk_u1_i2stx_4ch1_bclk_mst_inv (rw) register accessor: U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst_inv`]
 module"]
 pub type CLK_U1_I2STX_4CH1_BCLK_MST_INV =
     crate::Reg<clk_u1_i2stx_4ch1_bclk_mst_inv::CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC>;
 #[doc = "U1 Clock I2S TX 1 BCLK MST Inverter"]
 pub mod clk_u1_i2stx_4ch1_bclk_mst_inv;
-#[doc = "clk_i2stx1_lrck_mst (rw) register accessor: Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx1_lrck_mst`]
+#[doc = "clk_i2stx1_lrck_mst (rw) register accessor: Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx1_lrck_mst`]
 module"]
 pub type CLK_I2STX1_LRCK_MST = crate::Reg<clk_i2stx1_lrck_mst::CLK_I2STX1_LRCK_MST_SPEC>;
 #[doc = "Clock I2S TX 1 LRCK MST"]
 pub mod clk_i2stx1_lrck_mst;
-#[doc = "clk_u1_i2stx_bclk (rw) register accessor: U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk`]
+#[doc = "clk_u1_i2stx_bclk (rw) register accessor: U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk`]
 module"]
 pub type CLK_U1_I2STX_BCLK = crate::Reg<clk_u1_i2stx_bclk::CLK_U1_I2STX_BCLK_SPEC>;
 #[doc = "U1 Clock I2S TX BCLK"]
 pub mod clk_u1_i2stx_bclk;
-#[doc = "clk_u1_i2stx_bclk_neg (rw) register accessor: U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk_neg`]
+#[doc = "clk_u1_i2stx_bclk_neg (rw) register accessor: U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk_neg`]
 module"]
 pub type CLK_U1_I2STX_BCLK_NEG = crate::Reg<clk_u1_i2stx_bclk_neg::CLK_U1_I2STX_BCLK_NEG_SPEC>;
 #[doc = "U1 Clock I2S TX BCLK Negative"]
 pub mod clk_u1_i2stx_bclk_neg;
-#[doc = "clk_u1_i2stx_lrck (rw) register accessor: U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_lrck`]
+#[doc = "clk_u1_i2stx_lrck (rw) register accessor: U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_lrck`]
 module"]
 pub type CLK_U1_I2STX_LRCK = crate::Reg<clk_u1_i2stx_lrck::CLK_U1_I2STX_LRCK_SPEC>;
 #[doc = "U1 Clock I2S TX LRCK"]
 pub mod clk_u1_i2stx_lrck;
-#[doc = "clk_i2s_apb (rw) register accessor: Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_apb`]
+#[doc = "clk_i2s_apb (rw) register accessor: Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_apb`]
 module"]
 pub type CLK_I2S_APB = crate::Reg<clk_i2s_apb::CLK_I2S_APB_SPEC>;
 #[doc = "Clock I2S APB"]
 pub mod clk_i2s_apb;
-#[doc = "clk_i2s_bclk_mst (rw) register accessor: Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst`]
+#[doc = "clk_i2s_bclk_mst (rw) register accessor: Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst`]
 module"]
 pub type CLK_I2S_BCLK_MST = crate::Reg<clk_i2s_bclk_mst::CLK_I2S_BCLK_MST_SPEC>;
 #[doc = "Clock I2S BCLK MST"]
 pub mod clk_i2s_bclk_mst;
-#[doc = "clk_i2s_bclk_mst_inv (rw) register accessor: Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst_inv`]
+#[doc = "clk_i2s_bclk_mst_inv (rw) register accessor: Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst_inv`]
 module"]
 pub type CLK_I2S_BCLK_MST_INV = crate::Reg<clk_i2s_bclk_mst_inv::CLK_I2S_BCLK_MST_INV_SPEC>;
 #[doc = "Clock I2S BCLK MST Inverter"]
 pub mod clk_i2s_bclk_mst_inv;
-#[doc = "clk_i2s_lrck_mst (rw) register accessor: Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck_mst`]
+#[doc = "clk_i2s_lrck_mst (rw) register accessor: Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck_mst`]
 module"]
 pub type CLK_I2S_LRCK_MST = crate::Reg<clk_i2s_lrck_mst::CLK_I2S_LRCK_MST_SPEC>;
 #[doc = "Clock I2S LRCK MST"]
 pub mod clk_i2s_lrck_mst;
-#[doc = "clk_i2s_bclk (rw) register accessor: Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk`]
+#[doc = "clk_i2s_bclk (rw) register accessor: Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk`]
 module"]
 pub type CLK_I2S_BCLK = crate::Reg<clk_i2s_bclk::CLK_I2S_BCLK_SPEC>;
 #[doc = "Clock I2S BCLK"]
 pub mod clk_i2s_bclk;
-#[doc = "clk_i2s_bclk_neg (rw) register accessor: Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_neg`]
+#[doc = "clk_i2s_bclk_neg (rw) register accessor: Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_neg`]
 module"]
 pub type CLK_I2S_BCLK_NEG = crate::Reg<clk_i2s_bclk_neg::CLK_I2S_BCLK_NEG_SPEC>;
 #[doc = "Clock I2S BCLK Negative"]
 pub mod clk_i2s_bclk_neg;
-#[doc = "clk_i2s_lrck (rw) register accessor: Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck`]
+#[doc = "clk_i2s_lrck (rw) register accessor: Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck`]
 module"]
 pub type CLK_I2S_LRCK = crate::Reg<clk_i2s_lrck::CLK_I2S_LRCK_SPEC>;
 #[doc = "Clock I2S LRCK"]
 pub mod clk_i2s_lrck;
-#[doc = "clk_pdm_dmic (rw) register accessor: Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_dmic`]
+#[doc = "clk_pdm_dmic (rw) register accessor: Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_dmic`]
 module"]
 pub type CLK_PDM_DMIC = crate::Reg<clk_pdm_dmic::CLK_PDM_DMIC_SPEC>;
 #[doc = "Clock PDM DMIC"]
 pub mod clk_pdm_dmic;
-#[doc = "clk_pdm_apb (rw) register accessor: Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_apb`]
+#[doc = "clk_pdm_apb (rw) register accessor: Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_apb`]
 module"]
 pub type CLK_PDM_APB = crate::Reg<clk_pdm_apb::CLK_PDM_APB_SPEC>;
 #[doc = "Clock PDM APB"]
 pub mod clk_pdm_apb;
-#[doc = "clk_tdm_ahb (rw) register accessor: Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_ahb`]
+#[doc = "clk_tdm_ahb (rw) register accessor: Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_ahb`]
 module"]
 pub type CLK_TDM_AHB = crate::Reg<clk_tdm_ahb::CLK_TDM_AHB_SPEC>;
 #[doc = "Clock TDM AHB"]
 pub mod clk_tdm_ahb;
-#[doc = "clk_tdm_apb (rw) register accessor: Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_apb`]
+#[doc = "clk_tdm_apb (rw) register accessor: Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_apb`]
 module"]
 pub type CLK_TDM_APB = crate::Reg<clk_tdm_apb::CLK_TDM_APB_SPEC>;
 #[doc = "Clock TDM APB"]
 pub mod clk_tdm_apb;
-#[doc = "clk_tdm_internal (rw) register accessor: Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_internal`]
+#[doc = "clk_tdm_internal (rw) register accessor: Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_internal`]
 module"]
 pub type CLK_TDM_INTERNAL = crate::Reg<clk_tdm_internal::CLK_TDM_INTERNAL_SPEC>;
 #[doc = "Clock TDM Internal"]
 pub mod clk_tdm_internal;
-#[doc = "clk_tdm (rw) register accessor: Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm`]
+#[doc = "clk_tdm (rw) register accessor: Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm`]
 module"]
 pub type CLK_TDM = crate::Reg<clk_tdm::CLK_TDM_SPEC>;
 #[doc = "Clock TDM"]
 pub mod clk_tdm;
-#[doc = "clk_tdm_neg (rw) register accessor: Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_neg`]
+#[doc = "clk_tdm_neg (rw) register accessor: Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_neg`]
 module"]
 pub type CLK_TDM_NEG = crate::Reg<clk_tdm_neg::CLK_TDM_NEG_SPEC>;
 #[doc = "Clock TDM Negative"]
 pub mod clk_tdm_neg;
-#[doc = "clk_jtag_cert_trng (rw) register accessor: Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jtag_cert_trng`]
+#[doc = "clk_jtag_cert_trng (rw) register accessor: Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jtag_cert_trng`]
 module"]
 pub type CLK_JTAG_CERT_TRNG = crate::Reg<clk_jtag_cert_trng::CLK_JTAG_CERT_TRNG_SPEC>;
 #[doc = "Clock JTAG Certification TRNG"]
 pub mod clk_jtag_cert_trng;
-#[doc = "soft_rst0_addr_sel (rw) register accessor: Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst0_addr_sel`]
+#[doc = "soft_rst0_addr_sel (rw) register accessor: Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst0_addr_sel`]
 module"]
 pub type SOFT_RST0_ADDR_SEL = crate::Reg<soft_rst0_addr_sel::SOFT_RST0_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 0 Address Selector"]
 pub mod soft_rst0_addr_sel;
-#[doc = "soft_rst1_addr_sel (rw) register accessor: Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst1_addr_sel`]
+#[doc = "soft_rst1_addr_sel (rw) register accessor: Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst1_addr_sel`]
 module"]
 pub type SOFT_RST1_ADDR_SEL = crate::Reg<soft_rst1_addr_sel::SOFT_RST1_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 1 Address Selector"]
 pub mod soft_rst1_addr_sel;
-#[doc = "soft_rst2_addr_sel (rw) register accessor: Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst2_addr_sel`]
+#[doc = "soft_rst2_addr_sel (rw) register accessor: Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst2_addr_sel`]
 module"]
 pub type SOFT_RST2_ADDR_SEL = crate::Reg<soft_rst2_addr_sel::SOFT_RST2_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 2 Address Selector"]
 pub mod soft_rst2_addr_sel;
-#[doc = "soft_rst3_addr_sel (rw) register accessor: Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst3_addr_sel`]
+#[doc = "soft_rst3_addr_sel (rw) register accessor: Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst3_addr_sel`]
 module"]
 pub type SOFT_RST3_ADDR_SEL = crate::Reg<soft_rst3_addr_sel::SOFT_RST3_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 3 Address Selector"]
 pub mod soft_rst3_addr_sel;
-#[doc = "syscrg_rst0_status (rw) register accessor: SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst0_status`]
+#[doc = "syscrg_rst0_status (rw) register accessor: SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst0_status`]
 module"]
 pub type SYSCRG_RST0_STATUS = crate::Reg<syscrg_rst0_status::SYSCRG_RST0_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 0"]
 pub mod syscrg_rst0_status;
-#[doc = "syscrg_rst1_status (rw) register accessor: SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst1_status`]
+#[doc = "syscrg_rst1_status (rw) register accessor: SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst1_status`]
 module"]
 pub type SYSCRG_RST1_STATUS = crate::Reg<syscrg_rst1_status::SYSCRG_RST1_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 1"]
 pub mod syscrg_rst1_status;
-#[doc = "syscrg_rst2_status (rw) register accessor: SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst2_status`]
+#[doc = "syscrg_rst2_status (rw) register accessor: SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst2_status`]
 module"]
 pub type SYSCRG_RST2_STATUS = crate::Reg<syscrg_rst2_status::SYSCRG_RST2_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 2"]
 pub mod syscrg_rst2_status;
-#[doc = "syscrg_rst3_status (rw) register accessor: SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst3_status`]
+#[doc = "syscrg_rst3_status (rw) register accessor: SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst3_status`]
 module"]
 pub type SYSCRG_RST3_STATUS = crate::Reg<syscrg_rst3_status::SYSCRG_RST3_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 3"]

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_ahb0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_ahb0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB0_SPEC;
 impl crate::RegisterSpec for CLK_AHB0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB0_SPEC {}
 impl crate::Writable for CLK_AHB0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb0 to value 0"]
+impl crate::Resettable for CLK_AHB0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_ahb1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_ahb1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB1_SPEC;
 impl crate::RegisterSpec for CLK_AHB1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB1_SPEC {}
 impl crate::Writable for CLK_AHB1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb1 to value 0"]
+impl crate::Resettable for CLK_AHB1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_apb0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_apb0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_APB0_SPEC;
 impl crate::RegisterSpec for CLK_APB0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_APB0_SPEC {}
 impl crate::Writable for CLK_APB0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_apb0 to value 0"]
+impl crate::Resettable for CLK_APB0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_apb_bus.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_apb_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_APB_BUS_SPEC;
 impl crate::RegisterSpec for CLK_APB_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_APB_BUS_SPEC {}
 impl crate::Writable for CLK_APB_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_apb_bus to value 0"]
+impl crate::Resettable for CLK_APB_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_audio_root.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_audio_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AUDIO_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_AUDIO_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AUDIO_ROOT_SPEC {}
 impl crate::Writable for CLK_AUDIO_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_audio_root to value 0"]
+impl crate::Resettable for CLK_AUDIO_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0 to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_hifi4.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_hifi4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_HIFI4_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_hifi4 to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_main.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_MAIN_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_main to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_main_div.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_axi_cfg0_dec_main_div.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_main_div to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_aximem_128b_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_aximem_128b_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXIMEM_128B_AXI_SPEC;
 impl crate::RegisterSpec for CLK_AXIMEM_128B_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXIMEM_128B_AXI_SPEC {}
 impl crate::Writable for CLK_AXIMEM_128B_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_aximem_128b_axi to value 0"]
+impl crate::Resettable for CLK_AXIMEM_128B_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_bus_root.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_bus_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_BUS_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_BUS_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_BUS_ROOT_SPEC {}
 impl crate::Writable for CLK_BUS_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_bus_root to value 0"]
+impl crate::Resettable for CLK_BUS_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_APB_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CODAJ12_APB_SPEC {}
 impl crate::Writable for CLK_CODAJ12_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_apb to value 0"]
+impl crate::Resettable for CLK_CODAJ12_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_AXI_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CODAJ12_AXI_SPEC {}
 impl crate::Writable for CLK_CODAJ12_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_axi to value 0"]
+impl crate::Resettable for CLK_CODAJ12_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_codaj12_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_CORE_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_CODAJ12_CORE_SPEC {}
 impl crate::Writable for CLK_CODAJ12_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_core to value 0"]
+impl crate::Resettable for CLK_CODAJ12_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_bus.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_BUS_SPEC;
 impl crate::RegisterSpec for CLK_CPU_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_BUS_SPEC {}
 impl crate::Writable for CLK_CPU_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_bus to value 0"]
+impl crate::Resettable for CLK_CPU_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_CORE_SPEC;
 impl crate::RegisterSpec for CLK_CPU_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_CORE_SPEC {}
 impl crate::Writable for CLK_CPU_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_core to value 0"]
+impl crate::Resettable for CLK_CPU_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_root.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_cpu_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_CPU_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_ROOT_SPEC {}
 impl crate::Writable for CLK_CPU_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_root to value 0"]
+impl crate::Resettable for CLK_CPU_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_ddr_bus.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_ddr_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DDR_BUS_SPEC;
 impl crate::RegisterSpec for CLK_DDR_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DDR_BUS_SPEC {}
 impl crate::Writable for CLK_DDR_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ddr_bus to value 0"]
+impl crate::Resettable for CLK_DDR_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gclk0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gclk0.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK0_SPEC;
 impl crate::RegisterSpec for CLK_GCLK0_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK0_SPEC {}
 impl crate::Writable for CLK_GCLK0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk0 to value 0"]
+impl crate::Resettable for CLK_GCLK0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gclk1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gclk1.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK1_SPEC;
 impl crate::RegisterSpec for CLK_GCLK1_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK1_SPEC {}
 impl crate::Writable for CLK_GCLK1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk1 to value 0"]
+impl crate::Resettable for CLK_GCLK1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gclk2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gclk2.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK2_SPEC;
 impl crate::RegisterSpec for CLK_GCLK2_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK2_SPEC {}
 impl crate::Writable for CLK_GCLK2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk2 to value 0"]
+impl crate::Resettable for CLK_GCLK2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_gtx.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_gtx.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_GTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_GTX_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC0_GTX_SPEC {}
 impl crate::Writable for CLK_GMAC0_GTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_gtx to value 0"]
+impl crate::Resettable for CLK_GMAC0_GTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_gtxclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_gtxclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_GTXCLK_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_GTXCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC0_GTXCLK_SPEC {}
 impl crate::Writable for CLK_GMAC0_GTXCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_gtxclk to value 0"]
+impl crate::Resettable for CLK_GMAC0_GTXCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_ptp.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac0_ptp.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_PTP_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_PTP_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC0_PTP_SPEC {}
 impl crate::Writable for CLK_GMAC0_PTP_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_ptp to value 0"]
+impl crate::Resettable for CLK_GMAC0_PTP_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_gtx.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_gtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_GTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_GTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_GTX_SPEC {}
 impl crate::Writable for CLK_GMAC1_GTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_gtx to value 0"]
+impl crate::Resettable for CLK_GMAC1_GTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_gtxclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_gtxclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_GTXCLK_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_GTXCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_GTXCLK_SPEC {}
 impl crate::Writable for CLK_GMAC1_GTXCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_gtxclk to value 0"]
+impl crate::Resettable for CLK_GMAC1_GTXCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_rmii_rtx.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac1_rmii_rtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_RMII_RTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_RMII_RTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_RMII_RTX_SPEC {}
 impl crate::Writable for CLK_GMAC1_RMII_RTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_rmii_rtx to value 0"]
+impl crate::Resettable for CLK_GMAC1_RMII_RTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_AHB_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_AHB_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_ahb to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_AXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_AXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_axi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_ptp.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_ptp.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_PTP_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_PTP_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_PTP_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_PTP_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_ptp to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_PTP_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_rx.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_rx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_rxi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_rxi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rxi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_tx.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_tx.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TX_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_tx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_txi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac5_axi64_txi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_txi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac_phy.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac_phy.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC_PHY_SPEC;
 impl crate::RegisterSpec for CLK_GMAC_PHY_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC_PHY_SPEC {}
 impl crate::Writable for CLK_GMAC_PHY_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac_phy to value 0"]
+impl crate::Resettable for CLK_GMAC_PHY_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gmac_src.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gmac_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC_SRC_SPEC;
 impl crate::RegisterSpec for CLK_GMAC_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC_SRC_SPEC {}
 impl crate::Writable for CLK_GMAC_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac_src to value 0"]
+impl crate::Resettable for CLK_GMAC_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gpu_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gpu_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GPU_CORE_SPEC;
 impl crate::RegisterSpec for CLK_GPU_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GPU_CORE_SPEC {}
 impl crate::Writable for CLK_GPU_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gpu_core to value 0"]
+impl crate::Resettable for CLK_GPU_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_gpu_root.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_gpu_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GPU_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_GPU_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GPU_ROOT_SPEC {}
 impl crate::Writable for CLK_GPU_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gpu_root to value 0"]
+impl crate::Resettable for CLK_GPU_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_hifi4_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_hifi4_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_AXI_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_AXI_SPEC {}
 impl crate::Writable for CLK_HIFI4_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_axi to value 0"]
+impl crate::Resettable for CLK_HIFI4_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_hifi4_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_hifi4_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_CORE_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_CORE_SPEC {}
 impl crate::Writable for CLK_HIFI4_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_core to value 0"]
+impl crate::Resettable for CLK_HIFI4_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_APB_SPEC;
 impl crate::RegisterSpec for CLK_I2S_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_APB_SPEC {}
 impl crate::Writable for CLK_I2S_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_apb to value 0"]
+impl crate::Resettable for CLK_I2S_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2S_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_mst to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_mst_inv.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_neg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_neg to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_lrck.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_I2S_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_LRCK_SPEC {}
 impl crate::Writable for CLK_I2S_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_lrck to value 0"]
+impl crate::Resettable for CLK_I2S_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_lrck_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2s_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2S_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2S_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2S_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2S_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2stx0_lrck_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2stx0_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2STX0_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2STX0_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2STX0_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2STX0_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2stx0_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2STX0_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_i2stx1_lrck_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_i2stx1_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2STX1_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2STX1_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2STX1_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2STX1_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2stx1_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2STX1_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_internal_ctrl_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_internal_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_INTERNAL_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_INTERNAL_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_INTERNAL_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_INTERNAL_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_internal_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_INTERNAL_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_isp_2x.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_isp_2x.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_ISP_2X_SPEC;
 impl crate::RegisterSpec for CLK_ISP_2X_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_ISP_2X_SPEC {}
 impl crate::Writable for CLK_ISP_2X_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_isp_2x to value 0"]
+impl crate::Resettable for CLK_ISP_2X_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_isp_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_jpeg_codec_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_jpeg_codec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_JPEG_CODEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_JPEG_CODEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_JPEG_CODEC_AXI_SPEC {}
 impl crate::Writable for CLK_JPEG_CODEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_jpeg_codec_axi to value 0"]
+impl crate::Resettable for CLK_JPEG_CODEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_jtag_cert_trng.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_jtag_cert_trng.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_JTAG_CERT_TRNG_SPEC;
 impl crate::RegisterSpec for CLK_JTAG_CERT_TRNG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_JTAG_CERT_TRNG_SPEC {}
 impl crate::Writable for CLK_JTAG_CERT_TRNG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_jtag_cert_trng to value 0"]
+impl crate::Resettable for CLK_JTAG_CERT_TRNG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_mbox_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_mbox_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MBOX_APB_SPEC;
 impl crate::RegisterSpec for CLK_MBOX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MBOX_APB_SPEC {}
 impl crate::Writable for CLK_MBOX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mbox_apb to value 0"]
+impl crate::Resettable for CLK_MBOX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_mclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_mclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_SPEC {}
 impl crate::Writable for CLK_MCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk to value 0"]
+impl crate::Resettable for CLK_MCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_mclk_inner.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_mclk_inner.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_INNER_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_INNER_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_INNER_SPEC {}
 impl crate::Writable for CLK_MCLK_INNER_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk_inner to value 0"]
+impl crate::Resettable for CLK_MCLK_INNER_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_mclk_out.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_mclk_out.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_OUT_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_OUT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_OUT_SPEC {}
 impl crate::Writable for CLK_MCLK_OUT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk_out to value 0"]
+impl crate::Resettable for CLK_MCLK_OUT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_noc_display_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_noc_display_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_DISPLAY_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_DISPLAY_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_DISPLAY_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_DISPLAY_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_display_axi to value 0"]
+impl crate::Resettable for CLK_NOC_DISPLAY_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_noc_stg_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_noc_stg_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_STG_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_STG_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_STG_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_STG_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_stg_axi to value 0"]
+impl crate::Resettable for CLK_NOC_STG_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_noc_vdec_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_noc_vdec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_VDEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_VDEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_VDEC_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_VDEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_vdec_axi to value 0"]
+impl crate::Resettable for CLK_NOC_VDEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_noc_venc_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_noc_venc_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_VENC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_VENC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_VENC_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_VENC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_venc_axi to value 0"]
+impl crate::Resettable for CLK_NOC_VENC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_nocstg_bus.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_nocstg_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOCSTG_BUS_SPEC;
 impl crate::RegisterSpec for CLK_NOCSTG_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOCSTG_BUS_SPEC {}
 impl crate::Writable for CLK_NOCSTG_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_nocstg_bus to value 0"]
+impl crate::Resettable for CLK_NOCSTG_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_osc_div2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_osc_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OSC_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_OSC_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OSC_DIV2_SPEC {}
 impl crate::Writable for CLK_OSC_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_osc_div2 to value 0"]
+impl crate::Resettable for CLK_OSC_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pdm_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pdm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PDM_APB_SPEC;
 impl crate::RegisterSpec for CLK_PDM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PDM_APB_SPEC {}
 impl crate::Writable for CLK_PDM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pdm_apb to value 0"]
+impl crate::Resettable for CLK_PDM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pdm_dmic.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pdm_dmic.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PDM_DMIC_SPEC;
 impl crate::RegisterSpec for CLK_PDM_DMIC_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PDM_DMIC_SPEC {}
 impl crate::Writable for CLK_PDM_DMIC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pdm_dmic to value 0"]
+impl crate::Resettable for CLK_PDM_DMIC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_peripheral_root.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_peripheral_root.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PERIPHERAL_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_PERIPHERAL_ROOT_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PERIPHERAL_ROOT_SPEC {}
 impl crate::Writable for CLK_PERIPHERAL_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_peripheral_root to value 0"]
+impl crate::Resettable for CLK_PERIPHERAL_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pll0_div2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pll0_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL0_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL0_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL0_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL0_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll0_div2 to value 0"]
+impl crate::Resettable for CLK_PLL0_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div2 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div4.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV4_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV4_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div4 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div8.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pll1_div8.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV8_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV8_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV8_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV8_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div8 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV8_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pll2_div2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pll2_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL2_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL2_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL2_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL2_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll2_div2 to value 0"]
+impl crate::Resettable for CLK_PLL2_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pwm_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pwm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWM_APB_SPEC;
 impl crate::RegisterSpec for CLK_PWM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PWM_APB_SPEC {}
 impl crate::Writable for CLK_PWM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwm_apb to value 0"]
+impl crate::Resettable for CLK_PWM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pwmdac_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pwmdac_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWMDAC_APB_SPEC;
 impl crate::RegisterSpec for CLK_PWMDAC_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PWMDAC_APB_SPEC {}
 impl crate::Writable for CLK_PWMDAC_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwmdac_apb to value 0"]
+impl crate::Resettable for CLK_PWMDAC_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_pwmdac_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_pwmdac_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWMDAC_CORE_SPEC;
 impl crate::RegisterSpec for CLK_PWMDAC_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PWMDAC_CORE_SPEC {}
 impl crate::Writable for CLK_PWMDAC_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwmdac_core to value 0"]
+impl crate::Resettable for CLK_PWMDAC_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_AHB_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_AHB_SPEC {}
 impl crate::Writable for CLK_QSPI_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ahb to value 0"]
+impl crate::Resettable for CLK_QSPI_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_APB_SPEC {}
 impl crate::Writable for CLK_QSPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_apb to value 0"]
+impl crate::Resettable for CLK_QSPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ref.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ref.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_REF_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_REF_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_QSPI_REF_SPEC {}
 impl crate::Writable for CLK_QSPI_REF_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ref to value 0"]
+impl crate::Resettable for CLK_QSPI_REF_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ref_src.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_qspi_ref_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_REF_SRC_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_REF_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_REF_SRC_SPEC {}
 impl crate::Writable for CLK_QSPI_REF_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ref_src to value 0"]
+impl crate::Resettable for CLK_QSPI_REF_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_spdif_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_spdif_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SPDIF_APB_SPEC;
 impl crate::RegisterSpec for CLK_SPDIF_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SPDIF_APB_SPEC {}
 impl crate::Writable for CLK_SPDIF_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_spdif_apb to value 0"]
+impl crate::Resettable for CLK_SPDIF_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_spdif_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_spdif_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SPDIF_CORE_SPEC;
 impl crate::RegisterSpec for CLK_SPDIF_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SPDIF_CORE_SPEC {}
 impl crate::Writable for CLK_SPDIF_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_spdif_core to value 0"]
+impl crate::Resettable for CLK_SPDIF_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_stg_axiahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_stg_axiahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_AXIAHB_SPEC;
 impl crate::RegisterSpec for CLK_STG_AXIAHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_AXIAHB_SPEC {}
 impl crate::Writable for CLK_STG_AXIAHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_axiahb to value 0"]
+impl crate::Resettable for CLK_STG_AXIAHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_sys_iomux_pclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_sys_iomux_pclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SYS_IOMUX_PCLK_SPEC;
 impl crate::RegisterSpec for CLK_SYS_IOMUX_PCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SYS_IOMUX_PCLK_SPEC {}
 impl crate::Writable for CLK_SYS_IOMUX_PCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sys_iomux_pclk to value 0"]
+impl crate::Resettable for CLK_SYS_IOMUX_PCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tdm.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tdm.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_SPEC;
 impl crate::RegisterSpec for CLK_TDM_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_SPEC {}
 impl crate::Writable for CLK_TDM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm to value 0"]
+impl crate::Resettable for CLK_TDM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_AHB_SPEC;
 impl crate::RegisterSpec for CLK_TDM_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_AHB_SPEC {}
 impl crate::Writable for CLK_TDM_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_ahb to value 0"]
+impl crate::Resettable for CLK_TDM_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_APB_SPEC;
 impl crate::RegisterSpec for CLK_TDM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_APB_SPEC {}
 impl crate::Writable for CLK_TDM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_apb to value 0"]
+impl crate::Resettable for CLK_TDM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_internal.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_internal.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_INTERNAL_SPEC;
 impl crate::RegisterSpec for CLK_TDM_INTERNAL_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_TDM_INTERNAL_SPEC {}
 impl crate::Writable for CLK_TDM_INTERNAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_internal to value 0"]
+impl crate::Resettable for CLK_TDM_INTERNAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_neg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tdm_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_NEG_SPEC;
 impl crate::RegisterSpec for CLK_TDM_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_NEG_SPEC {}
 impl crate::Writable for CLK_TDM_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_neg to value 0"]
+impl crate::Resettable for CLK_TDM_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_temp_sensor.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_temp_sensor.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TEMP_SENSOR_SPEC;
 impl crate::RegisterSpec for CLK_TEMP_SENSOR_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_TEMP_SENSOR_SPEC {}
 impl crate::Writable for CLK_TEMP_SENSOR_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_temp_sensor to value 0"]
+impl crate::Resettable for CLK_TEMP_SENSOR_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_temp_sensor_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_temp_sensor_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TEMP_SENSOR_APB_SPEC;
 impl crate::RegisterSpec for CLK_TEMP_SENSOR_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TEMP_SENSOR_APB_SPEC {}
 impl crate::Writable for CLK_TEMP_SENSOR_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_temp_sensor_apb to value 0"]
+impl crate::Resettable for CLK_TEMP_SENSOR_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tim0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tim0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM0_SPEC;
 impl crate::RegisterSpec for CLK_TIM0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM0_SPEC {}
 impl crate::Writable for CLK_TIM0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim0 to value 0"]
+impl crate::Resettable for CLK_TIM0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tim1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tim1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM1_SPEC;
 impl crate::RegisterSpec for CLK_TIM1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM1_SPEC {}
 impl crate::Writable for CLK_TIM1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim1 to value 0"]
+impl crate::Resettable for CLK_TIM1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tim2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tim2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM2_SPEC;
 impl crate::RegisterSpec for CLK_TIM2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM2_SPEC {}
 impl crate::Writable for CLK_TIM2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim2 to value 0"]
+impl crate::Resettable for CLK_TIM2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tim3.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tim3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM3_SPEC;
 impl crate::RegisterSpec for CLK_TIM3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM3_SPEC {}
 impl crate::Writable for CLK_TIM3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim3 to value 0"]
+impl crate::Resettable for CLK_TIM3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_tim_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_tim_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM_APB_SPEC;
 impl crate::RegisterSpec for CLK_TIM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM_APB_SPEC {}
 impl crate::Writable for CLK_TIM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim_apb to value 0"]
+impl crate::Resettable for CLK_TIM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {}
 impl crate::Writable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_axi_cfg1_dec_clk_ahb to value 0"]
+impl crate::Resettable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_main.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {}
 impl crate::Writable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_axi_cfg1_dec_clk_main to value 0"]
+impl crate::Resettable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_can.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_can.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_CAN_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_CAN_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_CAN_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_CAN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_can to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_CAN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_tim.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_can_ctrl_tim.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_TIM_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_TIM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_TIM_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_TIM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_tim to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_TIM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_ddr_sft7110_clk_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_ddr_sft7110_clk_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DDR_SFT7110_CLK_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {}
 impl crate::Writable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_ddr_sft7110_clk_axi to value 0"]
+impl crate::Resettable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC 
 impl crate::Writable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x to value 0"]
+impl crate::Resettable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC 
 impl crate::Writable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src to value 0"]
+impl crate::Resettable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_gpu_rtc_toggle.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_gpu_rtc_toggle.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_GPU_RTC_TOGGLE_SPEC;
 impl crate::RegisterSpec for CLK_U0_GPU_RTC_TOGGLE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_GPU_RTC_TOGGLE_SPEC {}
 impl crate::Writable for CLK_U0_GPU_RTC_TOGGLE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_gpu_rtc_toggle to value 0"]
+impl crate::Resettable for CLK_U0_GPU_RTC_TOGGLE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U0_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U0_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2s_tx_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2s_tx_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2S_TX_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2S_TX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2S_TX_APB_SPEC {}
 impl crate::Writable for CLK_U0_I2S_TX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2s_tx_apb to value 0"]
+impl crate::Resettable for CLK_U0_I2S_TX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_4CH0_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_4ch0_bclk_mst to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst_inv.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_4ch0_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_bclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_BCLK_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_bclk to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_bclk_neg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_bclk_neg to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_lrck.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_i2stx_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_LRCK_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_lrck to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_clk_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_clk_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_CLK_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_CLK_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_CLK_APB_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_CLK_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_clk_apb to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_CLK_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_core_clk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_core_clk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_CORE_CLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_core_clk to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_sys_clk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_img_gpu_sys_clk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_SYS_CLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_sys_clk to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sd_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sd_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SD_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U0_SD_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SD_AHB_SPEC {}
 impl crate::Writable for CLK_U0_SD_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sd_ahb to value 0"]
+impl crate::Resettable for CLK_U0_SD_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sd_card.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sd_card.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SD_CARD_SPEC;
 impl crate::RegisterSpec for CLK_U0_SD_CARD_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_SD_CARD_SPEC {}
 impl crate::Writable for CLK_U0_SD_CARD_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sd_card to value 0"]
+impl crate::Resettable for CLK_U0_SD_CARD_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_axicfg0_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_axicfg0_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_axicfg0_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_cpu_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_cpu_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_cpu_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_gpu_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_gpu_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_gpu_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bux_clk_isp_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_sft7110_noc_bux_clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bux_clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U0_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_spi_apb to value 0"]
+impl crate::Resettable for CLK_U0_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_UART_APB_SPEC {}
 impl crate::Writable for CLK_U0_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_uart_apb to value 0"]
+impl crate::Resettable for CLK_U0_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u0_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u0_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U0_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U0_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_uart_core to value 0"]
+impl crate::Resettable for CLK_U0_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_can.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_can.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_CAN_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_CAN_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_CAN_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_CAN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_can to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_CAN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_tim.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_can_ctrl_tim.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_TIM_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_TIM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_TIM_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_TIM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_tim to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_TIM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U1_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U1_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2s_tx_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2s_tx_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2S_TX_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2S_TX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2S_TX_APB_SPEC {}
 impl crate::Writable for CLK_U1_I2S_TX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2s_tx_apb to value 0"]
+impl crate::Resettable for CLK_U1_I2S_TX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_4CH1_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_4ch1_bclk_mst to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst_inv.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_4ch1_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_bclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_BCLK_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_bclk to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_bclk_neg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_bclk_neg to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_lrck.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_i2stx_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_LRCK_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_lrck to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_sd_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_sd_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SD_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U1_SD_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_SD_AHB_SPEC {}
 impl crate::Writable for CLK_U1_SD_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_sd_ahb to value 0"]
+impl crate::Resettable for CLK_U1_SD_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_sd_card.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_sd_card.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SD_CARD_SPEC;
 impl crate::RegisterSpec for CLK_U1_SD_CARD_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_SD_CARD_SPEC {}
 impl crate::Writable for CLK_U1_SD_CARD_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_sd_card to value 0"]
+impl crate::Resettable for CLK_U1_SD_CARD_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U1_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_spi_apb to value 0"]
+impl crate::Resettable for CLK_U1_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_UART_APB_SPEC {}
 impl crate::Writable for CLK_U1_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_uart_apb to value 0"]
+impl crate::Resettable for CLK_U1_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u1_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u1_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U1_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U1_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_uart_core to value 0"]
+impl crate::Resettable for CLK_U1_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u2_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u2_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U2_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U2_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u2_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u2_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U2_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_spi_apb to value 0"]
+impl crate::Resettable for CLK_U2_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u2_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u2_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_UART_APB_SPEC {}
 impl crate::Writable for CLK_U2_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_uart_apb to value 0"]
+impl crate::Resettable for CLK_U2_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u2_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u2_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U2_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U2_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_uart_core to value 0"]
+impl crate::Resettable for CLK_U2_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u3_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u3_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U3_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U3_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u3_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u3_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U3_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_spi_apb to value 0"]
+impl crate::Resettable for CLK_U3_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u3_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u3_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_UART_APB_SPEC {}
 impl crate::Writable for CLK_U3_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_uart_apb to value 0"]
+impl crate::Resettable for CLK_U3_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u3_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u3_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U3_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U3_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U3_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_uart_core to value 0"]
+impl crate::Resettable for CLK_U3_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u4_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u4_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U4_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U4_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u4_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u4_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U4_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_spi_apb to value 0"]
+impl crate::Resettable for CLK_U4_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u4_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u4_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_UART_APB_SPEC {}
 impl crate::Writable for CLK_U4_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_uart_apb to value 0"]
+impl crate::Resettable for CLK_U4_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u4_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u4_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U4_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U4_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U4_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_uart_core to value 0"]
+impl crate::Resettable for CLK_U4_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u5_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u5_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U5_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U5_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u5_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u5_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U5_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_spi_apb to value 0"]
+impl crate::Resettable for CLK_U5_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u5_uart_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u5_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_UART_APB_SPEC {}
 impl crate::Writable for CLK_U5_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_uart_apb to value 0"]
+impl crate::Resettable for CLK_U5_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u5_uart_core.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u5_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U5_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U5_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U5_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_uart_core to value 0"]
+impl crate::Resettable for CLK_U5_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u6_i2c_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u6_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U6_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U6_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U6_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U6_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u6_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U6_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u6_spi_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u6_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U6_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U6_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U6_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U6_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u6_spi_apb to value 0"]
+impl crate::Resettable for CLK_U6_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE0_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE0_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core0 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE1_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE1_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core1 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE2_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE2_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core2 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core3.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE3_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE3_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core3 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core4.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_core4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE4_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE4_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core4 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_debug.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_debug.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_DEBUG_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_DEBUG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_DEBUG_SPEC {}
 impl crate::Writable for CLK_U7MC_DEBUG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_debug to value 0"]
+impl crate::Resettable for CLK_U7MC_DEBUG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE0_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE0_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace0 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE1_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE1_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace1 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE2_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE2_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace2 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace3.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE3_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE3_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace3 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace4.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE4_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE4_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace4 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace_com.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_u7mc_trace_com.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE_COM_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE_COM_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE_COM_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE_COM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace_com to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE_COM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_usb_125m.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_usb_125m.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_125M_SPEC;
 impl crate::RegisterSpec for CLK_USB_125M_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_125M_SPEC {}
 impl crate::Writable for CLK_USB_125M_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_125m to value 0"]
+impl crate::Resettable for CLK_USB_125M_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vdec_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vdec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VDEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_VDEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VDEC_AXI_SPEC {}
 impl crate::Writable for CLK_VDEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vdec_axi to value 0"]
+impl crate::Resettable for CLK_VDEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_venc_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_venc_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VENC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_VENC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VENC_AXI_SPEC {}
 impl crate::Writable for CLK_VENC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_venc_axi to value 0"]
+impl crate::Resettable for CLK_VENC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vout_ahb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vout_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AHB_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AHB_SPEC {}
 impl crate::Writable for CLK_VOUT_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_ahb to value 0"]
+impl crate::Resettable for CLK_VOUT_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vout_axi_divcfg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vout_axi_divcfg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AXI_DIVCFG_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AXI_DIVCFG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AXI_DIVCFG_SPEC {}
 impl crate::Writable for CLK_VOUT_AXI_DIVCFG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_axi_divcfg to value 0"]
+impl crate::Resettable for CLK_VOUT_AXI_DIVCFG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vout_axi_icg.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vout_axi_icg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AXI_ICG_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AXI_ICG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AXI_ICG_SPEC {}
 impl crate::Writable for CLK_VOUT_AXI_ICG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_axi_icg to value 0"]
+impl crate::Resettable for CLK_VOUT_AXI_ICG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vout_hdmi_tx0_mclk.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vout_hdmi_tx0_mclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_HDMI_TX0_MCLK_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {}
 impl crate::Writable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_hdmi_tx0_mclk to value 0"]
+impl crate::Resettable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_vout_mipi_phy.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_vout_mipi_phy.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_MIPI_PHY_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_MIPI_PHY_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_MIPI_PHY_SPEC {}
 impl crate::Writable for CLK_VOUT_MIPI_PHY_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_mipi_phy to value 0"]
+impl crate::Resettable for CLK_VOUT_MIPI_PHY_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_APB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE420L_APB_SPEC {}
 impl crate::Writable for CLK_WAVE420L_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_apb to value 0"]
+impl crate::Resettable for CLK_WAVE420L_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_AXI_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE420L_AXI_SPEC {}
 impl crate::Writable for CLK_WAVE420L_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_axi to value 0"]
+impl crate::Resettable for CLK_WAVE420L_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_bpu.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_bpu.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_BPU_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_BPU_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE420L_BPU_SPEC {}
 impl crate::Writable for CLK_WAVE420L_BPU_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_bpu to value 0"]
+impl crate::Resettable for CLK_WAVE420L_BPU_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_vce.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave420l_vce.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_VCE_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_VCE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE420L_VCE_SPEC {}
 impl crate::Writable for CLK_WAVE420L_VCE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_vce to value 0"]
+impl crate::Resettable for CLK_WAVE420L_VCE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_APB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_APB_SPEC {}
 impl crate::Writable for CLK_WAVE511_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_apb to value 0"]
+impl crate::Resettable for CLK_WAVE511_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_axi.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_AXI_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_AXI_SPEC {}
 impl crate::Writable for CLK_WAVE511_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_axi to value 0"]
+impl crate::Resettable for CLK_WAVE511_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_bpu.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_bpu.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_BPU_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_BPU_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE511_BPU_SPEC {}
 impl crate::Writable for CLK_WAVE511_BPU_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_bpu to value 0"]
+impl crate::Resettable for CLK_WAVE511_BPU_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_jpg_arb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_jpg_arb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_JPG_ARB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_JPG_ARB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_JPG_ARB_SPEC {}
 impl crate::Writable for CLK_WAVE511_JPG_ARB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_jpg_arb to value 0"]
+impl crate::Resettable for CLK_WAVE511_JPG_ARB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_jpg_main.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_jpg_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_JPG_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_JPG_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_JPG_MAIN_SPEC {}
 impl crate::Writable for CLK_WAVE511_JPG_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_jpg_main to value 0"]
+impl crate::Resettable for CLK_WAVE511_JPG_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_vce.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wave511_vce.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_VCE_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_VCE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE511_VCE_SPEC {}
 impl crate::Writable for CLK_WAVE511_VCE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_vce to value 0"]
+impl crate::Resettable for CLK_WAVE511_VCE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wdt.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wdt.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WDT_SPEC;
 impl crate::RegisterSpec for CLK_WDT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WDT_SPEC {}
 impl crate::Writable for CLK_WDT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wdt to value 0"]
+impl crate::Resettable for CLK_WDT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/clk_wdt_apb.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/clk_wdt_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WDT_APB_SPEC;
 impl crate::RegisterSpec for CLK_WDT_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WDT_APB_SPEC {}
 impl crate::Writable for CLK_WDT_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wdt_apb to value 0"]
+impl crate::Resettable for CLK_WDT_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst0_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst0_addr_sel.rs
@@ -578,7 +578,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST0_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST0_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -589,4 +589,8 @@ impl crate::Readable for SOFT_RST0_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST0_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst0_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST0_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst1_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst1_addr_sel.rs
@@ -569,7 +569,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST1_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST1_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -580,4 +580,8 @@ impl crate::Readable for SOFT_RST1_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST1_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst1_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST1_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst2_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst2_addr_sel.rs
@@ -518,7 +518,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST2_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST2_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -529,4 +529,8 @@ impl crate::Readable for SOFT_RST2_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST2_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst2_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST2_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst3_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst3_addr_sel.rs
@@ -526,7 +526,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST3_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST3_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -537,4 +537,8 @@ impl crate::Readable for SOFT_RST3_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST3_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst3_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST3_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst0_status.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst0_status.rs
@@ -578,7 +578,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST0_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST0_STATUS_SPEC {
     type Ux = u32;
@@ -589,4 +589,8 @@ impl crate::Readable for SYSCRG_RST0_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST0_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst0_status to value 0"]
+impl crate::Resettable for SYSCRG_RST0_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst1_status.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst1_status.rs
@@ -569,7 +569,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST1_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST1_STATUS_SPEC {
     type Ux = u32;
@@ -580,4 +580,8 @@ impl crate::Readable for SYSCRG_RST1_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST1_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst1_status to value 0"]
+impl crate::Resettable for SYSCRG_RST1_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst2_status.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst2_status.rs
@@ -518,7 +518,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST2_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST2_STATUS_SPEC {
     type Ux = u32;
@@ -529,4 +529,8 @@ impl crate::Readable for SYSCRG_RST2_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST2_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst2_status to value 0"]
+impl crate::Resettable for SYSCRG_RST2_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst3_status.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst3_status.rs
@@ -526,7 +526,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST3_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST3_STATUS_SPEC {
     type Ux = u32;
@@ -537,4 +537,8 @@ impl crate::Readable for SYSCRG_RST3_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST3_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst3_status to value 0"]
+impl crate::Resettable for SYSCRG_RST3_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/syscrg/u7mc_rtc_toggle.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/u7mc_rtc_toggle.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct U7MC_RTC_TOGGLE_SPEC;
 impl crate::RegisterSpec for U7MC_RTC_TOGGLE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for U7MC_RTC_TOGGLE_SPEC {}
 impl crate::Writable for U7MC_RTC_TOGGLE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets u7mc_rtc_toggle to value 0"]
+impl crate::Resettable for U7MC_RTC_TOGGLE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -11302,6 +11302,7 @@
           <description>Clock HIFI4 Core</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11316,6 +11317,7 @@
           <description>Clock USB APB</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11330,6 +11332,7 @@
           <description>Clock USB UTMI APB</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11344,6 +11347,7 @@
           <description>Clock USB AXI</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11358,6 +11362,7 @@
           <description>Clock USB AXI</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11378,6 +11383,7 @@
           <description>Clock USB STB</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11398,6 +11404,7 @@
           <description>Clock USB APP 125</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11412,6 +11419,7 @@
           <description>Clock USB Reference Clock</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -11426,6 +11434,7 @@
           <description>U0 Clock PCIe AXI MST 0</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11440,6 +11449,7 @@
           <description>U0 Clock PCIe APB</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11454,6 +11464,7 @@
           <description>U0 Clock PCIe TL</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11468,6 +11479,7 @@
           <description>U1 Clock PCIe AXI MST 0</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11482,6 +11494,7 @@
           <description>U1 Clock PCIe APB</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11496,6 +11509,7 @@
           <description>U1 Clock PCIe TL</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11510,6 +11524,7 @@
           <description>Clock PCIe 01 SLV DEC Main</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11524,6 +11539,7 @@
           <description>Clock Security HCLK</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11538,6 +11554,7 @@
           <description>Clock Security Miscellaneous AHB</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11552,6 +11569,7 @@
           <description>Clock STG MTRX Group 0 Main</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11566,6 +11584,7 @@
           <description>Clock STG MTRX Group 0 Bus</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11580,6 +11599,7 @@
           <description>Clock STG MTRX Group 0 STG</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11594,6 +11614,7 @@
           <description>Clock STG MTRX Group 1 Main</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11608,6 +11629,7 @@
           <description>Clock STG MTRX Group 1 Bus</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11622,6 +11644,7 @@
           <description>Clock STG MTRX Group 1 STG</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11636,6 +11659,7 @@
           <description>Clock STG MTRX Group 1 HIFI</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11650,6 +11674,7 @@
           <description>Clock E2 RTC</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11670,6 +11695,7 @@
           <description>Clock E2 Core</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11684,6 +11710,7 @@
           <description>Clock E2 DBG</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11698,6 +11725,7 @@
           <description>Clock DMA AXI</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11712,6 +11740,7 @@
           <description>Clock DMA AHB</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -11726,6 +11755,7 @@
           <description>Software RESET Address Selector</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_stg_syscon_presetn</name>
@@ -11872,6 +11902,7 @@
           <description>STGCRG RESET Status</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_stg_syscon_presetn</name>
@@ -27735,6 +27766,7 @@
           <description>Clock CPU Root</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27749,6 +27781,7 @@
           <description>Clock CPU Core</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27763,6 +27796,7 @@
           <description>Clock CPU Bus</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27777,6 +27811,7 @@
           <description>Clock GPU Root</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27791,6 +27826,7 @@
           <description>Clock Peripheral Root</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27811,6 +27847,7 @@
           <description>Clock Bus Root</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -27825,6 +27862,7 @@
           <description>Clock NOCSTG Bus</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27839,6 +27877,7 @@
           <description>Clock AXI Configuration 0</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27853,6 +27892,7 @@
           <description>Clock STG AXI AHB</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27867,6 +27907,7 @@
           <description>Clock AHB 0</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -27881,6 +27922,7 @@
           <description>Clock AHB 1</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -27895,6 +27937,7 @@
           <description>Clock APB Bus</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27909,6 +27952,7 @@
           <description>Clock APB 0</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -27923,6 +27967,7 @@
           <description>Clock PLL 0 Divider 2</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27937,6 +27982,7 @@
           <description>Clock PLL 1 Divider 2</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27951,6 +27997,7 @@
           <description>Clock PLL 2 Divider 2</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27965,6 +28012,7 @@
           <description>Clock Audio Root</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27979,6 +28027,7 @@
           <description>Clock MCLK Inner</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -27993,6 +28042,7 @@
           <description>Clock MCLK</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28007,6 +28057,7 @@
           <description>Clock MCLK Out</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28021,6 +28072,7 @@
           <description>Clock ISP 2x</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28041,6 +28093,7 @@
           <description>Clock ISP AXI</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28055,6 +28108,7 @@
           <description>Clock GCLK 0</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28075,6 +28129,7 @@
           <description>Clock GCLK 1</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28095,6 +28150,7 @@
           <description>Clock GCLK 2</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28115,6 +28171,7 @@
           <description>U7MC Core Clock 0</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28129,6 +28186,7 @@
           <description>U7MC Core Clock 1</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28143,6 +28201,7 @@
           <description>U7MC Core Clock 2</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28157,6 +28216,7 @@
           <description>U7MC Core Clock 3</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28171,6 +28231,7 @@
           <description>U7MC Core Clock 4</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28185,6 +28246,7 @@
           <description>U7MC Debug Clock</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28199,6 +28261,7 @@
           <description>U7MC RTC Toggle</description>
           <addressOffset>0x7c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28213,6 +28276,7 @@
           <description>U7MC Trace Clock 0</description>
           <addressOffset>0x80</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28227,6 +28291,7 @@
           <description>U7MC Trace Clock 1</description>
           <addressOffset>0x84</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28241,6 +28306,7 @@
           <description>U7MC Trace Clock 2</description>
           <addressOffset>0x88</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28255,6 +28321,7 @@
           <description>U7MC Trace Clock 3</description>
           <addressOffset>0x8c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28269,6 +28336,7 @@
           <description>U7MC Trace Clock 4</description>
           <addressOffset>0x90</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28283,6 +28351,7 @@
           <description>U7MC Trace Clock COM</description>
           <addressOffset>0x94</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28297,6 +28366,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_cpu_axi</description>
           <addressOffset>0x98</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28311,6 +28381,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_axicfg0_axi</description>
           <addressOffset>0x9c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28325,6 +28396,7 @@
           <description>clk_osc_div2</description>
           <addressOffset>0xa0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28339,6 +28411,7 @@
           <description>clk_pll1_div4</description>
           <addressOffset>0xa4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28353,6 +28426,7 @@
           <description>clk_pll1_div8</description>
           <addressOffset>0xa8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28367,6 +28441,7 @@
           <description>clk_ddr_bus</description>
           <addressOffset>0xac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -28381,6 +28456,7 @@
           <description>clk_u0_ddr_sfft7110_clk_axi</description>
           <addressOffset>0xb0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28395,6 +28471,7 @@
           <description>clk_gpu_core</description>
           <addressOffset>0xb4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28409,6 +28486,7 @@
           <description>clk_u0_img_gpu_core_clk</description>
           <addressOffset>0xb8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28423,6 +28501,7 @@
           <description>clk_u0_img_gpu_sys_clk</description>
           <addressOffset>0xbc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28437,6 +28516,7 @@
           <description>clk_u0_img_gpu_clk_apb</description>
           <addressOffset>0xc0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28451,6 +28531,7 @@
           <description>clk_u0_gpu_rtc_toggle</description>
           <addressOffset>0xc4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28471,6 +28552,7 @@
           <description>clk_u0_sft7110_noc_bus_clk_gpu_axi</description>
           <addressOffset>0xc8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28485,6 +28567,7 @@
           <description>clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x</description>
           <addressOffset>0xcc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28499,6 +28582,7 @@
           <description>clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi</description>
           <addressOffset>0xd0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28513,6 +28597,7 @@
           <description>clk_u0_sft7110_noc_bux_clk_isp_axi</description>
           <addressOffset>0xd4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28527,6 +28612,7 @@
           <description>clk_hifi4_core</description>
           <addressOffset>0xd8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28541,6 +28627,7 @@
           <description>clk_hifi4_axi</description>
           <addressOffset>0xdc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28555,6 +28642,7 @@
           <description>clk_u0_axi_cfg1_dec_clk_main</description>
           <addressOffset>0xe0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28569,6 +28657,7 @@
           <description>clk_u0_axi_cfg1_dec_clk_ahb</description>
           <addressOffset>0xe4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28583,6 +28672,7 @@
           <description>clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src</description>
           <addressOffset>0xe8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28597,6 +28687,7 @@
           <description>Clock Video Output AXI DIVCFG</description>
           <addressOffset>0xec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28611,6 +28702,7 @@
           <description>Clock NOC Display AXI</description>
           <addressOffset>0xf0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28625,6 +28717,7 @@
           <description>Clock Video Output AHB</description>
           <addressOffset>0xf4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28639,6 +28732,7 @@
           <description>Clock Video Output AXI ICG</description>
           <addressOffset>0xf8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28653,6 +28747,7 @@
           <description>Clock Video Output HDMI TX0 MCLK</description>
           <addressOffset>0xfc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28667,6 +28762,7 @@
           <description>Clock Video Output MIPI PHY Reference</description>
           <addressOffset>0x100</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28681,6 +28777,7 @@
           <description>Clock JPEG Codec AXI</description>
           <addressOffset>0x104</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28695,6 +28792,7 @@
           <description>CODAJ12 Clock AXI</description>
           <addressOffset>0x108</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28709,6 +28807,7 @@
           <description>CODAJ12 Clock Core</description>
           <addressOffset>0x10c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28729,6 +28828,7 @@
           <description>CODAJ12 Clock APB</description>
           <addressOffset>0x110</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28743,6 +28843,7 @@
           <description>Clock Video Decoder AXI</description>
           <addressOffset>0x114</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28757,6 +28858,7 @@
           <description>Clock WAVE511 AXI</description>
           <addressOffset>0x118</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28771,6 +28873,7 @@
           <description>Clock WAVE511 BPU</description>
           <addressOffset>0x11c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28791,6 +28894,7 @@
           <description>Clock WAVE511 VCE</description>
           <addressOffset>0x120</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28811,6 +28915,7 @@
           <description>Clock WAVE511 APB</description>
           <addressOffset>0x124</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28825,6 +28930,7 @@
           <description>Clock WAVE511 JPG ARB</description>
           <addressOffset>0x128</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28839,6 +28945,7 @@
           <description>Clock WAVE511 JPG Main</description>
           <addressOffset>0x12c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28853,6 +28960,7 @@
           <description>Clock NOC Video Decoder AXI</description>
           <addressOffset>0x130</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28867,6 +28975,7 @@
           <description>Clock Video Encoder AXI</description>
           <addressOffset>0x134</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -28881,6 +28990,7 @@
           <description>Clock WAVE420L AXI</description>
           <addressOffset>0x138</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28895,6 +29005,7 @@
           <description>Clock WAVE420L BPU</description>
           <addressOffset>0x13c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28915,6 +29026,7 @@
           <description>Clock WAVE420L VCE</description>
           <addressOffset>0x140</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28935,6 +29047,7 @@
           <description>Clock WAVE420L APB</description>
           <addressOffset>0x144</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28949,6 +29062,7 @@
           <description>Clock NOC Video Encoder AXI</description>
           <addressOffset>0x148</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28963,6 +29077,7 @@
           <description>Clock AXI Config 0 DEC Main Divider</description>
           <addressOffset>0x14c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28977,6 +29092,7 @@
           <description>Clock AXI Config 0 DEC Main</description>
           <addressOffset>0x150</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -28991,6 +29107,7 @@
           <description>Clock AXI Config 0 DEC HIFI4</description>
           <addressOffset>0x154</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29005,6 +29122,7 @@
           <description>Clock AXIMEM 128B AXI</description>
           <addressOffset>0x158</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29019,6 +29137,7 @@
           <description>Clock QSPI AHB</description>
           <addressOffset>0x15c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29033,6 +29152,7 @@
           <description>Clock QSPI APB</description>
           <addressOffset>0x160</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29047,6 +29167,7 @@
           <description>Clock QSPI Reference Source</description>
           <addressOffset>0x164</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29061,6 +29182,7 @@
           <description>Clock QSPI Reference</description>
           <addressOffset>0x168</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29081,6 +29203,7 @@
           <description>U0 SD Clock AHB</description>
           <addressOffset>0x16c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29095,6 +29218,7 @@
           <description>U1 SD Clock AHB</description>
           <addressOffset>0x170</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29109,6 +29233,7 @@
           <description>U0 SD Card Clock</description>
           <addressOffset>0x174</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29129,6 +29254,7 @@
           <description>U1 SD Card Clock</description>
           <addressOffset>0x178</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29149,6 +29275,7 @@
           <description>Clock USB 125M</description>
           <addressOffset>0x17c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29163,6 +29290,7 @@
           <description>Clock NOC STG AXI</description>
           <addressOffset>0x180</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29177,6 +29305,7 @@
           <description>Clock GMAC 5 AXI 64 AHB</description>
           <addressOffset>0x184</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29191,6 +29320,7 @@
           <description>Clock GMAC 5 AXI 64 AXI</description>
           <addressOffset>0x188</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29205,6 +29335,7 @@
           <description>Clock GMAC Source</description>
           <addressOffset>0x18c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29219,6 +29350,7 @@
           <description>Clock GMAC 1 GTX</description>
           <addressOffset>0x190</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29233,6 +29365,7 @@
           <description>Clock GMAC 1 RMII RTX</description>
           <addressOffset>0x194</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -29247,6 +29380,7 @@
           <description>Clock GMAC 5 AXI 64 PTP</description>
           <addressOffset>0x198</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29267,6 +29401,7 @@
           <description>Clock GMAC 5 AXI 64 RX</description>
           <addressOffset>0x19c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29281,6 +29416,7 @@
           <description>Clock GMAC 5 AXI 64 RX Inverter</description>
           <addressOffset>0x1a0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -29295,6 +29431,7 @@
           <description>Clock GMAC 5 AXI 64 TX</description>
           <addressOffset>0x1a4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29315,6 +29452,7 @@
           <description>Clock GMAC 5 AXI 64 TX Inverter</description>
           <addressOffset>0x1a8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -29329,6 +29467,7 @@
           <description>Clock GMAC 1 GTXC</description>
           <addressOffset>0x1ac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29343,6 +29482,7 @@
           <description>Clock GMAC 0 GTX</description>
           <addressOffset>0x1b0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29363,6 +29503,7 @@
           <description>Clock GMAC 0 PTP</description>
           <addressOffset>0x1b4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29383,6 +29524,7 @@
           <description>Clock GMAC PHY</description>
           <addressOffset>0x1b8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29403,6 +29545,7 @@
           <description>Clock GMAC 0 GTXC</description>
           <addressOffset>0x1bc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -29417,6 +29560,7 @@
           <description>Clock SYS IOMUX PCLK</description>
           <addressOffset>0x1c0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29431,6 +29575,7 @@
           <description>Clock Mailbox APB</description>
           <addressOffset>0x1c4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29445,6 +29590,7 @@
           <description>Clock Internal Controller APB</description>
           <addressOffset>0x1c8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29459,6 +29605,7 @@
           <description>U0 Clock CAN Controller APB</description>
           <addressOffset>0x1cc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29473,6 +29620,7 @@
           <description>U0 Clock CAN Controller Timer</description>
           <addressOffset>0x1d0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29493,6 +29641,7 @@
           <description>U0 Clock CAN Controller CAN</description>
           <addressOffset>0x1d4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29513,6 +29662,7 @@
           <description>U1 Clock CAN Controller APB</description>
           <addressOffset>0x1d8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29527,6 +29677,7 @@
           <description>U1 Clock CAN Controller Timer</description>
           <addressOffset>0x1dc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29547,6 +29698,7 @@
           <description>U1 Clock CAN Controller CAN</description>
           <addressOffset>0x1e0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29567,6 +29719,7 @@
           <description>Clock PWM APB</description>
           <addressOffset>0x1e4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29581,6 +29734,7 @@
           <description>Clock WDT APB</description>
           <addressOffset>0x1e8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29595,6 +29749,7 @@
           <description>Clock WDT</description>
           <addressOffset>0x1ec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29609,6 +29764,7 @@
           <description>Clock Timer APB</description>
           <addressOffset>0x1f0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29623,6 +29779,7 @@
           <description>Clock Timer 0</description>
           <addressOffset>0x1f4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29637,6 +29794,7 @@
           <description>Clock Timer 1</description>
           <addressOffset>0x1f8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29651,6 +29809,7 @@
           <description>Clock Timer 2</description>
           <addressOffset>0x1fc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29665,6 +29824,7 @@
           <description>Clock Timer 3</description>
           <addressOffset>0x200</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29679,6 +29839,7 @@
           <description>Clock Temperature Sensor APB</description>
           <addressOffset>0x204</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29693,6 +29854,7 @@
           <description>Clock Temperature Sensor</description>
           <addressOffset>0x208</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29713,6 +29875,7 @@
           <description>U0 Clock SPI APB</description>
           <addressOffset>0x20c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29727,6 +29890,7 @@
           <description>U1 Clock SPI APB</description>
           <addressOffset>0x210</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29741,6 +29905,7 @@
           <description>U2 Clock SPI APB</description>
           <addressOffset>0x214</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29755,6 +29920,7 @@
           <description>U3 Clock SPI APB</description>
           <addressOffset>0x218</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29769,6 +29935,7 @@
           <description>U4 Clock SPI APB</description>
           <addressOffset>0x21c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29783,6 +29950,7 @@
           <description>U5 Clock SPI APB</description>
           <addressOffset>0x220</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29797,6 +29965,7 @@
           <description>U6 Clock SPI APB</description>
           <addressOffset>0x224</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29811,6 +29980,7 @@
           <description>U0 Clock I2C APB</description>
           <addressOffset>0x228</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29825,6 +29995,7 @@
           <description>U1 Clock I2C APB</description>
           <addressOffset>0x22c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29839,6 +30010,7 @@
           <description>U2 Clock I2C APB</description>
           <addressOffset>0x230</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29853,6 +30025,7 @@
           <description>U3 Clock I2C APB</description>
           <addressOffset>0x234</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29867,6 +30040,7 @@
           <description>U4 Clock I2C APB</description>
           <addressOffset>0x238</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29881,6 +30055,7 @@
           <description>U5 Clock I2C APB</description>
           <addressOffset>0x23c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29895,6 +30070,7 @@
           <description>U6 Clock I2C APB</description>
           <addressOffset>0x240</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29909,6 +30085,7 @@
           <description>U0 Clock UART APB</description>
           <addressOffset>0x244</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29923,6 +30100,7 @@
           <description>U0 Clock UART Core</description>
           <addressOffset>0x248</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29937,6 +30115,7 @@
           <description>U1 Clock UART APB</description>
           <addressOffset>0x24c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29951,6 +30130,7 @@
           <description>U1 Clock UART Core</description>
           <addressOffset>0x250</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29965,6 +30145,7 @@
           <description>U2 Clock UART APB</description>
           <addressOffset>0x254</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29979,6 +30160,7 @@
           <description>U2 Clock UART Core</description>
           <addressOffset>0x258</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -29993,6 +30175,7 @@
           <description>U3 Clock UART APB</description>
           <addressOffset>0x25c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30007,6 +30190,7 @@
           <description>U3 Clock UART Core</description>
           <addressOffset>0x260</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30027,6 +30211,7 @@
           <description>U4 Clock UART APB</description>
           <addressOffset>0x264</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30041,6 +30226,7 @@
           <description>U4 Clock UART Core</description>
           <addressOffset>0x268</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30061,6 +30247,7 @@
           <description>U5 Clock UART APB</description>
           <addressOffset>0x26c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30075,6 +30262,7 @@
           <description>U5 Clock UART Core</description>
           <addressOffset>0x270</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30095,6 +30283,7 @@
           <description>Clock PWMDAC APB</description>
           <addressOffset>0x274</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30109,6 +30298,7 @@
           <description>Clock PWMDAC Core</description>
           <addressOffset>0x278</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30129,6 +30319,7 @@
           <description>Clock SPDIF APB</description>
           <addressOffset>0x27c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30143,6 +30334,7 @@
           <description>Clock SPDIF Core</description>
           <addressOffset>0x280</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30157,6 +30349,7 @@
           <description>U0 Clock I2S TX APB</description>
           <addressOffset>0x284</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30171,6 +30364,7 @@
           <description>U0 Clock I2S TX 0 BCLK MST</description>
           <addressOffset>0x288</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30191,6 +30385,7 @@
           <description>U0 Clock I2S TX 0 BCLK MST Inverter</description>
           <addressOffset>0x28c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30205,6 +30400,7 @@
           <description>Clock I2S TX 0 LRCK MST</description>
           <addressOffset>0x290</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30225,6 +30421,7 @@
           <description>U0 Clock I2S TX BCLK</description>
           <addressOffset>0x294</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30239,6 +30436,7 @@
           <description>U0 Clock I2S TX BCLK Negative</description>
           <addressOffset>0x298</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30253,6 +30451,7 @@
           <description>U0 Clock I2S TX LRCK</description>
           <addressOffset>0x29c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30267,6 +30466,7 @@
           <description>U1 Clock I2S TX APB</description>
           <addressOffset>0x2a0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30281,6 +30481,7 @@
           <description>U1 Clock I2S TX 1 BCLK MST</description>
           <addressOffset>0x2a4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30301,6 +30502,7 @@
           <description>U1 Clock I2S TX 1 BCLK MST Inverter</description>
           <addressOffset>0x2a8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30315,6 +30517,7 @@
           <description>Clock I2S TX 1 LRCK MST</description>
           <addressOffset>0x2ac</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30335,6 +30538,7 @@
           <description>U1 Clock I2S TX BCLK</description>
           <addressOffset>0x2b0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30349,6 +30553,7 @@
           <description>U1 Clock I2S TX BCLK Negative</description>
           <addressOffset>0x2b4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30363,6 +30568,7 @@
           <description>U1 Clock I2S TX LRCK</description>
           <addressOffset>0x2b8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30377,6 +30583,7 @@
           <description>Clock I2S APB</description>
           <addressOffset>0x2bc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30391,6 +30598,7 @@
           <description>Clock I2S BCLK MST</description>
           <addressOffset>0x2c0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30411,6 +30619,7 @@
           <description>Clock I2S BCLK MST Inverter</description>
           <addressOffset>0x2c4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30425,6 +30634,7 @@
           <description>Clock I2S LRCK MST</description>
           <addressOffset>0x2c8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30445,6 +30655,7 @@
           <description>Clock I2S BCLK</description>
           <addressOffset>0x2cc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30459,6 +30670,7 @@
           <description>Clock I2S BCLK Negative</description>
           <addressOffset>0x2d0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30473,6 +30685,7 @@
           <description>Clock I2S LRCK</description>
           <addressOffset>0x2d4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30487,6 +30700,7 @@
           <description>Clock PDM DMIC</description>
           <addressOffset>0x2d8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30507,6 +30721,7 @@
           <description>Clock PDM APB</description>
           <addressOffset>0x2dc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30521,6 +30736,7 @@
           <description>Clock TDM AHB</description>
           <addressOffset>0x2e0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30535,6 +30751,7 @@
           <description>Clock TDM APB</description>
           <addressOffset>0x2e4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30549,6 +30766,7 @@
           <description>Clock TDM Internal</description>
           <addressOffset>0x2e8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -30569,6 +30787,7 @@
           <description>Clock TDM</description>
           <addressOffset>0x2ec</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -30583,6 +30802,7 @@
           <description>Clock TDM Negative</description>
           <addressOffset>0x2f0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -30597,6 +30817,7 @@
           <description>Clock JTAG Certification TRNG</description>
           <addressOffset>0x2f4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -30611,6 +30832,7 @@
           <description>Software RESET 0 Address Selector</description>
           <addressOffset>0x2f8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_jtag2apb_presetn</name>
@@ -30811,6 +31033,7 @@
           <description>Software RESET 1 Address Selector</description>
           <addressOffset>0x2fc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
@@ -31011,6 +31234,7 @@
           <description>Software RESET 2 Address Selector</description>
           <addressOffset>0x300</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sdio_rstn_ahb</name>
@@ -31211,6 +31435,7 @@
           <description>Software RESET 3 Address Selector</description>
           <addressOffset>0x304</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_pwmdac_rstn_apb</name>
@@ -31399,6 +31624,7 @@
           <description>SYSCRG RESET Status 0</description>
           <addressOffset>0x308</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_jtag2apb_presetn</name>
@@ -31599,6 +31825,7 @@
           <description>SYSCRG RESET Status 1</description>
           <addressOffset>0x30c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
@@ -31799,6 +32026,7 @@
           <description>SYSCRG RESET Status 2</description>
           <addressOffset>0x310</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_sdio_rstn_ahb</name>
@@ -31999,6 +32227,7 @@
           <description>SYSCRG RESET Status 3</description>
           <addressOffset>0x314</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>rstn_u0_pwmdac_rstn_apb</name>
@@ -42187,6 +42416,7 @@
           <description>Oscillator Clock</description>
           <addressOffset>0x0</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42201,6 +42431,7 @@
           <description>AON APB Function Clock</description>
           <addressOffset>0x4</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42215,6 +42446,7 @@
           <description>AHB GMAC5 Clock</description>
           <addressOffset>0x8</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42229,6 +42461,7 @@
           <description>AXI GMAC5 Clock</description>
           <addressOffset>0xc</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42243,6 +42476,7 @@
           <description>GMAC0 RMII RTX Clock</description>
           <addressOffset>0x10</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42257,6 +42491,7 @@
           <description>GMAC5 AXI64 Clock Transmitter</description>
           <addressOffset>0x14</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42271,6 +42506,7 @@
           <description>GMAC5 AXI64 Clock Transmission Inverter</description>
           <addressOffset>0x18</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -42285,6 +42521,7 @@
           <description>GMAC5 AXI64 Clock Receiver</description>
           <addressOffset>0x1c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>dly_chain_sel</name>
@@ -42299,6 +42536,7 @@
           <description>GMAC5 AXI64 Clock Receiving Inverter</description>
           <addressOffset>0x20</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_polarity</name>
@@ -42313,6 +42551,7 @@
           <description>OPTC APB Clock</description>
           <addressOffset>0x24</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42327,6 +42566,7 @@
           <description>RTC HMS APB Clock</description>
           <addressOffset>0x28</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42341,6 +42581,7 @@
           <description>RTC Internal Clock</description>
           <addressOffset>0x2c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_divcfg</name>
@@ -42355,6 +42596,7 @@
           <description>RTC HMS Clock Oscillator 32K</description>
           <addressOffset>0x30</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_mux_sel</name>
@@ -42369,6 +42611,7 @@
           <description>RTC HMS Clock Calculator</description>
           <addressOffset>0x34</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>clk_icg</name>
@@ -42383,6 +42626,7 @@
           <description>Software RESET Address Selector</description>
           <addressOffset>0x38</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>gmac5_axi64_rstn_axi</name>
@@ -42439,6 +42683,7 @@
           <description>AONCRG RESET Status</description>
           <addressOffset>0x3c</addressOffset>
           <size>32</size>
+          <resetValue>0</resetValue>
           <fields>
             <field>
               <name>gmac5_axi64_rstn_axi</name>

--- a/jh7110-vf2-13b-pac/src/aoncrg.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg.rs
@@ -100,82 +100,82 @@ impl RegisterBlock {
         &self.aoncrg_rst_status
     }
 }
-#[doc = "clk_osc (rw) register accessor: Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc`]
+#[doc = "clk_osc (rw) register accessor: Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc`]
 module"]
 pub type CLK_OSC = crate::Reg<clk_osc::CLK_OSC_SPEC>;
 #[doc = "Oscillator Clock"]
 pub mod clk_osc;
-#[doc = "clk_aon_apb (rw) register accessor: AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aon_apb`]
+#[doc = "clk_aon_apb (rw) register accessor: AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aon_apb`]
 module"]
 pub type CLK_AON_APB = crate::Reg<clk_aon_apb::CLK_AON_APB_SPEC>;
 #[doc = "AON APB Function Clock"]
 pub mod clk_aon_apb;
-#[doc = "clk_ahb_gmac5 (rw) register accessor: AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb_gmac5`]
+#[doc = "clk_ahb_gmac5 (rw) register accessor: AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb_gmac5`]
 module"]
 pub type CLK_AHB_GMAC5 = crate::Reg<clk_ahb_gmac5::CLK_AHB_GMAC5_SPEC>;
 #[doc = "AHB GMAC5 Clock"]
 pub mod clk_ahb_gmac5;
-#[doc = "clk_axi_gmac5 (rw) register accessor: AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_gmac5`]
+#[doc = "clk_axi_gmac5 (rw) register accessor: AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_gmac5`]
 module"]
 pub type CLK_AXI_GMAC5 = crate::Reg<clk_axi_gmac5::CLK_AXI_GMAC5_SPEC>;
 #[doc = "AXI GMAC5 Clock"]
 pub mod clk_axi_gmac5;
-#[doc = "clk_gmac0_rmii_rtx (rw) register accessor: GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_rmii_rtx`]
+#[doc = "clk_gmac0_rmii_rtx (rw) register accessor: GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_rmii_rtx`]
 module"]
 pub type CLK_GMAC0_RMII_RTX = crate::Reg<clk_gmac0_rmii_rtx::CLK_GMAC0_RMII_RTX_SPEC>;
 #[doc = "GMAC0 RMII RTX Clock"]
 pub mod clk_gmac0_rmii_rtx;
-#[doc = "clk_gmac5_axi64_tx (rw) register accessor: GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
+#[doc = "clk_gmac5_axi64_tx (rw) register accessor: GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
 module"]
 pub type CLK_GMAC5_AXI64_TX = crate::Reg<clk_gmac5_axi64_tx::CLK_GMAC5_AXI64_TX_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Transmitter"]
 pub mod clk_gmac5_axi64_tx;
-#[doc = "clk_gmac5_axi64_txi (rw) register accessor: GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
+#[doc = "clk_gmac5_axi64_txi (rw) register accessor: GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
 module"]
 pub type CLK_GMAC5_AXI64_TXI = crate::Reg<clk_gmac5_axi64_txi::CLK_GMAC5_AXI64_TXI_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Transmission Inverter"]
 pub mod clk_gmac5_axi64_txi;
-#[doc = "clk_gmac5_axi64_rx (rw) register accessor: GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
+#[doc = "clk_gmac5_axi64_rx (rw) register accessor: GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
 module"]
 pub type CLK_GMAC5_AXI64_RX = crate::Reg<clk_gmac5_axi64_rx::CLK_GMAC5_AXI64_RX_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Receiver"]
 pub mod clk_gmac5_axi64_rx;
-#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
+#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
 module"]
 pub type CLK_GMAC5_AXI64_RXI = crate::Reg<clk_gmac5_axi64_rxi::CLK_GMAC5_AXI64_RXI_SPEC>;
 #[doc = "GMAC5 AXI64 Clock Receiving Inverter"]
 pub mod clk_gmac5_axi64_rxi;
-#[doc = "clk_optc_apb (rw) register accessor: OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_optc_apb`]
+#[doc = "clk_optc_apb (rw) register accessor: OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_optc_apb`]
 module"]
 pub type CLK_OPTC_APB = crate::Reg<clk_optc_apb::CLK_OPTC_APB_SPEC>;
 #[doc = "OPTC APB Clock"]
 pub mod clk_optc_apb;
-#[doc = "clk_rtc_hms_apb (rw) register accessor: RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_apb`]
+#[doc = "clk_rtc_hms_apb (rw) register accessor: RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_apb`]
 module"]
 pub type CLK_RTC_HMS_APB = crate::Reg<clk_rtc_hms_apb::CLK_RTC_HMS_APB_SPEC>;
 #[doc = "RTC HMS APB Clock"]
 pub mod clk_rtc_hms_apb;
-#[doc = "clk_rtc_internal (rw) register accessor: RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_internal`]
+#[doc = "clk_rtc_internal (rw) register accessor: RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_internal`]
 module"]
 pub type CLK_RTC_INTERNAL = crate::Reg<clk_rtc_internal::CLK_RTC_INTERNAL_SPEC>;
 #[doc = "RTC Internal Clock"]
 pub mod clk_rtc_internal;
-#[doc = "clk_rtc_hms_osc32k (rw) register accessor: RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_osc32k`]
+#[doc = "clk_rtc_hms_osc32k (rw) register accessor: RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_osc32k`]
 module"]
 pub type CLK_RTC_HMS_OSC32K = crate::Reg<clk_rtc_hms_osc32k::CLK_RTC_HMS_OSC32K_SPEC>;
 #[doc = "RTC HMS Clock Oscillator 32K"]
 pub mod clk_rtc_hms_osc32k;
-#[doc = "clk_rtc_hms_cal (rw) register accessor: RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_cal`]
+#[doc = "clk_rtc_hms_cal (rw) register accessor: RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_rtc_hms_cal`]
 module"]
 pub type CLK_RTC_HMS_CAL = crate::Reg<clk_rtc_hms_cal::CLK_RTC_HMS_CAL_SPEC>;
 #[doc = "RTC HMS Clock Calculator"]
 pub mod clk_rtc_hms_cal;
-#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
+#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
 module"]
 pub type SOFT_RST_ADDR_SEL = crate::Reg<soft_rst_addr_sel::SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Software RESET Address Selector"]
 pub mod soft_rst_addr_sel;
-#[doc = "aoncrg_rst_status (rw) register accessor: AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@aoncrg_rst_status`]
+#[doc = "aoncrg_rst_status (rw) register accessor: AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@aoncrg_rst_status`]
 module"]
 pub type AONCRG_RST_STATUS = crate::Reg<aoncrg_rst_status::AONCRG_RST_STATUS_SPEC>;
 #[doc = "AONCRG RESET Status"]

--- a/jh7110-vf2-13b-pac/src/aoncrg/aoncrg_rst_status.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/aoncrg_rst_status.rs
@@ -136,7 +136,7 @@ impl W {
         self
     }
 }
-#[doc = "AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AONCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`aoncrg_rst_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`aoncrg_rst_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct AONCRG_RST_STATUS_SPEC;
 impl crate::RegisterSpec for AONCRG_RST_STATUS_SPEC {
     type Ux = u32;
@@ -147,4 +147,8 @@ impl crate::Readable for AONCRG_RST_STATUS_SPEC {}
 impl crate::Writable for AONCRG_RST_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets aoncrg_rst_status to value 0"]
+impl crate::Resettable for AONCRG_RST_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_ahb_gmac5.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_ahb_gmac5.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AHB GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb_gmac5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB_GMAC5_SPEC;
 impl crate::RegisterSpec for CLK_AHB_GMAC5_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB_GMAC5_SPEC {}
 impl crate::Writable for CLK_AHB_GMAC5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb_gmac5 to value 0"]
+impl crate::Resettable for CLK_AHB_GMAC5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_aon_apb.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_aon_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AON APB Function Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aon_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aon_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AON_APB_SPEC;
 impl crate::RegisterSpec for CLK_AON_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AON_APB_SPEC {}
 impl crate::Writable for CLK_AON_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_aon_apb to value 0"]
+impl crate::Resettable for CLK_AON_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_axi_gmac5.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_axi_gmac5.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "AXI GMAC5 Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_gmac5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_gmac5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_GMAC5_SPEC;
 impl crate::RegisterSpec for CLK_AXI_GMAC5_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_GMAC5_SPEC {}
 impl crate::Writable for CLK_AXI_GMAC5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_gmac5 to value 0"]
+impl crate::Resettable for CLK_AXI_GMAC5_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac0_rmii_rtx.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac0_rmii_rtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC0 RMII RTX Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_rmii_rtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_RMII_RTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_RMII_RTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC0_RMII_RTX_SPEC {}
 impl crate::Writable for CLK_GMAC0_RMII_RTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_rmii_rtx to value 0"]
+impl crate::Resettable for CLK_GMAC0_RMII_RTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_rx.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_rx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Receiver\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_rxi.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_rxi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Receiving Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rxi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_tx.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_tx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Transmitter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_tx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_txi.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_gmac5_axi64_txi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "GMAC5 AXI64 Clock Transmission Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_txi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_optc_apb.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_optc_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "OPTC APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_optc_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_optc_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OPTC_APB_SPEC;
 impl crate::RegisterSpec for CLK_OPTC_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OPTC_APB_SPEC {}
 impl crate::Writable for CLK_OPTC_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_optc_apb to value 0"]
+impl crate::Resettable for CLK_OPTC_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_osc.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_osc.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Oscillator Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OSC_SPEC;
 impl crate::RegisterSpec for CLK_OSC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OSC_SPEC {}
 impl crate::Writable for CLK_OSC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_osc to value 0"]
+impl crate::Resettable for CLK_OSC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_apb.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS APB Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_APB_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_APB_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_apb to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_cal.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_cal.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS Clock Calculator\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_cal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_cal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_CAL_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_CAL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_CAL_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_CAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_cal to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_CAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_osc32k.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_hms_osc32k.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC HMS Clock Oscillator 32K\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_hms_osc32k::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_hms_osc32k::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_HMS_OSC32K_SPEC;
 impl crate::RegisterSpec for CLK_RTC_HMS_OSC32K_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_HMS_OSC32K_SPEC {}
 impl crate::Writable for CLK_RTC_HMS_OSC32K_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_hms_osc32k to value 0"]
+impl crate::Resettable for CLK_RTC_HMS_OSC32K_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_internal.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/clk_rtc_internal.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "RTC Internal Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_rtc_internal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_rtc_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_RTC_INTERNAL_SPEC;
 impl crate::RegisterSpec for CLK_RTC_INTERNAL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_RTC_INTERNAL_SPEC {}
 impl crate::Writable for CLK_RTC_INTERNAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_rtc_internal to value 0"]
+impl crate::Resettable for CLK_RTC_INTERNAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/aoncrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/soft_rst_addr_sel.rs
@@ -136,7 +136,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -147,4 +147,8 @@ impl crate::Readable for SOFT_RST_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg.rs
@@ -190,165 +190,165 @@ impl RegisterBlock {
         &self.stgcrg_rst_stat
     }
 }
-#[doc = "clk_hifi4_core (rw) register accessor: Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
+#[doc = "clk_hifi4_core (rw) register accessor: Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
 module"]
 pub type CLK_HIFI4_CORE = crate::Reg<clk_hifi4_core::CLK_HIFI4_CORE_SPEC>;
 #[doc = "Clock HIFI4 Core"]
 pub mod clk_hifi4_core;
-#[doc = "clk_usb_apb (rw) register accessor: Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_apb`]
+#[doc = "clk_usb_apb (rw) register accessor: Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_apb`]
 module"]
 pub type CLK_USB_APB = crate::Reg<clk_usb_apb::CLK_USB_APB_SPEC>;
 #[doc = "Clock USB APB"]
 pub mod clk_usb_apb;
-#[doc = "clk_usb_utmi_apb (rw) register accessor: Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_utmi_apb`]
+#[doc = "clk_usb_utmi_apb (rw) register accessor: Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_utmi_apb`]
 module"]
 pub type CLK_USB_UTMI_APB = crate::Reg<clk_usb_utmi_apb::CLK_USB_UTMI_APB_SPEC>;
 #[doc = "Clock USB UTMI APB"]
 pub mod clk_usb_utmi_apb;
-#[doc = "clk_usb_axi (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_axi`]
+#[doc = "clk_usb_axi (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_axi`]
 module"]
 pub type CLK_USB_AXI = crate::Reg<clk_usb_axi::CLK_USB_AXI_SPEC>;
 #[doc = "Clock USB AXI"]
 pub mod clk_usb_axi;
-#[doc = "clk_usb_ipm (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_ipm`]
+#[doc = "clk_usb_ipm (rw) register accessor: Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_ipm`]
 module"]
 pub type CLK_USB_IPM = crate::Reg<clk_usb_ipm::CLK_USB_IPM_SPEC>;
 #[doc = "Clock USB AXI"]
 pub mod clk_usb_ipm;
-#[doc = "clk_usb_stb (rw) register accessor: Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_stb`]
+#[doc = "clk_usb_stb (rw) register accessor: Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_stb`]
 module"]
 pub type CLK_USB_STB = crate::Reg<clk_usb_stb::CLK_USB_STB_SPEC>;
 #[doc = "Clock USB STB"]
 pub mod clk_usb_stb;
-#[doc = "clk_usb_app125 (rw) register accessor: Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_app125`]
+#[doc = "clk_usb_app125 (rw) register accessor: Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_app125`]
 module"]
 pub type CLK_USB_APP125 = crate::Reg<clk_usb_app125::CLK_USB_APP125_SPEC>;
 #[doc = "Clock USB APP 125"]
 pub mod clk_usb_app125;
-#[doc = "clk_usb_refclk (rw) register accessor: Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_refclk`]
+#[doc = "clk_usb_refclk (rw) register accessor: Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_refclk`]
 module"]
 pub type CLK_USB_REFCLK = crate::Reg<clk_usb_refclk::CLK_USB_REFCLK_SPEC>;
 #[doc = "Clock USB Reference Clock"]
 pub mod clk_usb_refclk;
-#[doc = "clk_u0_pcie_axi_mst0 (rw) register accessor: U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_axi_mst0`]
+#[doc = "clk_u0_pcie_axi_mst0 (rw) register accessor: U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_axi_mst0`]
 module"]
 pub type CLK_U0_PCIE_AXI_MST0 = crate::Reg<clk_u0_pcie_axi_mst0::CLK_U0_PCIE_AXI_MST0_SPEC>;
 #[doc = "U0 Clock PCIe AXI MST 0"]
 pub mod clk_u0_pcie_axi_mst0;
-#[doc = "clk_u0_pcie_apb (rw) register accessor: U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_apb`]
+#[doc = "clk_u0_pcie_apb (rw) register accessor: U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_apb`]
 module"]
 pub type CLK_U0_PCIE_APB = crate::Reg<clk_u0_pcie_apb::CLK_U0_PCIE_APB_SPEC>;
 #[doc = "U0 Clock PCIe APB"]
 pub mod clk_u0_pcie_apb;
-#[doc = "clk_u0_pcie_tl (rw) register accessor: U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_tl`]
+#[doc = "clk_u0_pcie_tl (rw) register accessor: U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_pcie_tl`]
 module"]
 pub type CLK_U0_PCIE_TL = crate::Reg<clk_u0_pcie_tl::CLK_U0_PCIE_TL_SPEC>;
 #[doc = "U0 Clock PCIe TL"]
 pub mod clk_u0_pcie_tl;
-#[doc = "clk_u1_pcie_axi_mst0 (rw) register accessor: U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_axi_mst0`]
+#[doc = "clk_u1_pcie_axi_mst0 (rw) register accessor: U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_axi_mst0`]
 module"]
 pub type CLK_U1_PCIE_AXI_MST0 = crate::Reg<clk_u1_pcie_axi_mst0::CLK_U1_PCIE_AXI_MST0_SPEC>;
 #[doc = "U1 Clock PCIe AXI MST 0"]
 pub mod clk_u1_pcie_axi_mst0;
-#[doc = "clk_u1_pcie_apb (rw) register accessor: U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_apb`]
+#[doc = "clk_u1_pcie_apb (rw) register accessor: U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_apb`]
 module"]
 pub type CLK_U1_PCIE_APB = crate::Reg<clk_u1_pcie_apb::CLK_U1_PCIE_APB_SPEC>;
 #[doc = "U1 Clock PCIe APB"]
 pub mod clk_u1_pcie_apb;
-#[doc = "clk_u1_pcie_tl (rw) register accessor: U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_tl`]
+#[doc = "clk_u1_pcie_tl (rw) register accessor: U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_pcie_tl`]
 module"]
 pub type CLK_U1_PCIE_TL = crate::Reg<clk_u1_pcie_tl::CLK_U1_PCIE_TL_SPEC>;
 #[doc = "U1 Clock PCIe TL"]
 pub mod clk_u1_pcie_tl;
-#[doc = "clk_pcie01_slv_dec_main (rw) register accessor: Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pcie01_slv_dec_main`]
+#[doc = "clk_pcie01_slv_dec_main (rw) register accessor: Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pcie01_slv_dec_main`]
 module"]
 pub type CLK_PCIE01_SLV_DEC_MAIN =
     crate::Reg<clk_pcie01_slv_dec_main::CLK_PCIE01_SLV_DEC_MAIN_SPEC>;
 #[doc = "Clock PCIe 01 SLV DEC Main"]
 pub mod clk_pcie01_slv_dec_main;
-#[doc = "clk_sec_hclk (rw) register accessor: Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_hclk`]
+#[doc = "clk_sec_hclk (rw) register accessor: Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_hclk`]
 module"]
 pub type CLK_SEC_HCLK = crate::Reg<clk_sec_hclk::CLK_SEC_HCLK_SPEC>;
 #[doc = "Clock Security HCLK"]
 pub mod clk_sec_hclk;
-#[doc = "clk_sec_misc_ahb (rw) register accessor: Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_misc_ahb`]
+#[doc = "clk_sec_misc_ahb (rw) register accessor: Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sec_misc_ahb`]
 module"]
 pub type CLK_SEC_MISC_AHB = crate::Reg<clk_sec_misc_ahb::CLK_SEC_MISC_AHB_SPEC>;
 #[doc = "Clock Security Miscellaneous AHB"]
 pub mod clk_sec_misc_ahb;
-#[doc = "clk_stg_mtrx_group0_main (rw) register accessor: Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_main`]
+#[doc = "clk_stg_mtrx_group0_main (rw) register accessor: Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_main`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_MAIN =
     crate::Reg<clk_stg_mtrx_group0_main::CLK_STG_MTRX_GROUP0_MAIN_SPEC>;
 #[doc = "Clock STG MTRX Group 0 Main"]
 pub mod clk_stg_mtrx_group0_main;
-#[doc = "clk_stg_mtrx_group0_bus (rw) register accessor: Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_bus`]
+#[doc = "clk_stg_mtrx_group0_bus (rw) register accessor: Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_bus`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_BUS =
     crate::Reg<clk_stg_mtrx_group0_bus::CLK_STG_MTRX_GROUP0_BUS_SPEC>;
 #[doc = "Clock STG MTRX Group 0 Bus"]
 pub mod clk_stg_mtrx_group0_bus;
-#[doc = "clk_stg_mtrx_group0_stg (rw) register accessor: Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_stg`]
+#[doc = "clk_stg_mtrx_group0_stg (rw) register accessor: Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group0_stg`]
 module"]
 pub type CLK_STG_MTRX_GROUP0_STG =
     crate::Reg<clk_stg_mtrx_group0_stg::CLK_STG_MTRX_GROUP0_STG_SPEC>;
 #[doc = "Clock STG MTRX Group 0 STG"]
 pub mod clk_stg_mtrx_group0_stg;
-#[doc = "clk_stg_mtrx_group1_main (rw) register accessor: Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_main`]
+#[doc = "clk_stg_mtrx_group1_main (rw) register accessor: Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_main`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_MAIN =
     crate::Reg<clk_stg_mtrx_group1_main::CLK_STG_MTRX_GROUP1_MAIN_SPEC>;
 #[doc = "Clock STG MTRX Group 1 Main"]
 pub mod clk_stg_mtrx_group1_main;
-#[doc = "clk_stg_mtrx_group1_bus (rw) register accessor: Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_bus`]
+#[doc = "clk_stg_mtrx_group1_bus (rw) register accessor: Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_bus`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_BUS =
     crate::Reg<clk_stg_mtrx_group1_bus::CLK_STG_MTRX_GROUP1_BUS_SPEC>;
 #[doc = "Clock STG MTRX Group 1 Bus"]
 pub mod clk_stg_mtrx_group1_bus;
-#[doc = "clk_stg_mtrx_group1_stg (rw) register accessor: Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_stg`]
+#[doc = "clk_stg_mtrx_group1_stg (rw) register accessor: Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_stg`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_STG =
     crate::Reg<clk_stg_mtrx_group1_stg::CLK_STG_MTRX_GROUP1_STG_SPEC>;
 #[doc = "Clock STG MTRX Group 1 STG"]
 pub mod clk_stg_mtrx_group1_stg;
-#[doc = "clk_stg_mtrx_group1_hifi (rw) register accessor: Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_hifi`]
+#[doc = "clk_stg_mtrx_group1_hifi (rw) register accessor: Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_mtrx_group1_hifi`]
 module"]
 pub type CLK_STG_MTRX_GROUP1_HIFI =
     crate::Reg<clk_stg_mtrx_group1_hifi::CLK_STG_MTRX_GROUP1_HIFI_SPEC>;
 #[doc = "Clock STG MTRX Group 1 HIFI"]
 pub mod clk_stg_mtrx_group1_hifi;
-#[doc = "clk_e2_rtc (rw) register accessor: Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_rtc`]
+#[doc = "clk_e2_rtc (rw) register accessor: Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_rtc`]
 module"]
 pub type CLK_E2_RTC = crate::Reg<clk_e2_rtc::CLK_E2_RTC_SPEC>;
 #[doc = "Clock E2 RTC"]
 pub mod clk_e2_rtc;
-#[doc = "clk_e2_core (rw) register accessor: Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_core`]
+#[doc = "clk_e2_core (rw) register accessor: Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_core`]
 module"]
 pub type CLK_E2_CORE = crate::Reg<clk_e2_core::CLK_E2_CORE_SPEC>;
 #[doc = "Clock E2 Core"]
 pub mod clk_e2_core;
-#[doc = "clk_e2_dbg (rw) register accessor: Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_dbg`]
+#[doc = "clk_e2_dbg (rw) register accessor: Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_e2_dbg`]
 module"]
 pub type CLK_E2_DBG = crate::Reg<clk_e2_dbg::CLK_E2_DBG_SPEC>;
 #[doc = "Clock E2 DBG"]
 pub mod clk_e2_dbg;
-#[doc = "clk_dma_axi (rw) register accessor: Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_axi`]
+#[doc = "clk_dma_axi (rw) register accessor: Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_axi`]
 module"]
 pub type CLK_DMA_AXI = crate::Reg<clk_dma_axi::CLK_DMA_AXI_SPEC>;
 #[doc = "Clock DMA AXI"]
 pub mod clk_dma_axi;
-#[doc = "clk_dma_ahb (rw) register accessor: Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_ahb`]
+#[doc = "clk_dma_ahb (rw) register accessor: Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_dma_ahb`]
 module"]
 pub type CLK_DMA_AHB = crate::Reg<clk_dma_ahb::CLK_DMA_AHB_SPEC>;
 #[doc = "Clock DMA AHB"]
 pub mod clk_dma_ahb;
-#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
+#[doc = "soft_rst_addr_sel (rw) register accessor: Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst_addr_sel`]
 module"]
 pub type SOFT_RST_ADDR_SEL = crate::Reg<soft_rst_addr_sel::SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Software RESET Address Selector"]
 pub mod soft_rst_addr_sel;
-#[doc = "stgcrg_rst_stat (rw) register accessor: STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stgcrg_rst_stat`]
+#[doc = "stgcrg_rst_stat (rw) register accessor: STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@stgcrg_rst_stat`]
 module"]
 pub type STGCRG_RST_STAT = crate::Reg<stgcrg_rst_stat::STGCRG_RST_STAT_SPEC>;
 #[doc = "STGCRG RESET Status"]

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_dma_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_dma_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock DMA AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DMA_AHB_SPEC;
 impl crate::RegisterSpec for CLK_DMA_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DMA_AHB_SPEC {}
 impl crate::Writable for CLK_DMA_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_dma_ahb to value 0"]
+impl crate::Resettable for CLK_DMA_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_dma_axi.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_dma_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock DMA AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_dma_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_dma_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DMA_AXI_SPEC;
 impl crate::RegisterSpec for CLK_DMA_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DMA_AXI_SPEC {}
 impl crate::Writable for CLK_DMA_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_dma_axi to value 0"]
+impl crate::Resettable for CLK_DMA_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_core.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_CORE_SPEC;
 impl crate::RegisterSpec for CLK_E2_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_E2_CORE_SPEC {}
 impl crate::Writable for CLK_E2_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_core to value 0"]
+impl crate::Resettable for CLK_E2_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_dbg.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_dbg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 DBG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_dbg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_dbg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_DBG_SPEC;
 impl crate::RegisterSpec for CLK_E2_DBG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_E2_DBG_SPEC {}
 impl crate::Writable for CLK_E2_DBG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_dbg to value 0"]
+impl crate::Resettable for CLK_E2_DBG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_rtc.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_e2_rtc.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock E2 RTC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_e2_rtc::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_e2_rtc::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_E2_RTC_SPEC;
 impl crate::RegisterSpec for CLK_E2_RTC_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_E2_RTC_SPEC {}
 impl crate::Writable for CLK_E2_RTC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_e2_rtc to value 0"]
+impl crate::Resettable for CLK_E2_RTC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_hifi4_core.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_hifi4_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock HIFI4 Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_CORE_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_CORE_SPEC {}
 impl crate::Writable for CLK_HIFI4_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_core to value 0"]
+impl crate::Resettable for CLK_HIFI4_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_pcie01_slv_dec_main.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_pcie01_slv_dec_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PCIe 01 SLV DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pcie01_slv_dec_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pcie01_slv_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PCIE01_SLV_DEC_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {}
 impl crate::Writable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pcie01_slv_dec_main to value 0"]
+impl crate::Resettable for CLK_PCIE01_SLV_DEC_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_sec_hclk.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_sec_hclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Security HCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_hclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_hclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SEC_HCLK_SPEC;
 impl crate::RegisterSpec for CLK_SEC_HCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SEC_HCLK_SPEC {}
 impl crate::Writable for CLK_SEC_HCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sec_hclk to value 0"]
+impl crate::Resettable for CLK_SEC_HCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_sec_misc_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_sec_misc_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Security Miscellaneous AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sec_misc_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sec_misc_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SEC_MISC_AHB_SPEC;
 impl crate::RegisterSpec for CLK_SEC_MISC_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SEC_MISC_AHB_SPEC {}
 impl crate::Writable for CLK_SEC_MISC_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sec_misc_ahb to value 0"]
+impl crate::Resettable for CLK_SEC_MISC_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_bus.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_BUS_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_BUS_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_bus to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_main.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_main to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_stg.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group0_stg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 0 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group0_stg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group0_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP0_STG_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP0_STG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP0_STG_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP0_STG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group0_stg to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP0_STG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_bus.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_BUS_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_BUS_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_bus to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_hifi.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_hifi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 HIFI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_hifi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_hifi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_HIFI_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_hifi to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_HIFI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_main.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_main to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_stg.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_stg_mtrx_group1_stg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG MTRX Group 1 STG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_mtrx_group1_stg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_mtrx_group1_stg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_MTRX_GROUP1_STG_SPEC;
 impl crate::RegisterSpec for CLK_STG_MTRX_GROUP1_STG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_MTRX_GROUP1_STG_SPEC {}
 impl crate::Writable for CLK_STG_MTRX_GROUP1_STG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_mtrx_group1_stg to value 0"]
+impl crate::Resettable for CLK_STG_MTRX_GROUP1_STG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_apb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_APB_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_apb to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_axi_mst0.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_axi_mst0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_axi_mst0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_AXI_MST0_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_AXI_MST0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_AXI_MST0_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_AXI_MST0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_axi_mst0 to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_AXI_MST0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_tl.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u0_pcie_tl.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_pcie_tl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_PCIE_TL_SPEC;
 impl crate::RegisterSpec for CLK_U0_PCIE_TL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_PCIE_TL_SPEC {}
 impl crate::Writable for CLK_U0_PCIE_TL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_pcie_tl to value 0"]
+impl crate::Resettable for CLK_U0_PCIE_TL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_apb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_APB_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_apb to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_axi_mst0.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_axi_mst0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe AXI MST 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_axi_mst0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_axi_mst0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_AXI_MST0_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_AXI_MST0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_AXI_MST0_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_AXI_MST0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_axi_mst0 to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_AXI_MST0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_tl.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_u1_pcie_tl.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock PCIe TL\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_pcie_tl::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_pcie_tl::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_PCIE_TL_SPEC;
 impl crate::RegisterSpec for CLK_U1_PCIE_TL_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_PCIE_TL_SPEC {}
 impl crate::Writable for CLK_U1_PCIE_TL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_pcie_tl to value 0"]
+impl crate::Resettable for CLK_U1_PCIE_TL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_apb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_APB_SPEC;
 impl crate::RegisterSpec for CLK_USB_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_APB_SPEC {}
 impl crate::Writable for CLK_USB_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_apb to value 0"]
+impl crate::Resettable for CLK_USB_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_app125.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_app125.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB APP 125\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_app125::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_app125::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_APP125_SPEC;
 impl crate::RegisterSpec for CLK_USB_APP125_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_APP125_SPEC {}
 impl crate::Writable for CLK_USB_APP125_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_app125 to value 0"]
+impl crate::Resettable for CLK_USB_APP125_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_axi.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_AXI_SPEC;
 impl crate::RegisterSpec for CLK_USB_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_AXI_SPEC {}
 impl crate::Writable for CLK_USB_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_axi to value 0"]
+impl crate::Resettable for CLK_USB_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_ipm.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_ipm.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_ipm::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_ipm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_IPM_SPEC;
 impl crate::RegisterSpec for CLK_USB_IPM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_USB_IPM_SPEC {}
 impl crate::Writable for CLK_USB_IPM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_ipm to value 0"]
+impl crate::Resettable for CLK_USB_IPM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_refclk.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_refclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB Reference Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_refclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_refclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_REFCLK_SPEC;
 impl crate::RegisterSpec for CLK_USB_REFCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_REFCLK_SPEC {}
 impl crate::Writable for CLK_USB_REFCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_refclk to value 0"]
+impl crate::Resettable for CLK_USB_REFCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_stb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_stb.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB STB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_stb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_stb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_STB_SPEC;
 impl crate::RegisterSpec for CLK_USB_STB_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_USB_STB_SPEC {}
 impl crate::Writable for CLK_USB_STB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_stb to value 0"]
+impl crate::Resettable for CLK_USB_STB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_utmi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/clk_usb_utmi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB UTMI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_utmi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_utmi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_UTMI_APB_SPEC;
 impl crate::RegisterSpec for CLK_USB_UTMI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_UTMI_APB_SPEC {}
 impl crate::Writable for CLK_USB_UTMI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_utmi_apb to value 0"]
+impl crate::Resettable for CLK_USB_UTMI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/soft_rst_addr_sel.rs
@@ -403,7 +403,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -414,4 +414,8 @@ impl crate::Readable for SOFT_RST_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/stgcrg/stgcrg_rst_stat.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/stgcrg_rst_stat.rs
@@ -399,7 +399,7 @@ impl W {
         self
     }
 }
-#[doc = "STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "STGCRG RESET Status\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`stgcrg_rst_stat::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`stgcrg_rst_stat::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct STGCRG_RST_STAT_SPEC;
 impl crate::RegisterSpec for STGCRG_RST_STAT_SPEC {
     type Ux = u32;
@@ -410,4 +410,8 @@ impl crate::Readable for STGCRG_RST_STAT_SPEC {}
 impl crate::Writable for STGCRG_RST_STAT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets stgcrg_rst_stat to value 0"]
+impl crate::Resettable for STGCRG_RST_STAT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg.rs
@@ -1202,1005 +1202,1005 @@ impl RegisterBlock {
         &self.syscrg_rst3_status
     }
 }
-#[doc = "clk_cpu_root (rw) register accessor: Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_root`]
+#[doc = "clk_cpu_root (rw) register accessor: Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_root`]
 module"]
 pub type CLK_CPU_ROOT = crate::Reg<clk_cpu_root::CLK_CPU_ROOT_SPEC>;
 #[doc = "Clock CPU Root"]
 pub mod clk_cpu_root;
-#[doc = "clk_cpu_core (rw) register accessor: Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_core`]
+#[doc = "clk_cpu_core (rw) register accessor: Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_core`]
 module"]
 pub type CLK_CPU_CORE = crate::Reg<clk_cpu_core::CLK_CPU_CORE_SPEC>;
 #[doc = "Clock CPU Core"]
 pub mod clk_cpu_core;
-#[doc = "clk_cpu_bus (rw) register accessor: Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_bus`]
+#[doc = "clk_cpu_bus (rw) register accessor: Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_cpu_bus`]
 module"]
 pub type CLK_CPU_BUS = crate::Reg<clk_cpu_bus::CLK_CPU_BUS_SPEC>;
 #[doc = "Clock CPU Bus"]
 pub mod clk_cpu_bus;
-#[doc = "clk_gpu_root (rw) register accessor: Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_root`]
+#[doc = "clk_gpu_root (rw) register accessor: Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_root`]
 module"]
 pub type CLK_GPU_ROOT = crate::Reg<clk_gpu_root::CLK_GPU_ROOT_SPEC>;
 #[doc = "Clock GPU Root"]
 pub mod clk_gpu_root;
-#[doc = "clk_peripheral_root (rw) register accessor: Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_peripheral_root`]
+#[doc = "clk_peripheral_root (rw) register accessor: Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_peripheral_root`]
 module"]
 pub type CLK_PERIPHERAL_ROOT = crate::Reg<clk_peripheral_root::CLK_PERIPHERAL_ROOT_SPEC>;
 #[doc = "Clock Peripheral Root"]
 pub mod clk_peripheral_root;
-#[doc = "clk_bus_root (rw) register accessor: Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_bus_root`]
+#[doc = "clk_bus_root (rw) register accessor: Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_bus_root`]
 module"]
 pub type CLK_BUS_ROOT = crate::Reg<clk_bus_root::CLK_BUS_ROOT_SPEC>;
 #[doc = "Clock Bus Root"]
 pub mod clk_bus_root;
-#[doc = "clk_nocstg_bus (rw) register accessor: Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_nocstg_bus`]
+#[doc = "clk_nocstg_bus (rw) register accessor: Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_nocstg_bus`]
 module"]
 pub type CLK_NOCSTG_BUS = crate::Reg<clk_nocstg_bus::CLK_NOCSTG_BUS_SPEC>;
 #[doc = "Clock NOCSTG Bus"]
 pub mod clk_nocstg_bus;
-#[doc = "clk_axi_cfg0 (rw) register accessor: Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0`]
+#[doc = "clk_axi_cfg0 (rw) register accessor: Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0`]
 module"]
 pub type CLK_AXI_CFG0 = crate::Reg<clk_axi_cfg0::CLK_AXI_CFG0_SPEC>;
 #[doc = "Clock AXI Configuration 0"]
 pub mod clk_axi_cfg0;
-#[doc = "clk_stg_axiahb (rw) register accessor: Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_axiahb`]
+#[doc = "clk_stg_axiahb (rw) register accessor: Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_stg_axiahb`]
 module"]
 pub type CLK_STG_AXIAHB = crate::Reg<clk_stg_axiahb::CLK_STG_AXIAHB_SPEC>;
 #[doc = "Clock STG AXI AHB"]
 pub mod clk_stg_axiahb;
-#[doc = "clk_ahb0 (rw) register accessor: Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb0`]
+#[doc = "clk_ahb0 (rw) register accessor: Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb0`]
 module"]
 pub type CLK_AHB0 = crate::Reg<clk_ahb0::CLK_AHB0_SPEC>;
 #[doc = "Clock AHB 0"]
 pub mod clk_ahb0;
-#[doc = "clk_ahb1 (rw) register accessor: Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb1`]
+#[doc = "clk_ahb1 (rw) register accessor: Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ahb1`]
 module"]
 pub type CLK_AHB1 = crate::Reg<clk_ahb1::CLK_AHB1_SPEC>;
 #[doc = "Clock AHB 1"]
 pub mod clk_ahb1;
-#[doc = "clk_apb_bus (rw) register accessor: Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb_bus`]
+#[doc = "clk_apb_bus (rw) register accessor: Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb_bus`]
 module"]
 pub type CLK_APB_BUS = crate::Reg<clk_apb_bus::CLK_APB_BUS_SPEC>;
 #[doc = "Clock APB Bus"]
 pub mod clk_apb_bus;
-#[doc = "clk_apb0 (rw) register accessor: Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb0`]
+#[doc = "clk_apb0 (rw) register accessor: Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_apb0`]
 module"]
 pub type CLK_APB0 = crate::Reg<clk_apb0::CLK_APB0_SPEC>;
 #[doc = "Clock APB 0"]
 pub mod clk_apb0;
-#[doc = "clk_pll0_div2 (rw) register accessor: Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll0_div2`]
+#[doc = "clk_pll0_div2 (rw) register accessor: Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll0_div2`]
 module"]
 pub type CLK_PLL0_DIV2 = crate::Reg<clk_pll0_div2::CLK_PLL0_DIV2_SPEC>;
 #[doc = "Clock PLL 0 Divider 2"]
 pub mod clk_pll0_div2;
-#[doc = "clk_pll1_div2 (rw) register accessor: Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div2`]
+#[doc = "clk_pll1_div2 (rw) register accessor: Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div2`]
 module"]
 pub type CLK_PLL1_DIV2 = crate::Reg<clk_pll1_div2::CLK_PLL1_DIV2_SPEC>;
 #[doc = "Clock PLL 1 Divider 2"]
 pub mod clk_pll1_div2;
-#[doc = "clk_pll2_div2 (rw) register accessor: Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll2_div2`]
+#[doc = "clk_pll2_div2 (rw) register accessor: Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll2_div2`]
 module"]
 pub type CLK_PLL2_DIV2 = crate::Reg<clk_pll2_div2::CLK_PLL2_DIV2_SPEC>;
 #[doc = "Clock PLL 2 Divider 2"]
 pub mod clk_pll2_div2;
-#[doc = "clk_audio_root (rw) register accessor: Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_audio_root`]
+#[doc = "clk_audio_root (rw) register accessor: Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_audio_root`]
 module"]
 pub type CLK_AUDIO_ROOT = crate::Reg<clk_audio_root::CLK_AUDIO_ROOT_SPEC>;
 #[doc = "Clock Audio Root"]
 pub mod clk_audio_root;
-#[doc = "clk_mclk_inner (rw) register accessor: Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_inner`]
+#[doc = "clk_mclk_inner (rw) register accessor: Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_inner`]
 module"]
 pub type CLK_MCLK_INNER = crate::Reg<clk_mclk_inner::CLK_MCLK_INNER_SPEC>;
 #[doc = "Clock MCLK Inner"]
 pub mod clk_mclk_inner;
-#[doc = "clk_mclk (rw) register accessor: Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk`]
+#[doc = "clk_mclk (rw) register accessor: Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk`]
 module"]
 pub type CLK_MCLK = crate::Reg<clk_mclk::CLK_MCLK_SPEC>;
 #[doc = "Clock MCLK"]
 pub mod clk_mclk;
-#[doc = "clk_mclk_out (rw) register accessor: Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_out`]
+#[doc = "clk_mclk_out (rw) register accessor: Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mclk_out`]
 module"]
 pub type CLK_MCLK_OUT = crate::Reg<clk_mclk_out::CLK_MCLK_OUT_SPEC>;
 #[doc = "Clock MCLK Out"]
 pub mod clk_mclk_out;
-#[doc = "clk_isp_2x (rw) register accessor: Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_2x`]
+#[doc = "clk_isp_2x (rw) register accessor: Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_2x`]
 module"]
 pub type CLK_ISP_2X = crate::Reg<clk_isp_2x::CLK_ISP_2X_SPEC>;
 #[doc = "Clock ISP 2x"]
 pub mod clk_isp_2x;
-#[doc = "clk_isp_axi (rw) register accessor: Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_axi`]
+#[doc = "clk_isp_axi (rw) register accessor: Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_isp_axi`]
 module"]
 pub type CLK_ISP_AXI = crate::Reg<clk_isp_axi::CLK_ISP_AXI_SPEC>;
 #[doc = "Clock ISP AXI"]
 pub mod clk_isp_axi;
-#[doc = "clk_gclk0 (rw) register accessor: Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk0`]
+#[doc = "clk_gclk0 (rw) register accessor: Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk0`]
 module"]
 pub type CLK_GCLK0 = crate::Reg<clk_gclk0::CLK_GCLK0_SPEC>;
 #[doc = "Clock GCLK 0"]
 pub mod clk_gclk0;
-#[doc = "clk_gclk1 (rw) register accessor: Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk1`]
+#[doc = "clk_gclk1 (rw) register accessor: Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk1`]
 module"]
 pub type CLK_GCLK1 = crate::Reg<clk_gclk1::CLK_GCLK1_SPEC>;
 #[doc = "Clock GCLK 1"]
 pub mod clk_gclk1;
-#[doc = "clk_gclk2 (rw) register accessor: Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk2`]
+#[doc = "clk_gclk2 (rw) register accessor: Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gclk2`]
 module"]
 pub type CLK_GCLK2 = crate::Reg<clk_gclk2::CLK_GCLK2_SPEC>;
 #[doc = "Clock GCLK 2"]
 pub mod clk_gclk2;
-#[doc = "clk_u7mc_core0 (rw) register accessor: U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core0`]
+#[doc = "clk_u7mc_core0 (rw) register accessor: U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core0`]
 module"]
 pub type CLK_U7MC_CORE0 = crate::Reg<clk_u7mc_core0::CLK_U7MC_CORE0_SPEC>;
 #[doc = "U7MC Core Clock 0"]
 pub mod clk_u7mc_core0;
-#[doc = "clk_u7mc_core1 (rw) register accessor: U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core1`]
+#[doc = "clk_u7mc_core1 (rw) register accessor: U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core1`]
 module"]
 pub type CLK_U7MC_CORE1 = crate::Reg<clk_u7mc_core1::CLK_U7MC_CORE1_SPEC>;
 #[doc = "U7MC Core Clock 1"]
 pub mod clk_u7mc_core1;
-#[doc = "clk_u7mc_core2 (rw) register accessor: U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core2`]
+#[doc = "clk_u7mc_core2 (rw) register accessor: U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core2`]
 module"]
 pub type CLK_U7MC_CORE2 = crate::Reg<clk_u7mc_core2::CLK_U7MC_CORE2_SPEC>;
 #[doc = "U7MC Core Clock 2"]
 pub mod clk_u7mc_core2;
-#[doc = "clk_u7mc_core3 (rw) register accessor: U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core3`]
+#[doc = "clk_u7mc_core3 (rw) register accessor: U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core3`]
 module"]
 pub type CLK_U7MC_CORE3 = crate::Reg<clk_u7mc_core3::CLK_U7MC_CORE3_SPEC>;
 #[doc = "U7MC Core Clock 3"]
 pub mod clk_u7mc_core3;
-#[doc = "clk_u7mc_core4 (rw) register accessor: U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core4`]
+#[doc = "clk_u7mc_core4 (rw) register accessor: U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_core4`]
 module"]
 pub type CLK_U7MC_CORE4 = crate::Reg<clk_u7mc_core4::CLK_U7MC_CORE4_SPEC>;
 #[doc = "U7MC Core Clock 4"]
 pub mod clk_u7mc_core4;
-#[doc = "clk_u7mc_debug (rw) register accessor: U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_debug`]
+#[doc = "clk_u7mc_debug (rw) register accessor: U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_debug`]
 module"]
 pub type CLK_U7MC_DEBUG = crate::Reg<clk_u7mc_debug::CLK_U7MC_DEBUG_SPEC>;
 #[doc = "U7MC Debug Clock"]
 pub mod clk_u7mc_debug;
-#[doc = "u7mc_rtc_toggle (rw) register accessor: U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@u7mc_rtc_toggle`]
+#[doc = "u7mc_rtc_toggle (rw) register accessor: U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@u7mc_rtc_toggle`]
 module"]
 pub type U7MC_RTC_TOGGLE = crate::Reg<u7mc_rtc_toggle::U7MC_RTC_TOGGLE_SPEC>;
 #[doc = "U7MC RTC Toggle"]
 pub mod u7mc_rtc_toggle;
-#[doc = "clk_u7mc_trace0 (rw) register accessor: U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace0`]
+#[doc = "clk_u7mc_trace0 (rw) register accessor: U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace0`]
 module"]
 pub type CLK_U7MC_TRACE0 = crate::Reg<clk_u7mc_trace0::CLK_U7MC_TRACE0_SPEC>;
 #[doc = "U7MC Trace Clock 0"]
 pub mod clk_u7mc_trace0;
-#[doc = "clk_u7mc_trace1 (rw) register accessor: U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace1`]
+#[doc = "clk_u7mc_trace1 (rw) register accessor: U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace1`]
 module"]
 pub type CLK_U7MC_TRACE1 = crate::Reg<clk_u7mc_trace1::CLK_U7MC_TRACE1_SPEC>;
 #[doc = "U7MC Trace Clock 1"]
 pub mod clk_u7mc_trace1;
-#[doc = "clk_u7mc_trace2 (rw) register accessor: U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace2`]
+#[doc = "clk_u7mc_trace2 (rw) register accessor: U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace2`]
 module"]
 pub type CLK_U7MC_TRACE2 = crate::Reg<clk_u7mc_trace2::CLK_U7MC_TRACE2_SPEC>;
 #[doc = "U7MC Trace Clock 2"]
 pub mod clk_u7mc_trace2;
-#[doc = "clk_u7mc_trace3 (rw) register accessor: U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace3`]
+#[doc = "clk_u7mc_trace3 (rw) register accessor: U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace3`]
 module"]
 pub type CLK_U7MC_TRACE3 = crate::Reg<clk_u7mc_trace3::CLK_U7MC_TRACE3_SPEC>;
 #[doc = "U7MC Trace Clock 3"]
 pub mod clk_u7mc_trace3;
-#[doc = "clk_u7mc_trace4 (rw) register accessor: U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace4`]
+#[doc = "clk_u7mc_trace4 (rw) register accessor: U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace4`]
 module"]
 pub type CLK_U7MC_TRACE4 = crate::Reg<clk_u7mc_trace4::CLK_U7MC_TRACE4_SPEC>;
 #[doc = "U7MC Trace Clock 4"]
 pub mod clk_u7mc_trace4;
-#[doc = "clk_u7mc_trace_com (rw) register accessor: U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace_com`]
+#[doc = "clk_u7mc_trace_com (rw) register accessor: U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u7mc_trace_com`]
 module"]
 pub type CLK_U7MC_TRACE_COM = crate::Reg<clk_u7mc_trace_com::CLK_U7MC_TRACE_COM_SPEC>;
 #[doc = "U7MC Trace Clock COM"]
 pub mod clk_u7mc_trace_com;
-#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_cpu_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_cpu_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_cpu_axi::CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_cpu_axi;
-#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_axicfg0_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_axicfg0_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_axicfg0_axi::CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_axicfg0_axi;
-#[doc = "clk_osc_div2 (rw) register accessor: clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc_div2`]
+#[doc = "clk_osc_div2 (rw) register accessor: clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_osc_div2`]
 module"]
 pub type CLK_OSC_DIV2 = crate::Reg<clk_osc_div2::CLK_OSC_DIV2_SPEC>;
 #[doc = "clk_osc_div2"]
 pub mod clk_osc_div2;
-#[doc = "clk_pll1_div4 (rw) register accessor: clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div4`]
+#[doc = "clk_pll1_div4 (rw) register accessor: clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div4`]
 module"]
 pub type CLK_PLL1_DIV4 = crate::Reg<clk_pll1_div4::CLK_PLL1_DIV4_SPEC>;
 #[doc = "clk_pll1_div4"]
 pub mod clk_pll1_div4;
-#[doc = "clk_pll1_div8 (rw) register accessor: clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div8`]
+#[doc = "clk_pll1_div8 (rw) register accessor: clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pll1_div8`]
 module"]
 pub type CLK_PLL1_DIV8 = crate::Reg<clk_pll1_div8::CLK_PLL1_DIV8_SPEC>;
 #[doc = "clk_pll1_div8"]
 pub mod clk_pll1_div8;
-#[doc = "clk_ddr_bus (rw) register accessor: clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ddr_bus`]
+#[doc = "clk_ddr_bus (rw) register accessor: clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_ddr_bus`]
 module"]
 pub type CLK_DDR_BUS = crate::Reg<clk_ddr_bus::CLK_DDR_BUS_SPEC>;
 #[doc = "clk_ddr_bus"]
 pub mod clk_ddr_bus;
-#[doc = "clk_u0_ddr_sft7110_clk_axi (rw) register accessor: clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_ddr_sft7110_clk_axi`]
+#[doc = "clk_u0_ddr_sft7110_clk_axi (rw) register accessor: clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_ddr_sft7110_clk_axi`]
 module"]
 pub type CLK_U0_DDR_SFT7110_CLK_AXI =
     crate::Reg<clk_u0_ddr_sft7110_clk_axi::CLK_U0_DDR_SFT7110_CLK_AXI_SPEC>;
 #[doc = "clk_u0_ddr_sfft7110_clk_axi"]
 pub mod clk_u0_ddr_sft7110_clk_axi;
-#[doc = "clk_gpu_core (rw) register accessor: clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_core`]
+#[doc = "clk_gpu_core (rw) register accessor: clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gpu_core`]
 module"]
 pub type CLK_GPU_CORE = crate::Reg<clk_gpu_core::CLK_GPU_CORE_SPEC>;
 #[doc = "clk_gpu_core"]
 pub mod clk_gpu_core;
-#[doc = "clk_u0_img_gpu_core_clk (rw) register accessor: clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_core_clk`]
+#[doc = "clk_u0_img_gpu_core_clk (rw) register accessor: clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_core_clk`]
 module"]
 pub type CLK_U0_IMG_GPU_CORE_CLK =
     crate::Reg<clk_u0_img_gpu_core_clk::CLK_U0_IMG_GPU_CORE_CLK_SPEC>;
 #[doc = "clk_u0_img_gpu_core_clk"]
 pub mod clk_u0_img_gpu_core_clk;
-#[doc = "clk_u0_img_gpu_sys_clk (rw) register accessor: clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_sys_clk`]
+#[doc = "clk_u0_img_gpu_sys_clk (rw) register accessor: clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_sys_clk`]
 module"]
 pub type CLK_U0_IMG_GPU_SYS_CLK = crate::Reg<clk_u0_img_gpu_sys_clk::CLK_U0_IMG_GPU_SYS_CLK_SPEC>;
 #[doc = "clk_u0_img_gpu_sys_clk"]
 pub mod clk_u0_img_gpu_sys_clk;
-#[doc = "clk_u0_img_gpu_clk_apb (rw) register accessor: clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_clk_apb`]
+#[doc = "clk_u0_img_gpu_clk_apb (rw) register accessor: clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_img_gpu_clk_apb`]
 module"]
 pub type CLK_U0_IMG_GPU_CLK_APB = crate::Reg<clk_u0_img_gpu_clk_apb::CLK_U0_IMG_GPU_CLK_APB_SPEC>;
 #[doc = "clk_u0_img_gpu_clk_apb"]
 pub mod clk_u0_img_gpu_clk_apb;
-#[doc = "clk_u0_gpu_rtc_toggle (rw) register accessor: clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_gpu_rtc_toggle`]
+#[doc = "clk_u0_gpu_rtc_toggle (rw) register accessor: clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_gpu_rtc_toggle`]
 module"]
 pub type CLK_U0_GPU_RTC_TOGGLE = crate::Reg<clk_u0_gpu_rtc_toggle::CLK_U0_GPU_RTC_TOGGLE_SPEC>;
 #[doc = "clk_u0_gpu_rtc_toggle"]
 pub mod clk_u0_gpu_rtc_toggle;
-#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_gpu_axi`]
+#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi (rw) register accessor: clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bus_clk_gpu_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI =
     crate::Reg<clk_u0_sft7110_noc_bus_clk_gpu_axi::CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi"]
 pub mod clk_u0_sft7110_noc_bus_clk_gpu_axi;
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x`]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x`]
 module"]
 pub type CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X = crate :: Reg < clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x :: CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC > ;
 #[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x"]
 pub mod clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x;
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi`]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi (rw) register accessor: clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi`]
 module"]
 pub type CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI = crate :: Reg < clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi :: CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC > ;
 #[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi"]
 pub mod clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi;
-#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi (rw) register accessor: clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bux_clk_isp_axi`]
+#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi (rw) register accessor: clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sft7110_noc_bux_clk_isp_axi`]
 module"]
 pub type CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI =
     crate::Reg<clk_u0_sft7110_noc_bux_clk_isp_axi::CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC>;
 #[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi"]
 pub mod clk_u0_sft7110_noc_bux_clk_isp_axi;
-#[doc = "clk_hifi4_core (rw) register accessor: clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
+#[doc = "clk_hifi4_core (rw) register accessor: clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_core`]
 module"]
 pub type CLK_HIFI4_CORE = crate::Reg<clk_hifi4_core::CLK_HIFI4_CORE_SPEC>;
 #[doc = "clk_hifi4_core"]
 pub mod clk_hifi4_core;
-#[doc = "clk_hifi4_axi (rw) register accessor: clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_axi`]
+#[doc = "clk_hifi4_axi (rw) register accessor: clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_hifi4_axi`]
 module"]
 pub type CLK_HIFI4_AXI = crate::Reg<clk_hifi4_axi::CLK_HIFI4_AXI_SPEC>;
 #[doc = "clk_hifi4_axi"]
 pub mod clk_hifi4_axi;
-#[doc = "clk_u0_axi_cfg1_dec_clk_main (rw) register accessor: clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_main`]
+#[doc = "clk_u0_axi_cfg1_dec_clk_main (rw) register accessor: clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_main`]
 module"]
 pub type CLK_U0_AXI_CFG1_DEC_CLK_MAIN =
     crate::Reg<clk_u0_axi_cfg1_dec_clk_main::CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC>;
 #[doc = "clk_u0_axi_cfg1_dec_clk_main"]
 pub mod clk_u0_axi_cfg1_dec_clk_main;
-#[doc = "clk_u0_axi_cfg1_dec_clk_ahb (rw) register accessor: clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_ahb`]
+#[doc = "clk_u0_axi_cfg1_dec_clk_ahb (rw) register accessor: clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_axi_cfg1_dec_clk_ahb`]
 module"]
 pub type CLK_U0_AXI_CFG1_DEC_CLK_AHB =
     crate::Reg<clk_u0_axi_cfg1_dec_clk_ahb::CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC>;
 #[doc = "clk_u0_axi_cfg1_dec_clk_ahb"]
 pub mod clk_u0_axi_cfg1_dec_clk_ahb;
-#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src (rw) register accessor: clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src`]
+#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src (rw) register accessor: clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src`]
 module"]
 pub type CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC = crate :: Reg < clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src :: CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC > ;
 #[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src"]
 pub mod clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src;
-#[doc = "clk_vout_axi_divcfg (rw) register accessor: Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_divcfg`]
+#[doc = "clk_vout_axi_divcfg (rw) register accessor: Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_divcfg`]
 module"]
 pub type CLK_VOUT_AXI_DIVCFG = crate::Reg<clk_vout_axi_divcfg::CLK_VOUT_AXI_DIVCFG_SPEC>;
 #[doc = "Clock Video Output AXI DIVCFG"]
 pub mod clk_vout_axi_divcfg;
-#[doc = "clk_noc_display_axi (rw) register accessor: Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_display_axi`]
+#[doc = "clk_noc_display_axi (rw) register accessor: Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_display_axi`]
 module"]
 pub type CLK_NOC_DISPLAY_AXI = crate::Reg<clk_noc_display_axi::CLK_NOC_DISPLAY_AXI_SPEC>;
 #[doc = "Clock NOC Display AXI"]
 pub mod clk_noc_display_axi;
-#[doc = "clk_vout_ahb (rw) register accessor: Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_ahb`]
+#[doc = "clk_vout_ahb (rw) register accessor: Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_ahb`]
 module"]
 pub type CLK_VOUT_AHB = crate::Reg<clk_vout_ahb::CLK_VOUT_AHB_SPEC>;
 #[doc = "Clock Video Output AHB"]
 pub mod clk_vout_ahb;
-#[doc = "clk_vout_axi_icg (rw) register accessor: Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_icg`]
+#[doc = "clk_vout_axi_icg (rw) register accessor: Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_axi_icg`]
 module"]
 pub type CLK_VOUT_AXI_ICG = crate::Reg<clk_vout_axi_icg::CLK_VOUT_AXI_ICG_SPEC>;
 #[doc = "Clock Video Output AXI ICG"]
 pub mod clk_vout_axi_icg;
-#[doc = "clk_vout_hdmi_tx0_mclk (rw) register accessor: Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_hdmi_tx0_mclk`]
+#[doc = "clk_vout_hdmi_tx0_mclk (rw) register accessor: Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_hdmi_tx0_mclk`]
 module"]
 pub type CLK_VOUT_HDMI_TX0_MCLK = crate::Reg<clk_vout_hdmi_tx0_mclk::CLK_VOUT_HDMI_TX0_MCLK_SPEC>;
 #[doc = "Clock Video Output HDMI TX0 MCLK"]
 pub mod clk_vout_hdmi_tx0_mclk;
-#[doc = "clk_vout_mipi_phy (rw) register accessor: Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_mipi_phy`]
+#[doc = "clk_vout_mipi_phy (rw) register accessor: Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vout_mipi_phy`]
 module"]
 pub type CLK_VOUT_MIPI_PHY = crate::Reg<clk_vout_mipi_phy::CLK_VOUT_MIPI_PHY_SPEC>;
 #[doc = "Clock Video Output MIPI PHY Reference"]
 pub mod clk_vout_mipi_phy;
-#[doc = "clk_jpeg_codec_axi (rw) register accessor: Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jpeg_codec_axi`]
+#[doc = "clk_jpeg_codec_axi (rw) register accessor: Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jpeg_codec_axi`]
 module"]
 pub type CLK_JPEG_CODEC_AXI = crate::Reg<clk_jpeg_codec_axi::CLK_JPEG_CODEC_AXI_SPEC>;
 #[doc = "Clock JPEG Codec AXI"]
 pub mod clk_jpeg_codec_axi;
-#[doc = "clk_codaj12_axi (rw) register accessor: CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_axi`]
+#[doc = "clk_codaj12_axi (rw) register accessor: CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_axi`]
 module"]
 pub type CLK_CODAJ12_AXI = crate::Reg<clk_codaj12_axi::CLK_CODAJ12_AXI_SPEC>;
 #[doc = "CODAJ12 Clock AXI"]
 pub mod clk_codaj12_axi;
-#[doc = "clk_codaj12_core (rw) register accessor: CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_core`]
+#[doc = "clk_codaj12_core (rw) register accessor: CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_core`]
 module"]
 pub type CLK_CODAJ12_CORE = crate::Reg<clk_codaj12_core::CLK_CODAJ12_CORE_SPEC>;
 #[doc = "CODAJ12 Clock Core"]
 pub mod clk_codaj12_core;
-#[doc = "clk_codaj12_apb (rw) register accessor: CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_apb`]
+#[doc = "clk_codaj12_apb (rw) register accessor: CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_codaj12_apb`]
 module"]
 pub type CLK_CODAJ12_APB = crate::Reg<clk_codaj12_apb::CLK_CODAJ12_APB_SPEC>;
 #[doc = "CODAJ12 Clock APB"]
 pub mod clk_codaj12_apb;
-#[doc = "clk_vdec_axi (rw) register accessor: Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vdec_axi`]
+#[doc = "clk_vdec_axi (rw) register accessor: Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_vdec_axi`]
 module"]
 pub type CLK_VDEC_AXI = crate::Reg<clk_vdec_axi::CLK_VDEC_AXI_SPEC>;
 #[doc = "Clock Video Decoder AXI"]
 pub mod clk_vdec_axi;
-#[doc = "clk_wave511_axi (rw) register accessor: Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_axi`]
+#[doc = "clk_wave511_axi (rw) register accessor: Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_axi`]
 module"]
 pub type CLK_WAVE511_AXI = crate::Reg<clk_wave511_axi::CLK_WAVE511_AXI_SPEC>;
 #[doc = "Clock WAVE511 AXI"]
 pub mod clk_wave511_axi;
-#[doc = "clk_wave511_bpu (rw) register accessor: Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_bpu`]
+#[doc = "clk_wave511_bpu (rw) register accessor: Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_bpu`]
 module"]
 pub type CLK_WAVE511_BPU = crate::Reg<clk_wave511_bpu::CLK_WAVE511_BPU_SPEC>;
 #[doc = "Clock WAVE511 BPU"]
 pub mod clk_wave511_bpu;
-#[doc = "clk_wave511_vce (rw) register accessor: Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_vce`]
+#[doc = "clk_wave511_vce (rw) register accessor: Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_vce`]
 module"]
 pub type CLK_WAVE511_VCE = crate::Reg<clk_wave511_vce::CLK_WAVE511_VCE_SPEC>;
 #[doc = "Clock WAVE511 VCE"]
 pub mod clk_wave511_vce;
-#[doc = "clk_wave511_apb (rw) register accessor: Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_apb`]
+#[doc = "clk_wave511_apb (rw) register accessor: Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_apb`]
 module"]
 pub type CLK_WAVE511_APB = crate::Reg<clk_wave511_apb::CLK_WAVE511_APB_SPEC>;
 #[doc = "Clock WAVE511 APB"]
 pub mod clk_wave511_apb;
-#[doc = "clk_wave511_jpg_arb (rw) register accessor: Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_arb`]
+#[doc = "clk_wave511_jpg_arb (rw) register accessor: Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_arb`]
 module"]
 pub type CLK_WAVE511_JPG_ARB = crate::Reg<clk_wave511_jpg_arb::CLK_WAVE511_JPG_ARB_SPEC>;
 #[doc = "Clock WAVE511 JPG ARB"]
 pub mod clk_wave511_jpg_arb;
-#[doc = "clk_wave511_jpg_main (rw) register accessor: Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_main`]
+#[doc = "clk_wave511_jpg_main (rw) register accessor: Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave511_jpg_main`]
 module"]
 pub type CLK_WAVE511_JPG_MAIN = crate::Reg<clk_wave511_jpg_main::CLK_WAVE511_JPG_MAIN_SPEC>;
 #[doc = "Clock WAVE511 JPG Main"]
 pub mod clk_wave511_jpg_main;
-#[doc = "clk_noc_vdec_axi (rw) register accessor: Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_vdec_axi`]
+#[doc = "clk_noc_vdec_axi (rw) register accessor: Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_vdec_axi`]
 module"]
 pub type CLK_NOC_VDEC_AXI = crate::Reg<clk_noc_vdec_axi::CLK_NOC_VDEC_AXI_SPEC>;
 #[doc = "Clock NOC Video Decoder AXI"]
 pub mod clk_noc_vdec_axi;
-#[doc = "clk_venc_axi (rw) register accessor: Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_venc_axi`]
+#[doc = "clk_venc_axi (rw) register accessor: Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_venc_axi`]
 module"]
 pub type CLK_VENC_AXI = crate::Reg<clk_venc_axi::CLK_VENC_AXI_SPEC>;
 #[doc = "Clock Video Encoder AXI"]
 pub mod clk_venc_axi;
-#[doc = "clk_wave420l_axi (rw) register accessor: Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_axi`]
+#[doc = "clk_wave420l_axi (rw) register accessor: Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_axi`]
 module"]
 pub type CLK_WAVE420L_AXI = crate::Reg<clk_wave420l_axi::CLK_WAVE420L_AXI_SPEC>;
 #[doc = "Clock WAVE420L AXI"]
 pub mod clk_wave420l_axi;
-#[doc = "clk_wave420l_bpu (rw) register accessor: Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_bpu`]
+#[doc = "clk_wave420l_bpu (rw) register accessor: Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_bpu`]
 module"]
 pub type CLK_WAVE420L_BPU = crate::Reg<clk_wave420l_bpu::CLK_WAVE420L_BPU_SPEC>;
 #[doc = "Clock WAVE420L BPU"]
 pub mod clk_wave420l_bpu;
-#[doc = "clk_wave420l_vce (rw) register accessor: Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_vce`]
+#[doc = "clk_wave420l_vce (rw) register accessor: Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_vce`]
 module"]
 pub type CLK_WAVE420L_VCE = crate::Reg<clk_wave420l_vce::CLK_WAVE420L_VCE_SPEC>;
 #[doc = "Clock WAVE420L VCE"]
 pub mod clk_wave420l_vce;
-#[doc = "clk_wave420l_apb (rw) register accessor: Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_apb`]
+#[doc = "clk_wave420l_apb (rw) register accessor: Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wave420l_apb`]
 module"]
 pub type CLK_WAVE420L_APB = crate::Reg<clk_wave420l_apb::CLK_WAVE420L_APB_SPEC>;
 #[doc = "Clock WAVE420L APB"]
 pub mod clk_wave420l_apb;
-#[doc = "clk_noc_venc_axi (rw) register accessor: Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_venc_axi`]
+#[doc = "clk_noc_venc_axi (rw) register accessor: Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_venc_axi`]
 module"]
 pub type CLK_NOC_VENC_AXI = crate::Reg<clk_noc_venc_axi::CLK_NOC_VENC_AXI_SPEC>;
 #[doc = "Clock NOC Video Encoder AXI"]
 pub mod clk_noc_venc_axi;
-#[doc = "clk_axi_cfg0_dec_main_div (rw) register accessor: Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main_div`]
+#[doc = "clk_axi_cfg0_dec_main_div (rw) register accessor: Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main_div`]
 module"]
 pub type CLK_AXI_CFG0_DEC_MAIN_DIV =
     crate::Reg<clk_axi_cfg0_dec_main_div::CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC>;
 #[doc = "Clock AXI Config 0 DEC Main Divider"]
 pub mod clk_axi_cfg0_dec_main_div;
-#[doc = "clk_axi_cfg0_dec_main (rw) register accessor: Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main`]
+#[doc = "clk_axi_cfg0_dec_main (rw) register accessor: Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_main`]
 module"]
 pub type CLK_AXI_CFG0_DEC_MAIN = crate::Reg<clk_axi_cfg0_dec_main::CLK_AXI_CFG0_DEC_MAIN_SPEC>;
 #[doc = "Clock AXI Config 0 DEC Main"]
 pub mod clk_axi_cfg0_dec_main;
-#[doc = "clk_axi_cfg0_dec_hifi4 (rw) register accessor: Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_hifi4`]
+#[doc = "clk_axi_cfg0_dec_hifi4 (rw) register accessor: Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_axi_cfg0_dec_hifi4`]
 module"]
 pub type CLK_AXI_CFG0_DEC_HIFI4 = crate::Reg<clk_axi_cfg0_dec_hifi4::CLK_AXI_CFG0_DEC_HIFI4_SPEC>;
 #[doc = "Clock AXI Config 0 DEC HIFI4"]
 pub mod clk_axi_cfg0_dec_hifi4;
-#[doc = "clk_aximem_128b_axi (rw) register accessor: Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aximem_128b_axi`]
+#[doc = "clk_aximem_128b_axi (rw) register accessor: Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_aximem_128b_axi`]
 module"]
 pub type CLK_AXIMEM_128B_AXI = crate::Reg<clk_aximem_128b_axi::CLK_AXIMEM_128B_AXI_SPEC>;
 #[doc = "Clock AXIMEM 128B AXI"]
 pub mod clk_aximem_128b_axi;
-#[doc = "clk_qspi_ahb (rw) register accessor: Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ahb`]
+#[doc = "clk_qspi_ahb (rw) register accessor: Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ahb`]
 module"]
 pub type CLK_QSPI_AHB = crate::Reg<clk_qspi_ahb::CLK_QSPI_AHB_SPEC>;
 #[doc = "Clock QSPI AHB"]
 pub mod clk_qspi_ahb;
-#[doc = "clk_qspi_apb (rw) register accessor: Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_apb`]
+#[doc = "clk_qspi_apb (rw) register accessor: Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_apb`]
 module"]
 pub type CLK_QSPI_APB = crate::Reg<clk_qspi_apb::CLK_QSPI_APB_SPEC>;
 #[doc = "Clock QSPI APB"]
 pub mod clk_qspi_apb;
-#[doc = "clk_qspi_ref_src (rw) register accessor: Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref_src`]
+#[doc = "clk_qspi_ref_src (rw) register accessor: Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref_src`]
 module"]
 pub type CLK_QSPI_REF_SRC = crate::Reg<clk_qspi_ref_src::CLK_QSPI_REF_SRC_SPEC>;
 #[doc = "Clock QSPI Reference Source"]
 pub mod clk_qspi_ref_src;
-#[doc = "clk_qspi_ref (rw) register accessor: Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref`]
+#[doc = "clk_qspi_ref (rw) register accessor: Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_qspi_ref`]
 module"]
 pub type CLK_QSPI_REF = crate::Reg<clk_qspi_ref::CLK_QSPI_REF_SPEC>;
 #[doc = "Clock QSPI Reference"]
 pub mod clk_qspi_ref;
-#[doc = "clk_u0_sd_ahb (rw) register accessor: U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_ahb`]
+#[doc = "clk_u0_sd_ahb (rw) register accessor: U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_ahb`]
 module"]
 pub type CLK_U0_SD_AHB = crate::Reg<clk_u0_sd_ahb::CLK_U0_SD_AHB_SPEC>;
 #[doc = "U0 SD Clock AHB"]
 pub mod clk_u0_sd_ahb;
-#[doc = "clk_u1_sd_ahb (rw) register accessor: U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_ahb`]
+#[doc = "clk_u1_sd_ahb (rw) register accessor: U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_ahb`]
 module"]
 pub type CLK_U1_SD_AHB = crate::Reg<clk_u1_sd_ahb::CLK_U1_SD_AHB_SPEC>;
 #[doc = "U1 SD Clock AHB"]
 pub mod clk_u1_sd_ahb;
-#[doc = "clk_u0_sd_card (rw) register accessor: U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_card`]
+#[doc = "clk_u0_sd_card (rw) register accessor: U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_sd_card`]
 module"]
 pub type CLK_U0_SD_CARD = crate::Reg<clk_u0_sd_card::CLK_U0_SD_CARD_SPEC>;
 #[doc = "U0 SD Card Clock"]
 pub mod clk_u0_sd_card;
-#[doc = "clk_u1_sd_card (rw) register accessor: U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_card`]
+#[doc = "clk_u1_sd_card (rw) register accessor: U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_sd_card`]
 module"]
 pub type CLK_U1_SD_CARD = crate::Reg<clk_u1_sd_card::CLK_U1_SD_CARD_SPEC>;
 #[doc = "U1 SD Card Clock"]
 pub mod clk_u1_sd_card;
-#[doc = "clk_usb_125m (rw) register accessor: Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_125m`]
+#[doc = "clk_usb_125m (rw) register accessor: Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_usb_125m`]
 module"]
 pub type CLK_USB_125M = crate::Reg<clk_usb_125m::CLK_USB_125M_SPEC>;
 #[doc = "Clock USB 125M"]
 pub mod clk_usb_125m;
-#[doc = "clk_noc_stg_axi (rw) register accessor: Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_stg_axi`]
+#[doc = "clk_noc_stg_axi (rw) register accessor: Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_noc_stg_axi`]
 module"]
 pub type CLK_NOC_STG_AXI = crate::Reg<clk_noc_stg_axi::CLK_NOC_STG_AXI_SPEC>;
 #[doc = "Clock NOC STG AXI"]
 pub mod clk_noc_stg_axi;
-#[doc = "clk_gmac5_axi64_ahb (rw) register accessor: Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ahb`]
+#[doc = "clk_gmac5_axi64_ahb (rw) register accessor: Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ahb`]
 module"]
 pub type CLK_GMAC5_AXI64_AHB = crate::Reg<clk_gmac5_axi64_ahb::CLK_GMAC5_AXI64_AHB_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 AHB"]
 pub mod clk_gmac5_axi64_ahb;
-#[doc = "clk_gmac5_axi64_axi (rw) register accessor: Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_axi`]
+#[doc = "clk_gmac5_axi64_axi (rw) register accessor: Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_axi`]
 module"]
 pub type CLK_GMAC5_AXI64_AXI = crate::Reg<clk_gmac5_axi64_axi::CLK_GMAC5_AXI64_AXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 AXI"]
 pub mod clk_gmac5_axi64_axi;
-#[doc = "clk_gmac_src (rw) register accessor: Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_src`]
+#[doc = "clk_gmac_src (rw) register accessor: Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_src`]
 module"]
 pub type CLK_GMAC_SRC = crate::Reg<clk_gmac_src::CLK_GMAC_SRC_SPEC>;
 #[doc = "Clock GMAC Source"]
 pub mod clk_gmac_src;
-#[doc = "clk_gmac1_gtx (rw) register accessor: Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtx`]
+#[doc = "clk_gmac1_gtx (rw) register accessor: Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtx`]
 module"]
 pub type CLK_GMAC1_GTX = crate::Reg<clk_gmac1_gtx::CLK_GMAC1_GTX_SPEC>;
 #[doc = "Clock GMAC 1 GTX"]
 pub mod clk_gmac1_gtx;
-#[doc = "clk_gmac1_rmii_rtx (rw) register accessor: Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_rmii_rtx`]
+#[doc = "clk_gmac1_rmii_rtx (rw) register accessor: Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_rmii_rtx`]
 module"]
 pub type CLK_GMAC1_RMII_RTX = crate::Reg<clk_gmac1_rmii_rtx::CLK_GMAC1_RMII_RTX_SPEC>;
 #[doc = "Clock GMAC 1 RMII RTX"]
 pub mod clk_gmac1_rmii_rtx;
-#[doc = "clk_gmac5_axi64_ptp (rw) register accessor: Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ptp`]
+#[doc = "clk_gmac5_axi64_ptp (rw) register accessor: Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_ptp`]
 module"]
 pub type CLK_GMAC5_AXI64_PTP = crate::Reg<clk_gmac5_axi64_ptp::CLK_GMAC5_AXI64_PTP_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 PTP"]
 pub mod clk_gmac5_axi64_ptp;
-#[doc = "clk_gmac5_axi64_rx (rw) register accessor: Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
+#[doc = "clk_gmac5_axi64_rx (rw) register accessor: Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rx`]
 module"]
 pub type CLK_GMAC5_AXI64_RX = crate::Reg<clk_gmac5_axi64_rx::CLK_GMAC5_AXI64_RX_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 RX"]
 pub mod clk_gmac5_axi64_rx;
-#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
+#[doc = "clk_gmac5_axi64_rxi (rw) register accessor: Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_rxi`]
 module"]
 pub type CLK_GMAC5_AXI64_RXI = crate::Reg<clk_gmac5_axi64_rxi::CLK_GMAC5_AXI64_RXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 RX Inverter"]
 pub mod clk_gmac5_axi64_rxi;
-#[doc = "clk_gmac5_axi64_tx (rw) register accessor: Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
+#[doc = "clk_gmac5_axi64_tx (rw) register accessor: Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_tx`]
 module"]
 pub type CLK_GMAC5_AXI64_TX = crate::Reg<clk_gmac5_axi64_tx::CLK_GMAC5_AXI64_TX_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 TX"]
 pub mod clk_gmac5_axi64_tx;
-#[doc = "clk_gmac5_axi64_txi (rw) register accessor: Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
+#[doc = "clk_gmac5_axi64_txi (rw) register accessor: Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac5_axi64_txi`]
 module"]
 pub type CLK_GMAC5_AXI64_TXI = crate::Reg<clk_gmac5_axi64_txi::CLK_GMAC5_AXI64_TXI_SPEC>;
 #[doc = "Clock GMAC 5 AXI 64 TX Inverter"]
 pub mod clk_gmac5_axi64_txi;
-#[doc = "clk_gmac1_gtxclk (rw) register accessor: Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtxclk`]
+#[doc = "clk_gmac1_gtxclk (rw) register accessor: Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac1_gtxclk`]
 module"]
 pub type CLK_GMAC1_GTXCLK = crate::Reg<clk_gmac1_gtxclk::CLK_GMAC1_GTXCLK_SPEC>;
 #[doc = "Clock GMAC 1 GTXC"]
 pub mod clk_gmac1_gtxclk;
-#[doc = "clk_gmac0_gtx (rw) register accessor: Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtx`]
+#[doc = "clk_gmac0_gtx (rw) register accessor: Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtx`]
 module"]
 pub type CLK_GMAC0_GTX = crate::Reg<clk_gmac0_gtx::CLK_GMAC0_GTX_SPEC>;
 #[doc = "Clock GMAC 0 GTX"]
 pub mod clk_gmac0_gtx;
-#[doc = "clk_gmac0_ptp (rw) register accessor: Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_ptp`]
+#[doc = "clk_gmac0_ptp (rw) register accessor: Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_ptp`]
 module"]
 pub type CLK_GMAC0_PTP = crate::Reg<clk_gmac0_ptp::CLK_GMAC0_PTP_SPEC>;
 #[doc = "Clock GMAC 0 PTP"]
 pub mod clk_gmac0_ptp;
-#[doc = "clk_gmac_phy (rw) register accessor: Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_phy`]
+#[doc = "clk_gmac_phy (rw) register accessor: Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac_phy`]
 module"]
 pub type CLK_GMAC_PHY = crate::Reg<clk_gmac_phy::CLK_GMAC_PHY_SPEC>;
 #[doc = "Clock GMAC PHY"]
 pub mod clk_gmac_phy;
-#[doc = "clk_gmac0_gtxclk (rw) register accessor: Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtxclk`]
+#[doc = "clk_gmac0_gtxclk (rw) register accessor: Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_gmac0_gtxclk`]
 module"]
 pub type CLK_GMAC0_GTXCLK = crate::Reg<clk_gmac0_gtxclk::CLK_GMAC0_GTXCLK_SPEC>;
 #[doc = "Clock GMAC 0 GTXC"]
 pub mod clk_gmac0_gtxclk;
-#[doc = "clk_sys_iomux_pclk (rw) register accessor: Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sys_iomux_pclk`]
+#[doc = "clk_sys_iomux_pclk (rw) register accessor: Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_sys_iomux_pclk`]
 module"]
 pub type CLK_SYS_IOMUX_PCLK = crate::Reg<clk_sys_iomux_pclk::CLK_SYS_IOMUX_PCLK_SPEC>;
 #[doc = "Clock SYS IOMUX PCLK"]
 pub mod clk_sys_iomux_pclk;
-#[doc = "clk_mbox_apb (rw) register accessor: Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mbox_apb`]
+#[doc = "clk_mbox_apb (rw) register accessor: Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_mbox_apb`]
 module"]
 pub type CLK_MBOX_APB = crate::Reg<clk_mbox_apb::CLK_MBOX_APB_SPEC>;
 #[doc = "Clock Mailbox APB"]
 pub mod clk_mbox_apb;
-#[doc = "clk_internal_ctrl_apb (rw) register accessor: Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_internal_ctrl_apb`]
+#[doc = "clk_internal_ctrl_apb (rw) register accessor: Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_internal_ctrl_apb`]
 module"]
 pub type CLK_INTERNAL_CTRL_APB = crate::Reg<clk_internal_ctrl_apb::CLK_INTERNAL_CTRL_APB_SPEC>;
 #[doc = "Clock Internal Controller APB"]
 pub mod clk_internal_ctrl_apb;
-#[doc = "clk_u0_can_ctrl_apb (rw) register accessor: U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_apb`]
+#[doc = "clk_u0_can_ctrl_apb (rw) register accessor: U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_apb`]
 module"]
 pub type CLK_U0_CAN_CTRL_APB = crate::Reg<clk_u0_can_ctrl_apb::CLK_U0_CAN_CTRL_APB_SPEC>;
 #[doc = "U0 Clock CAN Controller APB"]
 pub mod clk_u0_can_ctrl_apb;
-#[doc = "clk_u0_can_ctrl_tim (rw) register accessor: U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_tim`]
+#[doc = "clk_u0_can_ctrl_tim (rw) register accessor: U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_tim`]
 module"]
 pub type CLK_U0_CAN_CTRL_TIM = crate::Reg<clk_u0_can_ctrl_tim::CLK_U0_CAN_CTRL_TIM_SPEC>;
 #[doc = "U0 Clock CAN Controller Timer"]
 pub mod clk_u0_can_ctrl_tim;
-#[doc = "clk_u0_can_ctrl_can (rw) register accessor: U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_can`]
+#[doc = "clk_u0_can_ctrl_can (rw) register accessor: U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_can_ctrl_can`]
 module"]
 pub type CLK_U0_CAN_CTRL_CAN = crate::Reg<clk_u0_can_ctrl_can::CLK_U0_CAN_CTRL_CAN_SPEC>;
 #[doc = "U0 Clock CAN Controller CAN"]
 pub mod clk_u0_can_ctrl_can;
-#[doc = "clk_u1_can_ctrl_apb (rw) register accessor: U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_apb`]
+#[doc = "clk_u1_can_ctrl_apb (rw) register accessor: U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_apb`]
 module"]
 pub type CLK_U1_CAN_CTRL_APB = crate::Reg<clk_u1_can_ctrl_apb::CLK_U1_CAN_CTRL_APB_SPEC>;
 #[doc = "U1 Clock CAN Controller APB"]
 pub mod clk_u1_can_ctrl_apb;
-#[doc = "clk_u1_can_ctrl_tim (rw) register accessor: U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_tim`]
+#[doc = "clk_u1_can_ctrl_tim (rw) register accessor: U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_tim`]
 module"]
 pub type CLK_U1_CAN_CTRL_TIM = crate::Reg<clk_u1_can_ctrl_tim::CLK_U1_CAN_CTRL_TIM_SPEC>;
 #[doc = "U1 Clock CAN Controller Timer"]
 pub mod clk_u1_can_ctrl_tim;
-#[doc = "clk_u1_can_ctrl_can (rw) register accessor: U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_can`]
+#[doc = "clk_u1_can_ctrl_can (rw) register accessor: U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_can_ctrl_can`]
 module"]
 pub type CLK_U1_CAN_CTRL_CAN = crate::Reg<clk_u1_can_ctrl_can::CLK_U1_CAN_CTRL_CAN_SPEC>;
 #[doc = "U1 Clock CAN Controller CAN"]
 pub mod clk_u1_can_ctrl_can;
-#[doc = "clk_pwm_apb (rw) register accessor: Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwm_apb`]
+#[doc = "clk_pwm_apb (rw) register accessor: Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwm_apb`]
 module"]
 pub type CLK_PWM_APB = crate::Reg<clk_pwm_apb::CLK_PWM_APB_SPEC>;
 #[doc = "Clock PWM APB"]
 pub mod clk_pwm_apb;
-#[doc = "clk_wdt_apb (rw) register accessor: Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt_apb`]
+#[doc = "clk_wdt_apb (rw) register accessor: Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt_apb`]
 module"]
 pub type CLK_WDT_APB = crate::Reg<clk_wdt_apb::CLK_WDT_APB_SPEC>;
 #[doc = "Clock WDT APB"]
 pub mod clk_wdt_apb;
-#[doc = "clk_wdt (rw) register accessor: Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt`]
+#[doc = "clk_wdt (rw) register accessor: Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_wdt`]
 module"]
 pub type CLK_WDT = crate::Reg<clk_wdt::CLK_WDT_SPEC>;
 #[doc = "Clock WDT"]
 pub mod clk_wdt;
-#[doc = "clk_tim_apb (rw) register accessor: Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim_apb`]
+#[doc = "clk_tim_apb (rw) register accessor: Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim_apb`]
 module"]
 pub type CLK_TIM_APB = crate::Reg<clk_tim_apb::CLK_TIM_APB_SPEC>;
 #[doc = "Clock Timer APB"]
 pub mod clk_tim_apb;
-#[doc = "clk_tim0 (rw) register accessor: Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim0`]
+#[doc = "clk_tim0 (rw) register accessor: Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim0`]
 module"]
 pub type CLK_TIM0 = crate::Reg<clk_tim0::CLK_TIM0_SPEC>;
 #[doc = "Clock Timer 0"]
 pub mod clk_tim0;
-#[doc = "clk_tim1 (rw) register accessor: Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim1`]
+#[doc = "clk_tim1 (rw) register accessor: Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim1`]
 module"]
 pub type CLK_TIM1 = crate::Reg<clk_tim1::CLK_TIM1_SPEC>;
 #[doc = "Clock Timer 1"]
 pub mod clk_tim1;
-#[doc = "clk_tim2 (rw) register accessor: Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim2`]
+#[doc = "clk_tim2 (rw) register accessor: Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim2`]
 module"]
 pub type CLK_TIM2 = crate::Reg<clk_tim2::CLK_TIM2_SPEC>;
 #[doc = "Clock Timer 2"]
 pub mod clk_tim2;
-#[doc = "clk_tim3 (rw) register accessor: Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim3`]
+#[doc = "clk_tim3 (rw) register accessor: Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tim3`]
 module"]
 pub type CLK_TIM3 = crate::Reg<clk_tim3::CLK_TIM3_SPEC>;
 #[doc = "Clock Timer 3"]
 pub mod clk_tim3;
-#[doc = "clk_temp_sensor_apb (rw) register accessor: Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor_apb`]
+#[doc = "clk_temp_sensor_apb (rw) register accessor: Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor_apb`]
 module"]
 pub type CLK_TEMP_SENSOR_APB = crate::Reg<clk_temp_sensor_apb::CLK_TEMP_SENSOR_APB_SPEC>;
 #[doc = "Clock Temperature Sensor APB"]
 pub mod clk_temp_sensor_apb;
-#[doc = "clk_temp_sensor (rw) register accessor: Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor`]
+#[doc = "clk_temp_sensor (rw) register accessor: Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_temp_sensor`]
 module"]
 pub type CLK_TEMP_SENSOR = crate::Reg<clk_temp_sensor::CLK_TEMP_SENSOR_SPEC>;
 #[doc = "Clock Temperature Sensor"]
 pub mod clk_temp_sensor;
-#[doc = "clk_u0_spi_apb (rw) register accessor: U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_spi_apb`]
+#[doc = "clk_u0_spi_apb (rw) register accessor: U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_spi_apb`]
 module"]
 pub type CLK_U0_SPI_APB = crate::Reg<clk_u0_spi_apb::CLK_U0_SPI_APB_SPEC>;
 #[doc = "U0 Clock SPI APB"]
 pub mod clk_u0_spi_apb;
-#[doc = "clk_u1_spi_apb (rw) register accessor: U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_spi_apb`]
+#[doc = "clk_u1_spi_apb (rw) register accessor: U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_spi_apb`]
 module"]
 pub type CLK_U1_SPI_APB = crate::Reg<clk_u1_spi_apb::CLK_U1_SPI_APB_SPEC>;
 #[doc = "U1 Clock SPI APB"]
 pub mod clk_u1_spi_apb;
-#[doc = "clk_u2_spi_apb (rw) register accessor: U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_spi_apb`]
+#[doc = "clk_u2_spi_apb (rw) register accessor: U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_spi_apb`]
 module"]
 pub type CLK_U2_SPI_APB = crate::Reg<clk_u2_spi_apb::CLK_U2_SPI_APB_SPEC>;
 #[doc = "U2 Clock SPI APB"]
 pub mod clk_u2_spi_apb;
-#[doc = "clk_u3_spi_apb (rw) register accessor: U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_spi_apb`]
+#[doc = "clk_u3_spi_apb (rw) register accessor: U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_spi_apb`]
 module"]
 pub type CLK_U3_SPI_APB = crate::Reg<clk_u3_spi_apb::CLK_U3_SPI_APB_SPEC>;
 #[doc = "U3 Clock SPI APB"]
 pub mod clk_u3_spi_apb;
-#[doc = "clk_u4_spi_apb (rw) register accessor: U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_spi_apb`]
+#[doc = "clk_u4_spi_apb (rw) register accessor: U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_spi_apb`]
 module"]
 pub type CLK_U4_SPI_APB = crate::Reg<clk_u4_spi_apb::CLK_U4_SPI_APB_SPEC>;
 #[doc = "U4 Clock SPI APB"]
 pub mod clk_u4_spi_apb;
-#[doc = "clk_u5_spi_apb (rw) register accessor: U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_spi_apb`]
+#[doc = "clk_u5_spi_apb (rw) register accessor: U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_spi_apb`]
 module"]
 pub type CLK_U5_SPI_APB = crate::Reg<clk_u5_spi_apb::CLK_U5_SPI_APB_SPEC>;
 #[doc = "U5 Clock SPI APB"]
 pub mod clk_u5_spi_apb;
-#[doc = "clk_u6_spi_apb (rw) register accessor: U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_spi_apb`]
+#[doc = "clk_u6_spi_apb (rw) register accessor: U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_spi_apb`]
 module"]
 pub type CLK_U6_SPI_APB = crate::Reg<clk_u6_spi_apb::CLK_U6_SPI_APB_SPEC>;
 #[doc = "U6 Clock SPI APB"]
 pub mod clk_u6_spi_apb;
-#[doc = "clk_u0_i2c_apb (rw) register accessor: U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2c_apb`]
+#[doc = "clk_u0_i2c_apb (rw) register accessor: U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2c_apb`]
 module"]
 pub type CLK_U0_I2C_APB = crate::Reg<clk_u0_i2c_apb::CLK_U0_I2C_APB_SPEC>;
 #[doc = "U0 Clock I2C APB"]
 pub mod clk_u0_i2c_apb;
-#[doc = "clk_u1_i2c_apb (rw) register accessor: U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2c_apb`]
+#[doc = "clk_u1_i2c_apb (rw) register accessor: U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2c_apb`]
 module"]
 pub type CLK_U1_I2C_APB = crate::Reg<clk_u1_i2c_apb::CLK_U1_I2C_APB_SPEC>;
 #[doc = "U1 Clock I2C APB"]
 pub mod clk_u1_i2c_apb;
-#[doc = "clk_u2_i2c_apb (rw) register accessor: U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_i2c_apb`]
+#[doc = "clk_u2_i2c_apb (rw) register accessor: U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_i2c_apb`]
 module"]
 pub type CLK_U2_I2C_APB = crate::Reg<clk_u2_i2c_apb::CLK_U2_I2C_APB_SPEC>;
 #[doc = "U2 Clock I2C APB"]
 pub mod clk_u2_i2c_apb;
-#[doc = "clk_u3_i2c_apb (rw) register accessor: U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_i2c_apb`]
+#[doc = "clk_u3_i2c_apb (rw) register accessor: U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_i2c_apb`]
 module"]
 pub type CLK_U3_I2C_APB = crate::Reg<clk_u3_i2c_apb::CLK_U3_I2C_APB_SPEC>;
 #[doc = "U3 Clock I2C APB"]
 pub mod clk_u3_i2c_apb;
-#[doc = "clk_u4_i2c_apb (rw) register accessor: U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_i2c_apb`]
+#[doc = "clk_u4_i2c_apb (rw) register accessor: U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_i2c_apb`]
 module"]
 pub type CLK_U4_I2C_APB = crate::Reg<clk_u4_i2c_apb::CLK_U4_I2C_APB_SPEC>;
 #[doc = "U4 Clock I2C APB"]
 pub mod clk_u4_i2c_apb;
-#[doc = "clk_u5_i2c_apb (rw) register accessor: U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_i2c_apb`]
+#[doc = "clk_u5_i2c_apb (rw) register accessor: U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_i2c_apb`]
 module"]
 pub type CLK_U5_I2C_APB = crate::Reg<clk_u5_i2c_apb::CLK_U5_I2C_APB_SPEC>;
 #[doc = "U5 Clock I2C APB"]
 pub mod clk_u5_i2c_apb;
-#[doc = "clk_u6_i2c_apb (rw) register accessor: U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_i2c_apb`]
+#[doc = "clk_u6_i2c_apb (rw) register accessor: U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u6_i2c_apb`]
 module"]
 pub type CLK_U6_I2C_APB = crate::Reg<clk_u6_i2c_apb::CLK_U6_I2C_APB_SPEC>;
 #[doc = "U6 Clock I2C APB"]
 pub mod clk_u6_i2c_apb;
-#[doc = "clk_u0_uart_apb (rw) register accessor: U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_apb`]
+#[doc = "clk_u0_uart_apb (rw) register accessor: U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_apb`]
 module"]
 pub type CLK_U0_UART_APB = crate::Reg<clk_u0_uart_apb::CLK_U0_UART_APB_SPEC>;
 #[doc = "U0 Clock UART APB"]
 pub mod clk_u0_uart_apb;
-#[doc = "clk_u0_uart_core (rw) register accessor: U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_core`]
+#[doc = "clk_u0_uart_core (rw) register accessor: U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_uart_core`]
 module"]
 pub type CLK_U0_UART_CORE = crate::Reg<clk_u0_uart_core::CLK_U0_UART_CORE_SPEC>;
 #[doc = "U0 Clock UART Core"]
 pub mod clk_u0_uart_core;
-#[doc = "clk_u1_uart_apb (rw) register accessor: U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_apb`]
+#[doc = "clk_u1_uart_apb (rw) register accessor: U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_apb`]
 module"]
 pub type CLK_U1_UART_APB = crate::Reg<clk_u1_uart_apb::CLK_U1_UART_APB_SPEC>;
 #[doc = "U1 Clock UART APB"]
 pub mod clk_u1_uart_apb;
-#[doc = "clk_u1_uart_core (rw) register accessor: U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_core`]
+#[doc = "clk_u1_uart_core (rw) register accessor: U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_uart_core`]
 module"]
 pub type CLK_U1_UART_CORE = crate::Reg<clk_u1_uart_core::CLK_U1_UART_CORE_SPEC>;
 #[doc = "U1 Clock UART Core"]
 pub mod clk_u1_uart_core;
-#[doc = "clk_u2_uart_apb (rw) register accessor: U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_apb`]
+#[doc = "clk_u2_uart_apb (rw) register accessor: U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_apb`]
 module"]
 pub type CLK_U2_UART_APB = crate::Reg<clk_u2_uart_apb::CLK_U2_UART_APB_SPEC>;
 #[doc = "U2 Clock UART APB"]
 pub mod clk_u2_uart_apb;
-#[doc = "clk_u2_uart_core (rw) register accessor: U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_core`]
+#[doc = "clk_u2_uart_core (rw) register accessor: U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u2_uart_core`]
 module"]
 pub type CLK_U2_UART_CORE = crate::Reg<clk_u2_uart_core::CLK_U2_UART_CORE_SPEC>;
 #[doc = "U2 Clock UART Core"]
 pub mod clk_u2_uart_core;
-#[doc = "clk_u3_uart_apb (rw) register accessor: U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_apb`]
+#[doc = "clk_u3_uart_apb (rw) register accessor: U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_apb`]
 module"]
 pub type CLK_U3_UART_APB = crate::Reg<clk_u3_uart_apb::CLK_U3_UART_APB_SPEC>;
 #[doc = "U3 Clock UART APB"]
 pub mod clk_u3_uart_apb;
-#[doc = "clk_u3_uart_core (rw) register accessor: U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_core`]
+#[doc = "clk_u3_uart_core (rw) register accessor: U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u3_uart_core`]
 module"]
 pub type CLK_U3_UART_CORE = crate::Reg<clk_u3_uart_core::CLK_U3_UART_CORE_SPEC>;
 #[doc = "U3 Clock UART Core"]
 pub mod clk_u3_uart_core;
-#[doc = "clk_u4_uart_apb (rw) register accessor: U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_apb`]
+#[doc = "clk_u4_uart_apb (rw) register accessor: U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_apb`]
 module"]
 pub type CLK_U4_UART_APB = crate::Reg<clk_u4_uart_apb::CLK_U4_UART_APB_SPEC>;
 #[doc = "U4 Clock UART APB"]
 pub mod clk_u4_uart_apb;
-#[doc = "clk_u4_uart_core (rw) register accessor: U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_core`]
+#[doc = "clk_u4_uart_core (rw) register accessor: U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u4_uart_core`]
 module"]
 pub type CLK_U4_UART_CORE = crate::Reg<clk_u4_uart_core::CLK_U4_UART_CORE_SPEC>;
 #[doc = "U4 Clock UART Core"]
 pub mod clk_u4_uart_core;
-#[doc = "clk_u5_uart_apb (rw) register accessor: U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_apb`]
+#[doc = "clk_u5_uart_apb (rw) register accessor: U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_apb`]
 module"]
 pub type CLK_U5_UART_APB = crate::Reg<clk_u5_uart_apb::CLK_U5_UART_APB_SPEC>;
 #[doc = "U5 Clock UART APB"]
 pub mod clk_u5_uart_apb;
-#[doc = "clk_u5_uart_core (rw) register accessor: U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_core`]
+#[doc = "clk_u5_uart_core (rw) register accessor: U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u5_uart_core`]
 module"]
 pub type CLK_U5_UART_CORE = crate::Reg<clk_u5_uart_core::CLK_U5_UART_CORE_SPEC>;
 #[doc = "U5 Clock UART Core"]
 pub mod clk_u5_uart_core;
-#[doc = "clk_pwmdac_apb (rw) register accessor: Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_apb`]
+#[doc = "clk_pwmdac_apb (rw) register accessor: Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_apb`]
 module"]
 pub type CLK_PWMDAC_APB = crate::Reg<clk_pwmdac_apb::CLK_PWMDAC_APB_SPEC>;
 #[doc = "Clock PWMDAC APB"]
 pub mod clk_pwmdac_apb;
-#[doc = "clk_pwmdac_core (rw) register accessor: Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_core`]
+#[doc = "clk_pwmdac_core (rw) register accessor: Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pwmdac_core`]
 module"]
 pub type CLK_PWMDAC_CORE = crate::Reg<clk_pwmdac_core::CLK_PWMDAC_CORE_SPEC>;
 #[doc = "Clock PWMDAC Core"]
 pub mod clk_pwmdac_core;
-#[doc = "clk_spdif_apb (rw) register accessor: Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_apb`]
+#[doc = "clk_spdif_apb (rw) register accessor: Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_apb`]
 module"]
 pub type CLK_SPDIF_APB = crate::Reg<clk_spdif_apb::CLK_SPDIF_APB_SPEC>;
 #[doc = "Clock SPDIF APB"]
 pub mod clk_spdif_apb;
-#[doc = "clk_spdif_core (rw) register accessor: Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_core`]
+#[doc = "clk_spdif_core (rw) register accessor: Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_spdif_core`]
 module"]
 pub type CLK_SPDIF_CORE = crate::Reg<clk_spdif_core::CLK_SPDIF_CORE_SPEC>;
 #[doc = "Clock SPDIF Core"]
 pub mod clk_spdif_core;
-#[doc = "clk_u0_i2s_tx_apb (rw) register accessor: U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2s_tx_apb`]
+#[doc = "clk_u0_i2s_tx_apb (rw) register accessor: U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2s_tx_apb`]
 module"]
 pub type CLK_U0_I2S_TX_APB = crate::Reg<clk_u0_i2s_tx_apb::CLK_U0_I2S_TX_APB_SPEC>;
 #[doc = "U0 Clock I2S TX APB"]
 pub mod clk_u0_i2s_tx_apb;
-#[doc = "clk_u0_i2stx_4ch0_bclk_mst (rw) register accessor: U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst`]
+#[doc = "clk_u0_i2stx_4ch0_bclk_mst (rw) register accessor: U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst`]
 module"]
 pub type CLK_U0_I2STX_4CH0_BCLK_MST =
     crate::Reg<clk_u0_i2stx_4ch0_bclk_mst::CLK_U0_I2STX_4CH0_BCLK_MST_SPEC>;
 #[doc = "U0 Clock I2S TX 0 BCLK MST"]
 pub mod clk_u0_i2stx_4ch0_bclk_mst;
-#[doc = "clk_u0_i2stx_4ch0_bclk_mst_inv (rw) register accessor: U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst_inv`]
+#[doc = "clk_u0_i2stx_4ch0_bclk_mst_inv (rw) register accessor: U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_4ch0_bclk_mst_inv`]
 module"]
 pub type CLK_U0_I2STX_4CH0_BCLK_MST_INV =
     crate::Reg<clk_u0_i2stx_4ch0_bclk_mst_inv::CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC>;
 #[doc = "U0 Clock I2S TX 0 BCLK MST Inverter"]
 pub mod clk_u0_i2stx_4ch0_bclk_mst_inv;
-#[doc = "clk_i2stx0_lrck_mst (rw) register accessor: Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx0_lrck_mst`]
+#[doc = "clk_i2stx0_lrck_mst (rw) register accessor: Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx0_lrck_mst`]
 module"]
 pub type CLK_I2STX0_LRCK_MST = crate::Reg<clk_i2stx0_lrck_mst::CLK_I2STX0_LRCK_MST_SPEC>;
 #[doc = "Clock I2S TX 0 LRCK MST"]
 pub mod clk_i2stx0_lrck_mst;
-#[doc = "clk_u0_i2stx_bclk (rw) register accessor: U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk`]
+#[doc = "clk_u0_i2stx_bclk (rw) register accessor: U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk`]
 module"]
 pub type CLK_U0_I2STX_BCLK = crate::Reg<clk_u0_i2stx_bclk::CLK_U0_I2STX_BCLK_SPEC>;
 #[doc = "U0 Clock I2S TX BCLK"]
 pub mod clk_u0_i2stx_bclk;
-#[doc = "clk_u0_i2stx_bclk_neg (rw) register accessor: U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk_neg`]
+#[doc = "clk_u0_i2stx_bclk_neg (rw) register accessor: U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_bclk_neg`]
 module"]
 pub type CLK_U0_I2STX_BCLK_NEG = crate::Reg<clk_u0_i2stx_bclk_neg::CLK_U0_I2STX_BCLK_NEG_SPEC>;
 #[doc = "U0 Clock I2S TX BCLK Negative"]
 pub mod clk_u0_i2stx_bclk_neg;
-#[doc = "clk_u0_i2stx_lrck (rw) register accessor: U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_lrck`]
+#[doc = "clk_u0_i2stx_lrck (rw) register accessor: U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u0_i2stx_lrck`]
 module"]
 pub type CLK_U0_I2STX_LRCK = crate::Reg<clk_u0_i2stx_lrck::CLK_U0_I2STX_LRCK_SPEC>;
 #[doc = "U0 Clock I2S TX LRCK"]
 pub mod clk_u0_i2stx_lrck;
-#[doc = "clk_u1_i2s_tx_apb (rw) register accessor: U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2s_tx_apb`]
+#[doc = "clk_u1_i2s_tx_apb (rw) register accessor: U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2s_tx_apb`]
 module"]
 pub type CLK_U1_I2S_TX_APB = crate::Reg<clk_u1_i2s_tx_apb::CLK_U1_I2S_TX_APB_SPEC>;
 #[doc = "U1 Clock I2S TX APB"]
 pub mod clk_u1_i2s_tx_apb;
-#[doc = "clk_u1_i2stx_4ch1_bclk_mst (rw) register accessor: U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst`]
+#[doc = "clk_u1_i2stx_4ch1_bclk_mst (rw) register accessor: U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst`]
 module"]
 pub type CLK_U1_I2STX_4CH1_BCLK_MST =
     crate::Reg<clk_u1_i2stx_4ch1_bclk_mst::CLK_U1_I2STX_4CH1_BCLK_MST_SPEC>;
 #[doc = "U1 Clock I2S TX 1 BCLK MST"]
 pub mod clk_u1_i2stx_4ch1_bclk_mst;
-#[doc = "clk_u1_i2stx_4ch1_bclk_mst_inv (rw) register accessor: U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst_inv`]
+#[doc = "clk_u1_i2stx_4ch1_bclk_mst_inv (rw) register accessor: U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_4ch1_bclk_mst_inv`]
 module"]
 pub type CLK_U1_I2STX_4CH1_BCLK_MST_INV =
     crate::Reg<clk_u1_i2stx_4ch1_bclk_mst_inv::CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC>;
 #[doc = "U1 Clock I2S TX 1 BCLK MST Inverter"]
 pub mod clk_u1_i2stx_4ch1_bclk_mst_inv;
-#[doc = "clk_i2stx1_lrck_mst (rw) register accessor: Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx1_lrck_mst`]
+#[doc = "clk_i2stx1_lrck_mst (rw) register accessor: Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2stx1_lrck_mst`]
 module"]
 pub type CLK_I2STX1_LRCK_MST = crate::Reg<clk_i2stx1_lrck_mst::CLK_I2STX1_LRCK_MST_SPEC>;
 #[doc = "Clock I2S TX 1 LRCK MST"]
 pub mod clk_i2stx1_lrck_mst;
-#[doc = "clk_u1_i2stx_bclk (rw) register accessor: U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk`]
+#[doc = "clk_u1_i2stx_bclk (rw) register accessor: U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk`]
 module"]
 pub type CLK_U1_I2STX_BCLK = crate::Reg<clk_u1_i2stx_bclk::CLK_U1_I2STX_BCLK_SPEC>;
 #[doc = "U1 Clock I2S TX BCLK"]
 pub mod clk_u1_i2stx_bclk;
-#[doc = "clk_u1_i2stx_bclk_neg (rw) register accessor: U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk_neg`]
+#[doc = "clk_u1_i2stx_bclk_neg (rw) register accessor: U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_bclk_neg`]
 module"]
 pub type CLK_U1_I2STX_BCLK_NEG = crate::Reg<clk_u1_i2stx_bclk_neg::CLK_U1_I2STX_BCLK_NEG_SPEC>;
 #[doc = "U1 Clock I2S TX BCLK Negative"]
 pub mod clk_u1_i2stx_bclk_neg;
-#[doc = "clk_u1_i2stx_lrck (rw) register accessor: U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_lrck`]
+#[doc = "clk_u1_i2stx_lrck (rw) register accessor: U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_u1_i2stx_lrck`]
 module"]
 pub type CLK_U1_I2STX_LRCK = crate::Reg<clk_u1_i2stx_lrck::CLK_U1_I2STX_LRCK_SPEC>;
 #[doc = "U1 Clock I2S TX LRCK"]
 pub mod clk_u1_i2stx_lrck;
-#[doc = "clk_i2s_apb (rw) register accessor: Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_apb`]
+#[doc = "clk_i2s_apb (rw) register accessor: Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_apb`]
 module"]
 pub type CLK_I2S_APB = crate::Reg<clk_i2s_apb::CLK_I2S_APB_SPEC>;
 #[doc = "Clock I2S APB"]
 pub mod clk_i2s_apb;
-#[doc = "clk_i2s_bclk_mst (rw) register accessor: Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst`]
+#[doc = "clk_i2s_bclk_mst (rw) register accessor: Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst`]
 module"]
 pub type CLK_I2S_BCLK_MST = crate::Reg<clk_i2s_bclk_mst::CLK_I2S_BCLK_MST_SPEC>;
 #[doc = "Clock I2S BCLK MST"]
 pub mod clk_i2s_bclk_mst;
-#[doc = "clk_i2s_bclk_mst_inv (rw) register accessor: Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst_inv`]
+#[doc = "clk_i2s_bclk_mst_inv (rw) register accessor: Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_mst_inv`]
 module"]
 pub type CLK_I2S_BCLK_MST_INV = crate::Reg<clk_i2s_bclk_mst_inv::CLK_I2S_BCLK_MST_INV_SPEC>;
 #[doc = "Clock I2S BCLK MST Inverter"]
 pub mod clk_i2s_bclk_mst_inv;
-#[doc = "clk_i2s_lrck_mst (rw) register accessor: Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck_mst`]
+#[doc = "clk_i2s_lrck_mst (rw) register accessor: Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck_mst`]
 module"]
 pub type CLK_I2S_LRCK_MST = crate::Reg<clk_i2s_lrck_mst::CLK_I2S_LRCK_MST_SPEC>;
 #[doc = "Clock I2S LRCK MST"]
 pub mod clk_i2s_lrck_mst;
-#[doc = "clk_i2s_bclk (rw) register accessor: Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk`]
+#[doc = "clk_i2s_bclk (rw) register accessor: Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk`]
 module"]
 pub type CLK_I2S_BCLK = crate::Reg<clk_i2s_bclk::CLK_I2S_BCLK_SPEC>;
 #[doc = "Clock I2S BCLK"]
 pub mod clk_i2s_bclk;
-#[doc = "clk_i2s_bclk_neg (rw) register accessor: Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_neg`]
+#[doc = "clk_i2s_bclk_neg (rw) register accessor: Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_bclk_neg`]
 module"]
 pub type CLK_I2S_BCLK_NEG = crate::Reg<clk_i2s_bclk_neg::CLK_I2S_BCLK_NEG_SPEC>;
 #[doc = "Clock I2S BCLK Negative"]
 pub mod clk_i2s_bclk_neg;
-#[doc = "clk_i2s_lrck (rw) register accessor: Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck`]
+#[doc = "clk_i2s_lrck (rw) register accessor: Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_i2s_lrck`]
 module"]
 pub type CLK_I2S_LRCK = crate::Reg<clk_i2s_lrck::CLK_I2S_LRCK_SPEC>;
 #[doc = "Clock I2S LRCK"]
 pub mod clk_i2s_lrck;
-#[doc = "clk_pdm_dmic (rw) register accessor: Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_dmic`]
+#[doc = "clk_pdm_dmic (rw) register accessor: Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_dmic`]
 module"]
 pub type CLK_PDM_DMIC = crate::Reg<clk_pdm_dmic::CLK_PDM_DMIC_SPEC>;
 #[doc = "Clock PDM DMIC"]
 pub mod clk_pdm_dmic;
-#[doc = "clk_pdm_apb (rw) register accessor: Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_apb`]
+#[doc = "clk_pdm_apb (rw) register accessor: Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_pdm_apb`]
 module"]
 pub type CLK_PDM_APB = crate::Reg<clk_pdm_apb::CLK_PDM_APB_SPEC>;
 #[doc = "Clock PDM APB"]
 pub mod clk_pdm_apb;
-#[doc = "clk_tdm_ahb (rw) register accessor: Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_ahb`]
+#[doc = "clk_tdm_ahb (rw) register accessor: Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_ahb`]
 module"]
 pub type CLK_TDM_AHB = crate::Reg<clk_tdm_ahb::CLK_TDM_AHB_SPEC>;
 #[doc = "Clock TDM AHB"]
 pub mod clk_tdm_ahb;
-#[doc = "clk_tdm_apb (rw) register accessor: Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_apb`]
+#[doc = "clk_tdm_apb (rw) register accessor: Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_apb`]
 module"]
 pub type CLK_TDM_APB = crate::Reg<clk_tdm_apb::CLK_TDM_APB_SPEC>;
 #[doc = "Clock TDM APB"]
 pub mod clk_tdm_apb;
-#[doc = "clk_tdm_internal (rw) register accessor: Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_internal`]
+#[doc = "clk_tdm_internal (rw) register accessor: Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_internal`]
 module"]
 pub type CLK_TDM_INTERNAL = crate::Reg<clk_tdm_internal::CLK_TDM_INTERNAL_SPEC>;
 #[doc = "Clock TDM Internal"]
 pub mod clk_tdm_internal;
-#[doc = "clk_tdm (rw) register accessor: Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm`]
+#[doc = "clk_tdm (rw) register accessor: Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm`]
 module"]
 pub type CLK_TDM = crate::Reg<clk_tdm::CLK_TDM_SPEC>;
 #[doc = "Clock TDM"]
 pub mod clk_tdm;
-#[doc = "clk_tdm_neg (rw) register accessor: Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_neg`]
+#[doc = "clk_tdm_neg (rw) register accessor: Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_tdm_neg`]
 module"]
 pub type CLK_TDM_NEG = crate::Reg<clk_tdm_neg::CLK_TDM_NEG_SPEC>;
 #[doc = "Clock TDM Negative"]
 pub mod clk_tdm_neg;
-#[doc = "clk_jtag_cert_trng (rw) register accessor: Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jtag_cert_trng`]
+#[doc = "clk_jtag_cert_trng (rw) register accessor: Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@clk_jtag_cert_trng`]
 module"]
 pub type CLK_JTAG_CERT_TRNG = crate::Reg<clk_jtag_cert_trng::CLK_JTAG_CERT_TRNG_SPEC>;
 #[doc = "Clock JTAG Certification TRNG"]
 pub mod clk_jtag_cert_trng;
-#[doc = "soft_rst0_addr_sel (rw) register accessor: Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst0_addr_sel`]
+#[doc = "soft_rst0_addr_sel (rw) register accessor: Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst0_addr_sel`]
 module"]
 pub type SOFT_RST0_ADDR_SEL = crate::Reg<soft_rst0_addr_sel::SOFT_RST0_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 0 Address Selector"]
 pub mod soft_rst0_addr_sel;
-#[doc = "soft_rst1_addr_sel (rw) register accessor: Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst1_addr_sel`]
+#[doc = "soft_rst1_addr_sel (rw) register accessor: Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst1_addr_sel`]
 module"]
 pub type SOFT_RST1_ADDR_SEL = crate::Reg<soft_rst1_addr_sel::SOFT_RST1_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 1 Address Selector"]
 pub mod soft_rst1_addr_sel;
-#[doc = "soft_rst2_addr_sel (rw) register accessor: Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst2_addr_sel`]
+#[doc = "soft_rst2_addr_sel (rw) register accessor: Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst2_addr_sel`]
 module"]
 pub type SOFT_RST2_ADDR_SEL = crate::Reg<soft_rst2_addr_sel::SOFT_RST2_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 2 Address Selector"]
 pub mod soft_rst2_addr_sel;
-#[doc = "soft_rst3_addr_sel (rw) register accessor: Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst3_addr_sel`]
+#[doc = "soft_rst3_addr_sel (rw) register accessor: Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@soft_rst3_addr_sel`]
 module"]
 pub type SOFT_RST3_ADDR_SEL = crate::Reg<soft_rst3_addr_sel::SOFT_RST3_ADDR_SEL_SPEC>;
 #[doc = "Software RESET 3 Address Selector"]
 pub mod soft_rst3_addr_sel;
-#[doc = "syscrg_rst0_status (rw) register accessor: SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst0_status`]
+#[doc = "syscrg_rst0_status (rw) register accessor: SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst0_status`]
 module"]
 pub type SYSCRG_RST0_STATUS = crate::Reg<syscrg_rst0_status::SYSCRG_RST0_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 0"]
 pub mod syscrg_rst0_status;
-#[doc = "syscrg_rst1_status (rw) register accessor: SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst1_status`]
+#[doc = "syscrg_rst1_status (rw) register accessor: SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst1_status`]
 module"]
 pub type SYSCRG_RST1_STATUS = crate::Reg<syscrg_rst1_status::SYSCRG_RST1_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 1"]
 pub mod syscrg_rst1_status;
-#[doc = "syscrg_rst2_status (rw) register accessor: SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst2_status`]
+#[doc = "syscrg_rst2_status (rw) register accessor: SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst2_status`]
 module"]
 pub type SYSCRG_RST2_STATUS = crate::Reg<syscrg_rst2_status::SYSCRG_RST2_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 2"]
 pub mod syscrg_rst2_status;
-#[doc = "syscrg_rst3_status (rw) register accessor: SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`].  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst3_status`]
+#[doc = "syscrg_rst3_status (rw) register accessor: SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@syscrg_rst3_status`]
 module"]
 pub type SYSCRG_RST3_STATUS = crate::Reg<syscrg_rst3_status::SYSCRG_RST3_STATUS_SPEC>;
 #[doc = "SYSCRG RESET Status 3"]

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_ahb0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_ahb0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AHB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB0_SPEC;
 impl crate::RegisterSpec for CLK_AHB0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB0_SPEC {}
 impl crate::Writable for CLK_AHB0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb0 to value 0"]
+impl crate::Resettable for CLK_AHB0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_ahb1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_ahb1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AHB 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ahb1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ahb1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AHB1_SPEC;
 impl crate::RegisterSpec for CLK_AHB1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AHB1_SPEC {}
 impl crate::Writable for CLK_AHB1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ahb1 to value 0"]
+impl crate::Resettable for CLK_AHB1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_apb0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_apb0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock APB 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_APB0_SPEC;
 impl crate::RegisterSpec for CLK_APB0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_APB0_SPEC {}
 impl crate::Writable for CLK_APB0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_apb0 to value 0"]
+impl crate::Resettable for CLK_APB0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_apb_bus.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_apb_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock APB Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_apb_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_apb_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_APB_BUS_SPEC;
 impl crate::RegisterSpec for CLK_APB_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_APB_BUS_SPEC {}
 impl crate::Writable for CLK_APB_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_apb_bus to value 0"]
+impl crate::Resettable for CLK_APB_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_audio_root.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_audio_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Audio Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_audio_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_audio_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AUDIO_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_AUDIO_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AUDIO_ROOT_SPEC {}
 impl crate::Writable for CLK_AUDIO_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_audio_root to value 0"]
+impl crate::Resettable for CLK_AUDIO_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Configuration 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0 to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_hifi4.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_hifi4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC HIFI4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_hifi4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_hifi4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_HIFI4_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_hifi4 to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_HIFI4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_main.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_MAIN_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_main to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_main_div.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_axi_cfg0_dec_main_div.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXI Config 0 DEC Main Divider\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_axi_cfg0_dec_main_div::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_axi_cfg0_dec_main_div::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC;
 impl crate::RegisterSpec for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {}
 impl crate::Writable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_axi_cfg0_dec_main_div to value 0"]
+impl crate::Resettable for CLK_AXI_CFG0_DEC_MAIN_DIV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_aximem_128b_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_aximem_128b_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock AXIMEM 128B AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_aximem_128b_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_aximem_128b_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_AXIMEM_128B_AXI_SPEC;
 impl crate::RegisterSpec for CLK_AXIMEM_128B_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_AXIMEM_128B_AXI_SPEC {}
 impl crate::Writable for CLK_AXIMEM_128B_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_aximem_128b_axi to value 0"]
+impl crate::Resettable for CLK_AXIMEM_128B_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_bus_root.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_bus_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Bus Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_bus_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_bus_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_BUS_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_BUS_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_BUS_ROOT_SPEC {}
 impl crate::Writable for CLK_BUS_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_bus_root to value 0"]
+impl crate::Resettable for CLK_BUS_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_APB_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CODAJ12_APB_SPEC {}
 impl crate::Writable for CLK_CODAJ12_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_apb to value 0"]
+impl crate::Resettable for CLK_CODAJ12_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_AXI_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CODAJ12_AXI_SPEC {}
 impl crate::Writable for CLK_CODAJ12_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_axi to value 0"]
+impl crate::Resettable for CLK_CODAJ12_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_codaj12_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "CODAJ12 Clock Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_codaj12_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_codaj12_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CODAJ12_CORE_SPEC;
 impl crate::RegisterSpec for CLK_CODAJ12_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_CODAJ12_CORE_SPEC {}
 impl crate::Writable for CLK_CODAJ12_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_codaj12_core to value 0"]
+impl crate::Resettable for CLK_CODAJ12_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_bus.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_BUS_SPEC;
 impl crate::RegisterSpec for CLK_CPU_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_BUS_SPEC {}
 impl crate::Writable for CLK_CPU_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_bus to value 0"]
+impl crate::Resettable for CLK_CPU_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_CORE_SPEC;
 impl crate::RegisterSpec for CLK_CPU_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_CORE_SPEC {}
 impl crate::Writable for CLK_CPU_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_core to value 0"]
+impl crate::Resettable for CLK_CPU_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_root.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_cpu_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock CPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_cpu_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_cpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_CPU_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_CPU_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_CPU_ROOT_SPEC {}
 impl crate::Writable for CLK_CPU_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_cpu_root to value 0"]
+impl crate::Resettable for CLK_CPU_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_ddr_bus.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_ddr_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_ddr_bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_ddr_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_ddr_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_DDR_BUS_SPEC;
 impl crate::RegisterSpec for CLK_DDR_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_DDR_BUS_SPEC {}
 impl crate::Writable for CLK_DDR_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_ddr_bus to value 0"]
+impl crate::Resettable for CLK_DDR_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gclk0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gclk0.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK0_SPEC;
 impl crate::RegisterSpec for CLK_GCLK0_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK0_SPEC {}
 impl crate::Writable for CLK_GCLK0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk0 to value 0"]
+impl crate::Resettable for CLK_GCLK0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gclk1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gclk1.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK1_SPEC;
 impl crate::RegisterSpec for CLK_GCLK1_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK1_SPEC {}
 impl crate::Writable for CLK_GCLK1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk1 to value 0"]
+impl crate::Resettable for CLK_GCLK1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gclk2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gclk2.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GCLK 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gclk2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gclk2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GCLK2_SPEC;
 impl crate::RegisterSpec for CLK_GCLK2_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GCLK2_SPEC {}
 impl crate::Writable for CLK_GCLK2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gclk2 to value 0"]
+impl crate::Resettable for CLK_GCLK2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_gtx.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_gtx.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_GTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_GTX_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC0_GTX_SPEC {}
 impl crate::Writable for CLK_GMAC0_GTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_gtx to value 0"]
+impl crate::Resettable for CLK_GMAC0_GTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_gtxclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_gtxclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_gtxclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_GTXCLK_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_GTXCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC0_GTXCLK_SPEC {}
 impl crate::Writable for CLK_GMAC0_GTXCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_gtxclk to value 0"]
+impl crate::Resettable for CLK_GMAC0_GTXCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_ptp.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac0_ptp.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 0 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac0_ptp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac0_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC0_PTP_SPEC;
 impl crate::RegisterSpec for CLK_GMAC0_PTP_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC0_PTP_SPEC {}
 impl crate::Writable for CLK_GMAC0_PTP_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac0_ptp to value 0"]
+impl crate::Resettable for CLK_GMAC0_PTP_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_gtx.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_gtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 GTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_GTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_GTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_GTX_SPEC {}
 impl crate::Writable for CLK_GMAC1_GTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_gtx to value 0"]
+impl crate::Resettable for CLK_GMAC1_GTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_gtxclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_gtxclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 GTXC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_gtxclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_gtxclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_GTXCLK_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_GTXCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_GTXCLK_SPEC {}
 impl crate::Writable for CLK_GMAC1_GTXCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_gtxclk to value 0"]
+impl crate::Resettable for CLK_GMAC1_GTXCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_rmii_rtx.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac1_rmii_rtx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 1 RMII RTX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac1_rmii_rtx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac1_rmii_rtx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC1_RMII_RTX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC1_RMII_RTX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC1_RMII_RTX_SPEC {}
 impl crate::Writable for CLK_GMAC1_RMII_RTX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac1_rmii_rtx to value 0"]
+impl crate::Resettable for CLK_GMAC1_RMII_RTX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_AHB_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_AHB_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_ahb to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_AXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_AXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_axi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_ptp.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_ptp.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 PTP\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_ptp::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_ptp::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_PTP_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_PTP_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_PTP_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_PTP_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_ptp to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_PTP_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_rx.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_rx.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 RX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RX_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_rxi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_rxi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 RX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_rxi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_rxi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_RXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_RXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_RXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_RXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_rxi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_RXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_tx.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_tx.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 TX\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_tx::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_tx::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TX_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TX_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TX_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TX_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_tx to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TX_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_txi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac5_axi64_txi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC 5 AXI 64 TX Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac5_axi64_txi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac5_axi64_txi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC5_AXI64_TXI_SPEC;
 impl crate::RegisterSpec for CLK_GMAC5_AXI64_TXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC5_AXI64_TXI_SPEC {}
 impl crate::Writable for CLK_GMAC5_AXI64_TXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac5_axi64_txi to value 0"]
+impl crate::Resettable for CLK_GMAC5_AXI64_TXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac_phy.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac_phy.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC PHY\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_phy::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC_PHY_SPEC;
 impl crate::RegisterSpec for CLK_GMAC_PHY_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_GMAC_PHY_SPEC {}
 impl crate::Writable for CLK_GMAC_PHY_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac_phy to value 0"]
+impl crate::Resettable for CLK_GMAC_PHY_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gmac_src.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gmac_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GMAC Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gmac_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gmac_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GMAC_SRC_SPEC;
 impl crate::RegisterSpec for CLK_GMAC_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GMAC_SRC_SPEC {}
 impl crate::Writable for CLK_GMAC_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gmac_src to value 0"]
+impl crate::Resettable for CLK_GMAC_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gpu_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gpu_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_gpu_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GPU_CORE_SPEC;
 impl crate::RegisterSpec for CLK_GPU_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GPU_CORE_SPEC {}
 impl crate::Writable for CLK_GPU_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gpu_core to value 0"]
+impl crate::Resettable for CLK_GPU_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_gpu_root.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_gpu_root.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock GPU Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_gpu_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_gpu_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_GPU_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_GPU_ROOT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_GPU_ROOT_SPEC {}
 impl crate::Writable for CLK_GPU_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_gpu_root to value 0"]
+impl crate::Resettable for CLK_GPU_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_hifi4_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_hifi4_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_hifi4_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_AXI_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_AXI_SPEC {}
 impl crate::Writable for CLK_HIFI4_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_axi to value 0"]
+impl crate::Resettable for CLK_HIFI4_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_hifi4_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_hifi4_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_hifi4_core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_hifi4_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_hifi4_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_HIFI4_CORE_SPEC;
 impl crate::RegisterSpec for CLK_HIFI4_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_HIFI4_CORE_SPEC {}
 impl crate::Writable for CLK_HIFI4_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_hifi4_core to value 0"]
+impl crate::Resettable for CLK_HIFI4_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_APB_SPEC;
 impl crate::RegisterSpec for CLK_I2S_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_APB_SPEC {}
 impl crate::Writable for CLK_I2S_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_apb to value 0"]
+impl crate::Resettable for CLK_I2S_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2S_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_mst to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_mst_inv.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_neg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_I2S_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_I2S_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_bclk_neg to value 0"]
+impl crate::Resettable for CLK_I2S_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_lrck.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_I2S_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_I2S_LRCK_SPEC {}
 impl crate::Writable for CLK_I2S_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_lrck to value 0"]
+impl crate::Resettable for CLK_I2S_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_lrck_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2s_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2s_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2s_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2S_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2S_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2S_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2S_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2s_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2S_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2stx0_lrck_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2stx0_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S TX 0 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx0_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx0_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2STX0_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2STX0_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2STX0_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2STX0_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2stx0_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2STX0_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_i2stx1_lrck_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_i2stx1_lrck_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock I2S TX 1 LRCK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_i2stx1_lrck_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_i2stx1_lrck_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_I2STX1_LRCK_MST_SPEC;
 impl crate::RegisterSpec for CLK_I2STX1_LRCK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_I2STX1_LRCK_MST_SPEC {}
 impl crate::Writable for CLK_I2STX1_LRCK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_i2stx1_lrck_mst to value 0"]
+impl crate::Resettable for CLK_I2STX1_LRCK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_internal_ctrl_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_internal_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Internal Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_internal_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_internal_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_INTERNAL_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_INTERNAL_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_INTERNAL_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_INTERNAL_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_internal_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_INTERNAL_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_isp_2x.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_isp_2x.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock ISP 2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_2x::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_ISP_2X_SPEC;
 impl crate::RegisterSpec for CLK_ISP_2X_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_ISP_2X_SPEC {}
 impl crate::Writable for CLK_ISP_2X_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_isp_2x to value 0"]
+impl crate::Resettable for CLK_ISP_2X_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_isp_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock ISP AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_jpeg_codec_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_jpeg_codec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock JPEG Codec AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jpeg_codec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jpeg_codec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_JPEG_CODEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_JPEG_CODEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_JPEG_CODEC_AXI_SPEC {}
 impl crate::Writable for CLK_JPEG_CODEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_jpeg_codec_axi to value 0"]
+impl crate::Resettable for CLK_JPEG_CODEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_jtag_cert_trng.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_jtag_cert_trng.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock JTAG Certification TRNG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_jtag_cert_trng::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_jtag_cert_trng::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_JTAG_CERT_TRNG_SPEC;
 impl crate::RegisterSpec for CLK_JTAG_CERT_TRNG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_JTAG_CERT_TRNG_SPEC {}
 impl crate::Writable for CLK_JTAG_CERT_TRNG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_jtag_cert_trng to value 0"]
+impl crate::Resettable for CLK_JTAG_CERT_TRNG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_mbox_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_mbox_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Mailbox APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mbox_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mbox_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MBOX_APB_SPEC;
 impl crate::RegisterSpec for CLK_MBOX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MBOX_APB_SPEC {}
 impl crate::Writable for CLK_MBOX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mbox_apb to value 0"]
+impl crate::Resettable for CLK_MBOX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_mclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_mclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_SPEC {}
 impl crate::Writable for CLK_MCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk to value 0"]
+impl crate::Resettable for CLK_MCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_mclk_inner.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_mclk_inner.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK Inner\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_inner::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_inner::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_INNER_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_INNER_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_INNER_SPEC {}
 impl crate::Writable for CLK_MCLK_INNER_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk_inner to value 0"]
+impl crate::Resettable for CLK_MCLK_INNER_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_mclk_out.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_mclk_out.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock MCLK Out\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_mclk_out::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_mclk_out::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_MCLK_OUT_SPEC;
 impl crate::RegisterSpec for CLK_MCLK_OUT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_MCLK_OUT_SPEC {}
 impl crate::Writable for CLK_MCLK_OUT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_mclk_out to value 0"]
+impl crate::Resettable for CLK_MCLK_OUT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_noc_display_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_noc_display_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Display AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_display_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_display_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_DISPLAY_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_DISPLAY_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_DISPLAY_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_DISPLAY_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_display_axi to value 0"]
+impl crate::Resettable for CLK_NOC_DISPLAY_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_noc_stg_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_noc_stg_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC STG AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_stg_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_stg_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_STG_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_STG_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_STG_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_STG_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_stg_axi to value 0"]
+impl crate::Resettable for CLK_NOC_STG_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_noc_vdec_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_noc_vdec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_vdec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_VDEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_VDEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_VDEC_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_VDEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_vdec_axi to value 0"]
+impl crate::Resettable for CLK_NOC_VDEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_noc_venc_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_noc_venc_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOC Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_noc_venc_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_noc_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOC_VENC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_NOC_VENC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOC_VENC_AXI_SPEC {}
 impl crate::Writable for CLK_NOC_VENC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_noc_venc_axi to value 0"]
+impl crate::Resettable for CLK_NOC_VENC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_nocstg_bus.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_nocstg_bus.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock NOCSTG Bus\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_nocstg_bus::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_nocstg_bus::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_NOCSTG_BUS_SPEC;
 impl crate::RegisterSpec for CLK_NOCSTG_BUS_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_NOCSTG_BUS_SPEC {}
 impl crate::Writable for CLK_NOCSTG_BUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_nocstg_bus to value 0"]
+impl crate::Resettable for CLK_NOCSTG_BUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_osc_div2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_osc_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_osc_div2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_osc_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_osc_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_OSC_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_OSC_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_OSC_DIV2_SPEC {}
 impl crate::Writable for CLK_OSC_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_osc_div2 to value 0"]
+impl crate::Resettable for CLK_OSC_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pdm_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pdm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PDM_APB_SPEC;
 impl crate::RegisterSpec for CLK_PDM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PDM_APB_SPEC {}
 impl crate::Writable for CLK_PDM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pdm_apb to value 0"]
+impl crate::Resettable for CLK_PDM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pdm_dmic.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pdm_dmic.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PDM DMIC\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pdm_dmic::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pdm_dmic::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PDM_DMIC_SPEC;
 impl crate::RegisterSpec for CLK_PDM_DMIC_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PDM_DMIC_SPEC {}
 impl crate::Writable for CLK_PDM_DMIC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pdm_dmic to value 0"]
+impl crate::Resettable for CLK_PDM_DMIC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_peripheral_root.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_peripheral_root.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Peripheral Root\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_peripheral_root::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_peripheral_root::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PERIPHERAL_ROOT_SPEC;
 impl crate::RegisterSpec for CLK_PERIPHERAL_ROOT_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PERIPHERAL_ROOT_SPEC {}
 impl crate::Writable for CLK_PERIPHERAL_ROOT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_peripheral_root to value 0"]
+impl crate::Resettable for CLK_PERIPHERAL_ROOT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pll0_div2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pll0_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 0 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll0_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll0_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL0_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL0_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL0_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL0_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll0_div2 to value 0"]
+impl crate::Resettable for CLK_PLL0_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 1 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div2 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div4.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_pll1_div4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV4_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV4_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div4 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div8.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pll1_div8.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_pll1_div8\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll1_div8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll1_div8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL1_DIV8_SPEC;
 impl crate::RegisterSpec for CLK_PLL1_DIV8_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL1_DIV8_SPEC {}
 impl crate::Writable for CLK_PLL1_DIV8_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll1_div8 to value 0"]
+impl crate::Resettable for CLK_PLL1_DIV8_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pll2_div2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pll2_div2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PLL 2 Divider 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pll2_div2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pll2_div2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PLL2_DIV2_SPEC;
 impl crate::RegisterSpec for CLK_PLL2_DIV2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PLL2_DIV2_SPEC {}
 impl crate::Writable for CLK_PLL2_DIV2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pll2_div2 to value 0"]
+impl crate::Resettable for CLK_PLL2_DIV2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pwm_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pwm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWM_APB_SPEC;
 impl crate::RegisterSpec for CLK_PWM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PWM_APB_SPEC {}
 impl crate::Writable for CLK_PWM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwm_apb to value 0"]
+impl crate::Resettable for CLK_PWM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pwmdac_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pwmdac_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWMDAC APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWMDAC_APB_SPEC;
 impl crate::RegisterSpec for CLK_PWMDAC_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_PWMDAC_APB_SPEC {}
 impl crate::Writable for CLK_PWMDAC_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwmdac_apb to value 0"]
+impl crate::Resettable for CLK_PWMDAC_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_pwmdac_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_pwmdac_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock PWMDAC Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_pwmdac_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_pwmdac_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_PWMDAC_CORE_SPEC;
 impl crate::RegisterSpec for CLK_PWMDAC_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_PWMDAC_CORE_SPEC {}
 impl crate::Writable for CLK_PWMDAC_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_pwmdac_core to value 0"]
+impl crate::Resettable for CLK_PWMDAC_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_AHB_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_AHB_SPEC {}
 impl crate::Writable for CLK_QSPI_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ahb to value 0"]
+impl crate::Resettable for CLK_QSPI_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_APB_SPEC {}
 impl crate::Writable for CLK_QSPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_apb to value 0"]
+impl crate::Resettable for CLK_QSPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ref.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ref.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_REF_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_REF_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_QSPI_REF_SPEC {}
 impl crate::Writable for CLK_QSPI_REF_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ref to value 0"]
+impl crate::Resettable for CLK_QSPI_REF_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ref_src.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_qspi_ref_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock QSPI Reference Source\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_qspi_ref_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_qspi_ref_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_QSPI_REF_SRC_SPEC;
 impl crate::RegisterSpec for CLK_QSPI_REF_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_QSPI_REF_SRC_SPEC {}
 impl crate::Writable for CLK_QSPI_REF_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_qspi_ref_src to value 0"]
+impl crate::Resettable for CLK_QSPI_REF_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_spdif_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_spdif_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SPDIF APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SPDIF_APB_SPEC;
 impl crate::RegisterSpec for CLK_SPDIF_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SPDIF_APB_SPEC {}
 impl crate::Writable for CLK_SPDIF_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_spdif_apb to value 0"]
+impl crate::Resettable for CLK_SPDIF_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_spdif_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_spdif_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SPDIF Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_spdif_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_spdif_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SPDIF_CORE_SPEC;
 impl crate::RegisterSpec for CLK_SPDIF_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SPDIF_CORE_SPEC {}
 impl crate::Writable for CLK_SPDIF_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_spdif_core to value 0"]
+impl crate::Resettable for CLK_SPDIF_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_stg_axiahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_stg_axiahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock STG AXI AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_stg_axiahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_stg_axiahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_STG_AXIAHB_SPEC;
 impl crate::RegisterSpec for CLK_STG_AXIAHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_STG_AXIAHB_SPEC {}
 impl crate::Writable for CLK_STG_AXIAHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_stg_axiahb to value 0"]
+impl crate::Resettable for CLK_STG_AXIAHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_sys_iomux_pclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_sys_iomux_pclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock SYS IOMUX PCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_sys_iomux_pclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_sys_iomux_pclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_SYS_IOMUX_PCLK_SPEC;
 impl crate::RegisterSpec for CLK_SYS_IOMUX_PCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_SYS_IOMUX_PCLK_SPEC {}
 impl crate::Writable for CLK_SYS_IOMUX_PCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_sys_iomux_pclk to value 0"]
+impl crate::Resettable for CLK_SYS_IOMUX_PCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tdm.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tdm.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_SPEC;
 impl crate::RegisterSpec for CLK_TDM_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_SPEC {}
 impl crate::Writable for CLK_TDM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm to value 0"]
+impl crate::Resettable for CLK_TDM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_AHB_SPEC;
 impl crate::RegisterSpec for CLK_TDM_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_AHB_SPEC {}
 impl crate::Writable for CLK_TDM_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_ahb to value 0"]
+impl crate::Resettable for CLK_TDM_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_APB_SPEC;
 impl crate::RegisterSpec for CLK_TDM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_APB_SPEC {}
 impl crate::Writable for CLK_TDM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_apb to value 0"]
+impl crate::Resettable for CLK_TDM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_internal.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_internal.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM Internal\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_internal::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_internal::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_INTERNAL_SPEC;
 impl crate::RegisterSpec for CLK_TDM_INTERNAL_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_TDM_INTERNAL_SPEC {}
 impl crate::Writable for CLK_TDM_INTERNAL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_internal to value 0"]
+impl crate::Resettable for CLK_TDM_INTERNAL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_neg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tdm_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock TDM Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tdm_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tdm_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TDM_NEG_SPEC;
 impl crate::RegisterSpec for CLK_TDM_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TDM_NEG_SPEC {}
 impl crate::Writable for CLK_TDM_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tdm_neg to value 0"]
+impl crate::Resettable for CLK_TDM_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_temp_sensor.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_temp_sensor.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Temperature Sensor\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TEMP_SENSOR_SPEC;
 impl crate::RegisterSpec for CLK_TEMP_SENSOR_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_TEMP_SENSOR_SPEC {}
 impl crate::Writable for CLK_TEMP_SENSOR_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_temp_sensor to value 0"]
+impl crate::Resettable for CLK_TEMP_SENSOR_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_temp_sensor_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_temp_sensor_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Temperature Sensor APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_temp_sensor_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_temp_sensor_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TEMP_SENSOR_APB_SPEC;
 impl crate::RegisterSpec for CLK_TEMP_SENSOR_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TEMP_SENSOR_APB_SPEC {}
 impl crate::Writable for CLK_TEMP_SENSOR_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_temp_sensor_apb to value 0"]
+impl crate::Resettable for CLK_TEMP_SENSOR_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tim0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tim0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM0_SPEC;
 impl crate::RegisterSpec for CLK_TIM0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM0_SPEC {}
 impl crate::Writable for CLK_TIM0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim0 to value 0"]
+impl crate::Resettable for CLK_TIM0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tim1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tim1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM1_SPEC;
 impl crate::RegisterSpec for CLK_TIM1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM1_SPEC {}
 impl crate::Writable for CLK_TIM1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim1 to value 0"]
+impl crate::Resettable for CLK_TIM1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tim2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tim2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM2_SPEC;
 impl crate::RegisterSpec for CLK_TIM2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM2_SPEC {}
 impl crate::Writable for CLK_TIM2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim2 to value 0"]
+impl crate::Resettable for CLK_TIM2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tim3.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tim3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM3_SPEC;
 impl crate::RegisterSpec for CLK_TIM3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM3_SPEC {}
 impl crate::Writable for CLK_TIM3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim3 to value 0"]
+impl crate::Resettable for CLK_TIM3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_tim_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_tim_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Timer APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_tim_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_tim_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_TIM_APB_SPEC;
 impl crate::RegisterSpec for CLK_TIM_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_TIM_APB_SPEC {}
 impl crate::Writable for CLK_TIM_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_tim_apb to value 0"]
+impl crate::Resettable for CLK_TIM_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_axi_cfg1_dec_clk_ahb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {}
 impl crate::Writable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_axi_cfg1_dec_clk_ahb to value 0"]
+impl crate::Resettable for CLK_U0_AXI_CFG1_DEC_CLK_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_main.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_axi_cfg1_dec_clk_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_axi_cfg1_dec_clk_main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_axi_cfg1_dec_clk_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_axi_cfg1_dec_clk_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {}
 impl crate::Writable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_axi_cfg1_dec_clk_main to value 0"]
+impl crate::Resettable for CLK_U0_AXI_CFG1_DEC_CLK_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_can.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_can.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_can::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_CAN_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_CAN_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_CAN_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_CAN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_can to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_CAN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_tim.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_can_ctrl_tim.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_can_ctrl_tim::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_CAN_CTRL_TIM_SPEC;
 impl crate::RegisterSpec for CLK_U0_CAN_CTRL_TIM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_CAN_CTRL_TIM_SPEC {}
 impl crate::Writable for CLK_U0_CAN_CTRL_TIM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_can_ctrl_tim to value 0"]
+impl crate::Resettable for CLK_U0_CAN_CTRL_TIM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_ddr_sft7110_clk_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_ddr_sft7110_clk_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_ddr_sfft7110_clk_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_ddr_sft7110_clk_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_ddr_sft7110_clk_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DDR_SFT7110_CLK_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {}
 impl crate::Writable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_ddr_sft7110_clk_axi to value 0"]
+impl crate::Resettable for CLK_U0_DDR_SFT7110_CLK_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_isp_top_clk_dom_isp_top_clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC 
 impl crate::Writable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_isp_top_clk_dom_isp_top_clk_ispcore_2x to value 0"]
+impl crate::Resettable for CLK_U0_DOM_ISP_TOP_CLK_DOM_ISP_TOP_CLK_ISPCORE_2X_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC;
 impl crate::RegisterSpec for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC 
 impl crate::Writable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_dom_vout_top_clk_dom_vout_top_clk_vout_src to value 0"]
+impl crate::Resettable for CLK_U0_DOM_VOUT_TOP_CLK_DOM_VOUT_TOP_CLK_VOUT_SRC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_gpu_rtc_toggle.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_gpu_rtc_toggle.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_gpu_rtc_toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_gpu_rtc_toggle::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_gpu_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_GPU_RTC_TOGGLE_SPEC;
 impl crate::RegisterSpec for CLK_U0_GPU_RTC_TOGGLE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_GPU_RTC_TOGGLE_SPEC {}
 impl crate::Writable for CLK_U0_GPU_RTC_TOGGLE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_gpu_rtc_toggle to value 0"]
+impl crate::Resettable for CLK_U0_GPU_RTC_TOGGLE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U0_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U0_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2s_tx_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2s_tx_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2s_tx_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2S_TX_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2S_TX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2S_TX_APB_SPEC {}
 impl crate::Writable for CLK_U0_I2S_TX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2s_tx_apb to value 0"]
+impl crate::Resettable for CLK_U0_I2S_TX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX 0 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_4CH0_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_4ch0_bclk_mst to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_4CH0_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst_inv.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_4ch0_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX 0 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_4ch0_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_4ch0_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_4ch0_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_4CH0_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_bclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_BCLK_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_bclk to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_bclk_neg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_bclk_neg to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_lrck.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_i2stx_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_i2stx_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_I2STX_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_U0_I2STX_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_I2STX_LRCK_SPEC {}
 impl crate::Writable for CLK_U0_I2STX_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_i2stx_lrck to value 0"]
+impl crate::Resettable for CLK_U0_I2STX_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_clk_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_clk_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_clk_apb\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_clk_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_clk_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_CLK_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_CLK_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_CLK_APB_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_CLK_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_clk_apb to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_CLK_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_core_clk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_core_clk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_core_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_core_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_core_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_CORE_CLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_core_clk to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_CORE_CLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_sys_clk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_img_gpu_sys_clk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_img_gpu_sys_clk\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_img_gpu_sys_clk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_img_gpu_sys_clk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_IMG_GPU_SYS_CLK_SPEC;
 impl crate::RegisterSpec for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {}
 impl crate::Writable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_img_gpu_sys_clk to value 0"]
+impl crate::Resettable for CLK_U0_IMG_GPU_SYS_CLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sd_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sd_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SD_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U0_SD_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SD_AHB_SPEC {}
 impl crate::Writable for CLK_U0_SD_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sd_ahb to value 0"]
+impl crate::Resettable for CLK_U0_SD_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sd_card.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sd_card.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sd_card::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SD_CARD_SPEC;
 impl crate::RegisterSpec for CLK_U0_SD_CARD_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U0_SD_CARD_SPEC {}
 impl crate::Writable for CLK_U0_SD_CARD_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sd_card to value 0"]
+impl crate::Resettable for CLK_U0_SD_CARD_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_axicfg0_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_axicfg0_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_axicfg0_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_axicfg0_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_axicfg0_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_AXICFG0_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_cpu_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_cpu_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_cpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_cpu_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_cpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_cpu_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_CPU_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_gpu_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bus_clk_gpu_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bus_clk_gpu_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bus_clk_gpu_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bus_clk_gpu_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bus_clk_gpu_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUS_CLK_GPU_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bux_clk_isp_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_sft7110_noc_bux_clk_isp_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "clk_u0_sft7110_noc_bux_clk_isp_axi\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_sft7110_noc_bux_clk_isp_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_sft7110_noc_bux_clk_isp_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC;
 impl crate::RegisterSpec for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {}
 impl crate::Writable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_sft7110_noc_bux_clk_isp_axi to value 0"]
+impl crate::Resettable for CLK_U0_SFT7110_NOC_BUX_CLK_ISP_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U0_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_spi_apb to value 0"]
+impl crate::Resettable for CLK_U0_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U0_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_UART_APB_SPEC {}
 impl crate::Writable for CLK_U0_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_uart_apb to value 0"]
+impl crate::Resettable for CLK_U0_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u0_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u0_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U0 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u0_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u0_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U0_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U0_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U0_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U0_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u0_uart_core to value 0"]
+impl crate::Resettable for CLK_U0_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_APB_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_apb to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_can.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_can.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller CAN\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_can::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_can::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_CAN_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_CAN_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_CAN_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_CAN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_can to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_CAN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_tim.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_can_ctrl_tim.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock CAN Controller Timer\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_can_ctrl_tim::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_can_ctrl_tim::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_CAN_CTRL_TIM_SPEC;
 impl crate::RegisterSpec for CLK_U1_CAN_CTRL_TIM_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_CAN_CTRL_TIM_SPEC {}
 impl crate::Writable for CLK_U1_CAN_CTRL_TIM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_can_ctrl_tim to value 0"]
+impl crate::Resettable for CLK_U1_CAN_CTRL_TIM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U1_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U1_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2s_tx_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2s_tx_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2s_tx_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2s_tx_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2S_TX_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2S_TX_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2S_TX_APB_SPEC {}
 impl crate::Writable for CLK_U1_I2S_TX_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2s_tx_apb to value 0"]
+impl crate::Resettable for CLK_U1_I2S_TX_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX 1 BCLK MST\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_4CH1_BCLK_MST_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_4ch1_bclk_mst to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_4CH1_BCLK_MST_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst_inv.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_4ch1_bclk_mst_inv.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX 1 BCLK MST Inverter\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_4ch1_bclk_mst_inv::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_4ch1_bclk_mst_inv::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_4ch1_bclk_mst_inv to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_4CH1_BCLK_MST_INV_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_bclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_bclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX BCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_BCLK_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_BCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_BCLK_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_BCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_bclk to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_BCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_bclk_neg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_bclk_neg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX BCLK Negative\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_bclk_neg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_bclk_neg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_BCLK_NEG_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_BCLK_NEG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_BCLK_NEG_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_BCLK_NEG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_bclk_neg to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_BCLK_NEG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_lrck.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_i2stx_lrck.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock I2S TX LRCK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_i2stx_lrck::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_i2stx_lrck::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_I2STX_LRCK_SPEC;
 impl crate::RegisterSpec for CLK_U1_I2STX_LRCK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_I2STX_LRCK_SPEC {}
 impl crate::Writable for CLK_U1_I2STX_LRCK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_i2stx_lrck to value 0"]
+impl crate::Resettable for CLK_U1_I2STX_LRCK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_sd_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_sd_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 SD Clock AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SD_AHB_SPEC;
 impl crate::RegisterSpec for CLK_U1_SD_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_SD_AHB_SPEC {}
 impl crate::Writable for CLK_U1_SD_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_sd_ahb to value 0"]
+impl crate::Resettable for CLK_U1_SD_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_sd_card.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_sd_card.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 SD Card Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_sd_card::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_sd_card::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SD_CARD_SPEC;
 impl crate::RegisterSpec for CLK_U1_SD_CARD_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U1_SD_CARD_SPEC {}
 impl crate::Writable for CLK_U1_SD_CARD_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_sd_card to value 0"]
+impl crate::Resettable for CLK_U1_SD_CARD_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U1_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_spi_apb to value 0"]
+impl crate::Resettable for CLK_U1_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U1_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_UART_APB_SPEC {}
 impl crate::Writable for CLK_U1_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_uart_apb to value 0"]
+impl crate::Resettable for CLK_U1_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u1_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u1_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U1 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u1_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u1_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U1_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U1_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U1_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U1_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u1_uart_core to value 0"]
+impl crate::Resettable for CLK_U1_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u2_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u2_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U2_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U2_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u2_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u2_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U2_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_spi_apb to value 0"]
+impl crate::Resettable for CLK_U2_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u2_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u2_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U2_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_UART_APB_SPEC {}
 impl crate::Writable for CLK_U2_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_uart_apb to value 0"]
+impl crate::Resettable for CLK_U2_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u2_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u2_uart_core.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U2 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u2_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u2_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U2_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U2_UART_CORE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U2_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U2_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u2_uart_core to value 0"]
+impl crate::Resettable for CLK_U2_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u3_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u3_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U3_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U3_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u3_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u3_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U3_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_spi_apb to value 0"]
+impl crate::Resettable for CLK_U3_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u3_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u3_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U3_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U3_UART_APB_SPEC {}
 impl crate::Writable for CLK_U3_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_uart_apb to value 0"]
+impl crate::Resettable for CLK_U3_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u3_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u3_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U3 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u3_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u3_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U3_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U3_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U3_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U3_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u3_uart_core to value 0"]
+impl crate::Resettable for CLK_U3_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u4_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u4_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U4_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U4_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u4_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u4_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U4_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_spi_apb to value 0"]
+impl crate::Resettable for CLK_U4_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u4_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u4_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U4_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U4_UART_APB_SPEC {}
 impl crate::Writable for CLK_U4_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_uart_apb to value 0"]
+impl crate::Resettable for CLK_U4_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u4_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u4_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U4 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u4_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u4_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U4_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U4_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U4_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U4_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u4_uart_core to value 0"]
+impl crate::Resettable for CLK_U4_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u5_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u5_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U5_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U5_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u5_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u5_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U5_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_spi_apb to value 0"]
+impl crate::Resettable for CLK_U5_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u5_uart_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u5_uart_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock UART APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_UART_APB_SPEC;
 impl crate::RegisterSpec for CLK_U5_UART_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U5_UART_APB_SPEC {}
 impl crate::Writable for CLK_U5_UART_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_uart_apb to value 0"]
+impl crate::Resettable for CLK_U5_UART_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u5_uart_core.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u5_uart_core.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U5 Clock UART Core\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u5_uart_core::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u5_uart_core::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U5_UART_CORE_SPEC;
 impl crate::RegisterSpec for CLK_U5_UART_CORE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_U5_UART_CORE_SPEC {}
 impl crate::Writable for CLK_U5_UART_CORE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u5_uart_core to value 0"]
+impl crate::Resettable for CLK_U5_UART_CORE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u6_i2c_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u6_i2c_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U6 Clock I2C APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_i2c_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_i2c_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U6_I2C_APB_SPEC;
 impl crate::RegisterSpec for CLK_U6_I2C_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U6_I2C_APB_SPEC {}
 impl crate::Writable for CLK_U6_I2C_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u6_i2c_apb to value 0"]
+impl crate::Resettable for CLK_U6_I2C_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u6_spi_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u6_spi_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U6 Clock SPI APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u6_spi_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u6_spi_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U6_SPI_APB_SPEC;
 impl crate::RegisterSpec for CLK_U6_SPI_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U6_SPI_APB_SPEC {}
 impl crate::Writable for CLK_U6_SPI_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u6_spi_apb to value 0"]
+impl crate::Resettable for CLK_U6_SPI_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE0_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE0_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core0 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE1_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE1_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core1 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE2_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE2_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core2 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core3.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE3_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE3_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core3 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core4.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_core4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Core Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_core4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_core4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_CORE4_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_CORE4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_CORE4_SPEC {}
 impl crate::Writable for CLK_U7MC_CORE4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_core4 to value 0"]
+impl crate::Resettable for CLK_U7MC_CORE4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_debug.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_debug.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Debug Clock\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_debug::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_debug::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_DEBUG_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_DEBUG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_DEBUG_SPEC {}
 impl crate::Writable for CLK_U7MC_DEBUG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_debug to value 0"]
+impl crate::Resettable for CLK_U7MC_DEBUG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace0.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE0_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE0_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE0_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace0 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE0_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace1.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE1_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE1_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE1_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace1 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE1_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace2.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE2_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE2_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE2_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace2 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE2_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace3.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace3.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE3_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE3_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE3_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace3 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace4.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace4.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock 4\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE4_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE4_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE4_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace4 to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE4_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace_com.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_u7mc_trace_com.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC Trace Clock COM\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_u7mc_trace_com::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_u7mc_trace_com::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_U7MC_TRACE_COM_SPEC;
 impl crate::RegisterSpec for CLK_U7MC_TRACE_COM_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_U7MC_TRACE_COM_SPEC {}
 impl crate::Writable for CLK_U7MC_TRACE_COM_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_u7mc_trace_com to value 0"]
+impl crate::Resettable for CLK_U7MC_TRACE_COM_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_usb_125m.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_usb_125m.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock USB 125M\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_usb_125m::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_usb_125m::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_USB_125M_SPEC;
 impl crate::RegisterSpec for CLK_USB_125M_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_USB_125M_SPEC {}
 impl crate::Writable for CLK_USB_125M_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_usb_125m to value 0"]
+impl crate::Resettable for CLK_USB_125M_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vdec_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vdec_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Decoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vdec_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vdec_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VDEC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_VDEC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VDEC_AXI_SPEC {}
 impl crate::Writable for CLK_VDEC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vdec_axi to value 0"]
+impl crate::Resettable for CLK_VDEC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_venc_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_venc_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Encoder AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_venc_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_venc_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VENC_AXI_SPEC;
 impl crate::RegisterSpec for CLK_VENC_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VENC_AXI_SPEC {}
 impl crate::Writable for CLK_VENC_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_venc_axi to value 0"]
+impl crate::Resettable for CLK_VENC_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vout_ahb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vout_ahb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AHB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_ahb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_ahb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AHB_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AHB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AHB_SPEC {}
 impl crate::Writable for CLK_VOUT_AHB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_ahb to value 0"]
+impl crate::Resettable for CLK_VOUT_AHB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vout_axi_divcfg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vout_axi_divcfg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AXI DIVCFG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_divcfg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_divcfg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AXI_DIVCFG_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AXI_DIVCFG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AXI_DIVCFG_SPEC {}
 impl crate::Writable for CLK_VOUT_AXI_DIVCFG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_axi_divcfg to value 0"]
+impl crate::Resettable for CLK_VOUT_AXI_DIVCFG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vout_axi_icg.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vout_axi_icg.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output AXI ICG\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_axi_icg::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_axi_icg::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_AXI_ICG_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_AXI_ICG_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_AXI_ICG_SPEC {}
 impl crate::Writable for CLK_VOUT_AXI_ICG_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_axi_icg to value 0"]
+impl crate::Resettable for CLK_VOUT_AXI_ICG_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vout_hdmi_tx0_mclk.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vout_hdmi_tx0_mclk.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output HDMI TX0 MCLK\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_hdmi_tx0_mclk::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_hdmi_tx0_mclk::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_HDMI_TX0_MCLK_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {}
 impl crate::Writable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_hdmi_tx0_mclk to value 0"]
+impl crate::Resettable for CLK_VOUT_HDMI_TX0_MCLK_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_vout_mipi_phy.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_vout_mipi_phy.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock Video Output MIPI PHY Reference\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_vout_mipi_phy::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_vout_mipi_phy::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_VOUT_MIPI_PHY_SPEC;
 impl crate::RegisterSpec for CLK_VOUT_MIPI_PHY_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_VOUT_MIPI_PHY_SPEC {}
 impl crate::Writable for CLK_VOUT_MIPI_PHY_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_vout_mipi_phy to value 0"]
+impl crate::Resettable for CLK_VOUT_MIPI_PHY_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_APB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE420L_APB_SPEC {}
 impl crate::Writable for CLK_WAVE420L_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_apb to value 0"]
+impl crate::Resettable for CLK_WAVE420L_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_AXI_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE420L_AXI_SPEC {}
 impl crate::Writable for CLK_WAVE420L_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_axi to value 0"]
+impl crate::Resettable for CLK_WAVE420L_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_bpu.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_bpu.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_bpu::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_BPU_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_BPU_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE420L_BPU_SPEC {}
 impl crate::Writable for CLK_WAVE420L_BPU_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_bpu to value 0"]
+impl crate::Resettable for CLK_WAVE420L_BPU_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_vce.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave420l_vce.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE420L VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave420l_vce::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave420l_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE420L_VCE_SPEC;
 impl crate::RegisterSpec for CLK_WAVE420L_VCE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE420L_VCE_SPEC {}
 impl crate::Writable for CLK_WAVE420L_VCE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave420l_vce to value 0"]
+impl crate::Resettable for CLK_WAVE420L_VCE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_APB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_APB_SPEC {}
 impl crate::Writable for CLK_WAVE511_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_apb to value 0"]
+impl crate::Resettable for CLK_WAVE511_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_axi.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_axi.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 AXI\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_axi::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_axi::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_AXI_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_AXI_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_AXI_SPEC {}
 impl crate::Writable for CLK_WAVE511_AXI_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_axi to value 0"]
+impl crate::Resettable for CLK_WAVE511_AXI_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_bpu.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_bpu.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 BPU\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_bpu::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_bpu::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_BPU_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_BPU_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE511_BPU_SPEC {}
 impl crate::Writable for CLK_WAVE511_BPU_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_bpu to value 0"]
+impl crate::Resettable for CLK_WAVE511_BPU_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_jpg_arb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_jpg_arb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 JPG ARB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_arb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_arb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_JPG_ARB_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_JPG_ARB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_JPG_ARB_SPEC {}
 impl crate::Writable for CLK_WAVE511_JPG_ARB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_jpg_arb to value 0"]
+impl crate::Resettable for CLK_WAVE511_JPG_ARB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_jpg_main.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_jpg_main.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 JPG Main\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_jpg_main::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_jpg_main::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_JPG_MAIN_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_JPG_MAIN_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WAVE511_JPG_MAIN_SPEC {}
 impl crate::Writable for CLK_WAVE511_JPG_MAIN_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_jpg_main to value 0"]
+impl crate::Resettable for CLK_WAVE511_JPG_MAIN_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_vce.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wave511_vce.rs
@@ -46,7 +46,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WAVE511 VCE\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wave511_vce::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wave511_vce::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WAVE511_VCE_SPEC;
 impl crate::RegisterSpec for CLK_WAVE511_VCE_SPEC {
     type Ux = u32;
@@ -57,4 +57,8 @@ impl crate::Readable for CLK_WAVE511_VCE_SPEC {}
 impl crate::Writable for CLK_WAVE511_VCE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wave511_vce to value 0"]
+impl crate::Resettable for CLK_WAVE511_VCE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wdt.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wdt.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WDT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WDT_SPEC;
 impl crate::RegisterSpec for CLK_WDT_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WDT_SPEC {}
 impl crate::Writable for CLK_WDT_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wdt to value 0"]
+impl crate::Resettable for CLK_WDT_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/clk_wdt_apb.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/clk_wdt_apb.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Clock WDT APB\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`clk_wdt_apb::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`clk_wdt_apb::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct CLK_WDT_APB_SPEC;
 impl crate::RegisterSpec for CLK_WDT_APB_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for CLK_WDT_APB_SPEC {}
 impl crate::Writable for CLK_WDT_APB_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets clk_wdt_apb to value 0"]
+impl crate::Resettable for CLK_WDT_APB_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst0_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst0_addr_sel.rs
@@ -578,7 +578,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 0 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst0_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst0_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST0_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST0_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -589,4 +589,8 @@ impl crate::Readable for SOFT_RST0_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST0_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst0_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST0_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst1_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst1_addr_sel.rs
@@ -569,7 +569,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 1 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst1_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst1_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST1_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST1_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -580,4 +580,8 @@ impl crate::Readable for SOFT_RST1_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST1_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst1_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST1_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst2_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst2_addr_sel.rs
@@ -518,7 +518,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 2 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst2_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst2_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST2_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST2_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -529,4 +529,8 @@ impl crate::Readable for SOFT_RST2_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST2_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst2_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST2_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst3_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst3_addr_sel.rs
@@ -526,7 +526,7 @@ impl W {
         self
     }
 }
-#[doc = "Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "Software RESET 3 Address Selector\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`soft_rst3_addr_sel::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`soft_rst3_addr_sel::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SOFT_RST3_ADDR_SEL_SPEC;
 impl crate::RegisterSpec for SOFT_RST3_ADDR_SEL_SPEC {
     type Ux = u32;
@@ -537,4 +537,8 @@ impl crate::Readable for SOFT_RST3_ADDR_SEL_SPEC {}
 impl crate::Writable for SOFT_RST3_ADDR_SEL_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets soft_rst3_addr_sel to value 0"]
+impl crate::Resettable for SOFT_RST3_ADDR_SEL_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst0_status.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst0_status.rs
@@ -578,7 +578,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 0\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst0_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst0_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST0_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST0_STATUS_SPEC {
     type Ux = u32;
@@ -589,4 +589,8 @@ impl crate::Readable for SYSCRG_RST0_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST0_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst0_status to value 0"]
+impl crate::Resettable for SYSCRG_RST0_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst1_status.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst1_status.rs
@@ -569,7 +569,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 1\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst1_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst1_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST1_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST1_STATUS_SPEC {
     type Ux = u32;
@@ -580,4 +580,8 @@ impl crate::Readable for SYSCRG_RST1_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST1_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst1_status to value 0"]
+impl crate::Resettable for SYSCRG_RST1_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst2_status.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst2_status.rs
@@ -518,7 +518,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 2\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst2_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst2_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST2_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST2_STATUS_SPEC {
     type Ux = u32;
@@ -529,4 +529,8 @@ impl crate::Readable for SYSCRG_RST2_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST2_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst2_status to value 0"]
+impl crate::Resettable for SYSCRG_RST2_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst3_status.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst3_status.rs
@@ -526,7 +526,7 @@ impl W {
         self
     }
 }
-#[doc = "SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "SYSCRG RESET Status 3\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`syscrg_rst3_status::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`syscrg_rst3_status::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct SYSCRG_RST3_STATUS_SPEC;
 impl crate::RegisterSpec for SYSCRG_RST3_STATUS_SPEC {
     type Ux = u32;
@@ -537,4 +537,8 @@ impl crate::Readable for SYSCRG_RST3_STATUS_SPEC {}
 impl crate::Writable for SYSCRG_RST3_STATUS_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets syscrg_rst3_status to value 0"]
+impl crate::Resettable for SYSCRG_RST3_STATUS_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-13b-pac/src/syscrg/u7mc_rtc_toggle.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/u7mc_rtc_toggle.rs
@@ -31,7 +31,7 @@ impl W {
         self
     }
 }
-#[doc = "U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`](R).  You can [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+#[doc = "U7MC RTC Toggle\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`u7mc_rtc_toggle::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`u7mc_rtc_toggle::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct U7MC_RTC_TOGGLE_SPEC;
 impl crate::RegisterSpec for U7MC_RTC_TOGGLE_SPEC {
     type Ux = u32;
@@ -42,4 +42,8 @@ impl crate::Readable for U7MC_RTC_TOGGLE_SPEC {}
 impl crate::Writable for U7MC_RTC_TOGGLE_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets u7mc_rtc_toggle to value 0"]
+impl crate::Resettable for U7MC_RTC_TOGGLE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
 }


### PR DESCRIPTION
Uses the `generate_register` helper function in common register definitions to increase code re-use, and enable resettable functionality.