### PR TITLE
fixup: export PAC sub-crates with `*-rt` features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 #![no_std]
 
-#[cfg(feature = "visionfive2-12a")]
+#[cfg(any(feature = "visionfive2-12a", feature = "visionfive2-12a-rt"))]
 pub extern crate jh7110_vf2_12a_pac;
 
-#[cfg(feature = "visionfive2-13b")]
+#[cfg(any(feature = "visionfive2-13b", feature = "visionfive2-13b-rt"))]
 pub extern crate jh7110_vf2_13b_pac;


### PR DESCRIPTION
Exports the `jh7110-12a-pac` and `jh7110-13b-pac` sub-crates if their respective `*-rt` feature is enabled.

Fixes an omission from a previous commit that introduced the `-rt` features.