### PR TITLE
interrupt: add interrupts to generated code

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -2747,6 +2747,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart0</name>
+        <value>27</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -4043,6 +4047,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart1</name>
+        <value>28</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -5339,6 +5347,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart2</name>
+        <value>29</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -6635,6 +6647,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c0</name>
+        <value>30</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -7736,6 +7752,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c1</name>
+        <value>31</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -8837,6 +8857,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c2</name>
+        <value>32</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -9938,6 +9962,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi0</name>
+        <value>33</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -10384,6 +10412,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi1</name>
+        <value>34</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -10820,6 +10852,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi2</name>
+        <value>35</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -16859,6 +16895,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart3</name>
+        <value>40</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -18155,6 +18195,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart4</name>
+        <value>41</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -19451,6 +19495,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart5</name>
+        <value>42</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -20747,6 +20795,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c3</name>
+        <value>43</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -21848,6 +21900,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c4</name>
+        <value>44</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -22949,6 +23005,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c5</name>
+        <value>45</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -24050,6 +24110,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c6</name>
+        <value>46</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -25151,6 +25215,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi3</name>
+        <value>47</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -25587,6 +25655,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi4</name>
+        <value>48</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26023,6 +26095,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi5</name>
+        <value>49</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26459,6 +26535,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi6</name>
+        <value>50</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26915,6 +26995,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>qspi</name>
+        <value>20</value>
+      </interrupt>
       <registers>
         <register>
           <name>config</name>
@@ -43884,6 +43968,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>pmu</name>
+        <value>106</value>
+      </interrupt>
       <registers>
         <register>
           <name>hard_event_turn_on_mask</name>

--- a/jh7110-vf2-12a-pac/src/interrupt.rs
+++ b/jh7110-vf2-12a-pac/src/interrupt.rs
@@ -1,0 +1,121 @@
+#[doc = r"Enumeration of all the interrupts."]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Interrupt {
+    #[doc = "20 - qspi"]
+    QSPI = 20,
+    #[doc = "27 - uart0"]
+    UART0 = 27,
+    #[doc = "28 - uart1"]
+    UART1 = 28,
+    #[doc = "29 - uart2"]
+    UART2 = 29,
+    #[doc = "30 - i2c0"]
+    I2C0 = 30,
+    #[doc = "31 - i2c1"]
+    I2C1 = 31,
+    #[doc = "32 - i2c2"]
+    I2C2 = 32,
+    #[doc = "33 - spi0"]
+    SPI0 = 33,
+    #[doc = "34 - spi1"]
+    SPI1 = 34,
+    #[doc = "35 - spi2"]
+    SPI2 = 35,
+    #[doc = "40 - uart3"]
+    UART3 = 40,
+    #[doc = "41 - uart4"]
+    UART4 = 41,
+    #[doc = "42 - uart5"]
+    UART5 = 42,
+    #[doc = "43 - i2c3"]
+    I2C3 = 43,
+    #[doc = "44 - i2c4"]
+    I2C4 = 44,
+    #[doc = "45 - i2c5"]
+    I2C5 = 45,
+    #[doc = "46 - i2c6"]
+    I2C6 = 46,
+    #[doc = "47 - spi3"]
+    SPI3 = 47,
+    #[doc = "48 - spi4"]
+    SPI4 = 48,
+    #[doc = "49 - spi5"]
+    SPI5 = 49,
+    #[doc = "50 - spi6"]
+    SPI6 = 50,
+    #[doc = "106 - pmu"]
+    PMU = 106,
+}
+#[doc = r" TryFromInterruptError"]
+#[derive(Debug, Copy, Clone)]
+pub struct TryFromInterruptError(());
+impl Interrupt {
+    #[doc = r" Attempt to convert a given value into an `Interrupt`"]
+    #[inline]
+    pub fn try_from(value: u8) -> Result<Self, TryFromInterruptError> {
+        match value {
+            20 => Ok(Interrupt::QSPI),
+            27 => Ok(Interrupt::UART0),
+            28 => Ok(Interrupt::UART1),
+            29 => Ok(Interrupt::UART2),
+            30 => Ok(Interrupt::I2C0),
+            31 => Ok(Interrupt::I2C1),
+            32 => Ok(Interrupt::I2C2),
+            33 => Ok(Interrupt::SPI0),
+            34 => Ok(Interrupt::SPI1),
+            35 => Ok(Interrupt::SPI2),
+            40 => Ok(Interrupt::UART3),
+            41 => Ok(Interrupt::UART4),
+            42 => Ok(Interrupt::UART5),
+            43 => Ok(Interrupt::I2C3),
+            44 => Ok(Interrupt::I2C4),
+            45 => Ok(Interrupt::I2C5),
+            46 => Ok(Interrupt::I2C6),
+            47 => Ok(Interrupt::SPI3),
+            48 => Ok(Interrupt::SPI4),
+            49 => Ok(Interrupt::SPI5),
+            50 => Ok(Interrupt::SPI6),
+            106 => Ok(Interrupt::PMU),
+            _ => Err(TryFromInterruptError(())),
+        }
+    }
+}
+#[cfg(feature = "rt")]
+#[macro_export]
+#[doc = r" Assigns a handler to an interrupt"]
+#[doc = r""]
+#[doc = r" This macro takes two arguments: the name of an interrupt and the path to the"]
+#[doc = r" function that will be used as the handler of that interrupt. That function"]
+#[doc = r" must have signature `fn()`."]
+#[doc = r""]
+#[doc = r" Optionally, a third argument may be used to declare interrupt local data."]
+#[doc = r" The handler will have exclusive access to these *local* variables on each"]
+#[doc = r" invocation. If the third argument is used then the signature of the handler"]
+#[doc = r" function must be `fn(&mut $NAME::Locals)` where `$NAME` is the first argument"]
+#[doc = r" passed to the macro."]
+#[doc = r""]
+#[doc = r" # Example"]
+#[doc = r""]
+#[doc = r" ``` ignore"]
+#[doc = r" interrupt!(TIM2, periodic);"]
+#[doc = r""]
+#[doc = r" fn periodic() {"]
+#[doc = r#"     print!(".");"#]
+#[doc = r" }"]
+#[doc = r""]
+#[doc = r" interrupt!(TIM3, tick, locals: {"]
+#[doc = r"     tick: bool = false;"]
+#[doc = r" });"]
+#[doc = r""]
+#[doc = r" fn tick(locals: &mut TIM3::Locals) {"]
+#[doc = r"     locals.tick = !locals.tick;"]
+#[doc = r""]
+#[doc = r"     if locals.tick {"]
+#[doc = r#"         println!("Tick");"#]
+#[doc = r"     } else {"]
+#[doc = r#"         println!("Tock");"#]
+#[doc = r"     }"]
+#[doc = r" }"]
+#[doc = r" ```"]
+macro_rules ! interrupt { ($ NAME : ident , $ path : path , locals : { $ ($ lvar : ident : $ lty : ty = $ lval : expr ;) * }) => { # [allow (non_snake_case)] mod $ NAME { pub struct Locals { $ (pub $ lvar : $ lty ,) * } } # [allow (non_snake_case)] # [no_mangle] pub extern "C" fn $ NAME () { let _ = $ crate :: interrupt :: Interrupt :: $ NAME ; static mut LOCALS : self :: $ NAME :: Locals = self :: $ NAME :: Locals { $ ($ lvar : $ lval ,) * } ; let f : fn (& mut self :: $ NAME :: Locals) = $ path ; f (unsafe { & mut LOCALS }) ; } } ; ($ NAME : ident , $ path : path) => { # [allow (non_snake_case)] # [no_mangle] pub extern "C" fn $ NAME () { let _ = $ crate :: interrupt :: Interrupt :: $ NAME ; let f : fn () = $ path ; f () ; } } }

--- a/jh7110-vf2-12a-pac/src/lib.rs
+++ b/jh7110-vf2-12a-pac/src/lib.rs
@@ -10,7 +10,30 @@ use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
 #[cfg(feature = "rt")]
-extern "C" {}
+extern "C" {
+    fn QSPI();
+    fn UART0();
+    fn UART1();
+    fn UART2();
+    fn I2C0();
+    fn I2C1();
+    fn I2C2();
+    fn SPI0();
+    fn SPI1();
+    fn SPI2();
+    fn UART3();
+    fn UART4();
+    fn UART5();
+    fn I2C3();
+    fn I2C4();
+    fn I2C5();
+    fn I2C6();
+    fn SPI3();
+    fn SPI4();
+    fn SPI5();
+    fn SPI6();
+    fn PMU();
+}
 #[doc(hidden)]
 #[repr(C)]
 pub union Vector {
@@ -20,7 +43,118 @@ pub union Vector {
 #[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
-pub static __EXTERNAL_INTERRUPTS: [Vector; 0] = [];
+pub static __EXTERNAL_INTERRUPTS: [Vector; 107] = [
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: QSPI },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: UART0 },
+    Vector { _handler: UART1 },
+    Vector { _handler: UART2 },
+    Vector { _handler: I2C0 },
+    Vector { _handler: I2C1 },
+    Vector { _handler: I2C2 },
+    Vector { _handler: SPI0 },
+    Vector { _handler: SPI1 },
+    Vector { _handler: SPI2 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: UART3 },
+    Vector { _handler: UART4 },
+    Vector { _handler: UART5 },
+    Vector { _handler: I2C3 },
+    Vector { _handler: I2C4 },
+    Vector { _handler: I2C5 },
+    Vector { _handler: I2C6 },
+    Vector { _handler: SPI3 },
+    Vector { _handler: SPI4 },
+    Vector { _handler: SPI5 },
+    Vector { _handler: SPI6 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: PMU },
+];
+#[doc(hidden)]
+pub mod interrupt;
+pub use self::interrupt::Interrupt;
 #[doc = "From starfive,jh7110-clint, peripheral generator"]
 pub struct CLINT {
     _marker: PhantomData<*const ()>,

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -2747,6 +2747,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart0</name>
+        <value>27</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -4043,6 +4047,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart1</name>
+        <value>28</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -5339,6 +5347,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart2</name>
+        <value>29</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -6635,6 +6647,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c0</name>
+        <value>30</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -7736,6 +7752,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c1</name>
+        <value>31</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -8837,6 +8857,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c2</name>
+        <value>32</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -9938,6 +9962,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi0</name>
+        <value>33</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -10384,6 +10412,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi1</name>
+        <value>34</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -10820,6 +10852,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi2</name>
+        <value>35</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -16859,6 +16895,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart3</name>
+        <value>40</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -18155,6 +18195,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart4</name>
+        <value>41</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -19451,6 +19495,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>uart5</name>
+        <value>42</value>
+      </interrupt>
       <registers>
         <register>
           <name>rbr</name>
@@ -20747,6 +20795,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c3</name>
+        <value>43</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -21848,6 +21900,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c4</name>
+        <value>44</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -22949,6 +23005,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c5</name>
+        <value>45</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -24060,6 +24120,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>i2c6</name>
+        <value>46</value>
+      </interrupt>
       <registers>
         <register>
           <name>con</name>
@@ -25161,6 +25225,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi3</name>
+        <value>47</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -25597,6 +25665,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi4</name>
+        <value>48</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26033,6 +26105,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi5</name>
+        <value>49</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26469,6 +26545,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>spi6</name>
+        <value>50</value>
+      </interrupt>
       <registers>
         <register>
           <name>ssp_cr0</name>
@@ -26925,6 +27005,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>qspi</name>
+        <value>20</value>
+      </interrupt>
       <registers>
         <register>
           <name>config</name>
@@ -43782,6 +43866,10 @@
         <size>0x10000</size>
         <usage>registers</usage>
       </addressBlock>
+      <interrupt>
+        <name>pmu</name>
+        <value>106</value>
+      </interrupt>
       <registers>
         <register>
           <name>hard_event_turn_on_mask</name>

--- a/jh7110-vf2-13b-pac/src/interrupt.rs
+++ b/jh7110-vf2-13b-pac/src/interrupt.rs
@@ -1,0 +1,121 @@
+#[doc = r"Enumeration of all the interrupts."]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Interrupt {
+    #[doc = "20 - qspi"]
+    QSPI = 20,
+    #[doc = "27 - uart0"]
+    UART0 = 27,
+    #[doc = "28 - uart1"]
+    UART1 = 28,
+    #[doc = "29 - uart2"]
+    UART2 = 29,
+    #[doc = "30 - i2c0"]
+    I2C0 = 30,
+    #[doc = "31 - i2c1"]
+    I2C1 = 31,
+    #[doc = "32 - i2c2"]
+    I2C2 = 32,
+    #[doc = "33 - spi0"]
+    SPI0 = 33,
+    #[doc = "34 - spi1"]
+    SPI1 = 34,
+    #[doc = "35 - spi2"]
+    SPI2 = 35,
+    #[doc = "40 - uart3"]
+    UART3 = 40,
+    #[doc = "41 - uart4"]
+    UART4 = 41,
+    #[doc = "42 - uart5"]
+    UART5 = 42,
+    #[doc = "43 - i2c3"]
+    I2C3 = 43,
+    #[doc = "44 - i2c4"]
+    I2C4 = 44,
+    #[doc = "45 - i2c5"]
+    I2C5 = 45,
+    #[doc = "46 - i2c6"]
+    I2C6 = 46,
+    #[doc = "47 - spi3"]
+    SPI3 = 47,
+    #[doc = "48 - spi4"]
+    SPI4 = 48,
+    #[doc = "49 - spi5"]
+    SPI5 = 49,
+    #[doc = "50 - spi6"]
+    SPI6 = 50,
+    #[doc = "106 - pmu"]
+    PMU = 106,
+}
+#[doc = r" TryFromInterruptError"]
+#[derive(Debug, Copy, Clone)]
+pub struct TryFromInterruptError(());
+impl Interrupt {
+    #[doc = r" Attempt to convert a given value into an `Interrupt`"]
+    #[inline]
+    pub fn try_from(value: u8) -> Result<Self, TryFromInterruptError> {
+        match value {
+            20 => Ok(Interrupt::QSPI),
+            27 => Ok(Interrupt::UART0),
+            28 => Ok(Interrupt::UART1),
+            29 => Ok(Interrupt::UART2),
+            30 => Ok(Interrupt::I2C0),
+            31 => Ok(Interrupt::I2C1),
+            32 => Ok(Interrupt::I2C2),
+            33 => Ok(Interrupt::SPI0),
+            34 => Ok(Interrupt::SPI1),
+            35 => Ok(Interrupt::SPI2),
+            40 => Ok(Interrupt::UART3),
+            41 => Ok(Interrupt::UART4),
+            42 => Ok(Interrupt::UART5),
+            43 => Ok(Interrupt::I2C3),
+            44 => Ok(Interrupt::I2C4),
+            45 => Ok(Interrupt::I2C5),
+            46 => Ok(Interrupt::I2C6),
+            47 => Ok(Interrupt::SPI3),
+            48 => Ok(Interrupt::SPI4),
+            49 => Ok(Interrupt::SPI5),
+            50 => Ok(Interrupt::SPI6),
+            106 => Ok(Interrupt::PMU),
+            _ => Err(TryFromInterruptError(())),
+        }
+    }
+}
+#[cfg(feature = "rt")]
+#[macro_export]
+#[doc = r" Assigns a handler to an interrupt"]
+#[doc = r""]
+#[doc = r" This macro takes two arguments: the name of an interrupt and the path to the"]
+#[doc = r" function that will be used as the handler of that interrupt. That function"]
+#[doc = r" must have signature `fn()`."]
+#[doc = r""]
+#[doc = r" Optionally, a third argument may be used to declare interrupt local data."]
+#[doc = r" The handler will have exclusive access to these *local* variables on each"]
+#[doc = r" invocation. If the third argument is used then the signature of the handler"]
+#[doc = r" function must be `fn(&mut $NAME::Locals)` where `$NAME` is the first argument"]
+#[doc = r" passed to the macro."]
+#[doc = r""]
+#[doc = r" # Example"]
+#[doc = r""]
+#[doc = r" ``` ignore"]
+#[doc = r" interrupt!(TIM2, periodic);"]
+#[doc = r""]
+#[doc = r" fn periodic() {"]
+#[doc = r#"     print!(".");"#]
+#[doc = r" }"]
+#[doc = r""]
+#[doc = r" interrupt!(TIM3, tick, locals: {"]
+#[doc = r"     tick: bool = false;"]
+#[doc = r" });"]
+#[doc = r""]
+#[doc = r" fn tick(locals: &mut TIM3::Locals) {"]
+#[doc = r"     locals.tick = !locals.tick;"]
+#[doc = r""]
+#[doc = r"     if locals.tick {"]
+#[doc = r#"         println!("Tick");"#]
+#[doc = r"     } else {"]
+#[doc = r#"         println!("Tock");"#]
+#[doc = r"     }"]
+#[doc = r" }"]
+#[doc = r" ```"]
+macro_rules ! interrupt { ($ NAME : ident , $ path : path , locals : { $ ($ lvar : ident : $ lty : ty = $ lval : expr ;) * }) => { # [allow (non_snake_case)] mod $ NAME { pub struct Locals { $ (pub $ lvar : $ lty ,) * } } # [allow (non_snake_case)] # [no_mangle] pub extern "C" fn $ NAME () { let _ = $ crate :: interrupt :: Interrupt :: $ NAME ; static mut LOCALS : self :: $ NAME :: Locals = self :: $ NAME :: Locals { $ ($ lvar : $ lval ,) * } ; let f : fn (& mut self :: $ NAME :: Locals) = $ path ; f (unsafe { & mut LOCALS }) ; } } ; ($ NAME : ident , $ path : path) => { # [allow (non_snake_case)] # [no_mangle] pub extern "C" fn $ NAME () { let _ = $ crate :: interrupt :: Interrupt :: $ NAME ; let f : fn () = $ path ; f () ; } } }

--- a/jh7110-vf2-13b-pac/src/lib.rs
+++ b/jh7110-vf2-13b-pac/src/lib.rs
@@ -10,7 +10,30 @@ use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
 #[cfg(feature = "rt")]
-extern "C" {}
+extern "C" {
+    fn QSPI();
+    fn UART0();
+    fn UART1();
+    fn UART2();
+    fn I2C0();
+    fn I2C1();
+    fn I2C2();
+    fn SPI0();
+    fn SPI1();
+    fn SPI2();
+    fn UART3();
+    fn UART4();
+    fn UART5();
+    fn I2C3();
+    fn I2C4();
+    fn I2C5();
+    fn I2C6();
+    fn SPI3();
+    fn SPI4();
+    fn SPI5();
+    fn SPI6();
+    fn PMU();
+}
 #[doc(hidden)]
 #[repr(C)]
 pub union Vector {
@@ -20,7 +43,118 @@ pub union Vector {
 #[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
-pub static __EXTERNAL_INTERRUPTS: [Vector; 0] = [];
+pub static __EXTERNAL_INTERRUPTS: [Vector; 107] = [
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: QSPI },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: UART0 },
+    Vector { _handler: UART1 },
+    Vector { _handler: UART2 },
+    Vector { _handler: I2C0 },
+    Vector { _handler: I2C1 },
+    Vector { _handler: I2C2 },
+    Vector { _handler: SPI0 },
+    Vector { _handler: SPI1 },
+    Vector { _handler: SPI2 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: UART3 },
+    Vector { _handler: UART4 },
+    Vector { _handler: UART5 },
+    Vector { _handler: I2C3 },
+    Vector { _handler: I2C4 },
+    Vector { _handler: I2C5 },
+    Vector { _handler: I2C6 },
+    Vector { _handler: SPI3 },
+    Vector { _handler: SPI4 },
+    Vector { _handler: SPI5 },
+    Vector { _handler: SPI6 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _reserved: 0 },
+    Vector { _handler: PMU },
+];
+#[doc(hidden)]
+pub mod interrupt;
+pub use self::interrupt::Interrupt;
 #[doc = "From starfive,jh7110-clint, peripheral generator"]
 pub struct CLINT {
     _marker: PhantomData<*const ()>,


### PR DESCRIPTION
Adds the `Interrupt` enum to generated code with the `generate_interrupt` function in `cmsis-svd-generator`.