### PR TITLE
fixup: sys_syscon: simplify register naming

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -32617,50 +32617,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_e24_remap_haddr</name>
-              <description>scfg_e24_remap_haddr</description>
+              <name>e24_remap_haddr</name>
+              <description>e24_remap_haddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_idma_remap_araddr</name>
-              <description>scfg_hifi4_idma_remap_araddr</description>
+              <name>hifi4_idma_remap_araddr</name>
+              <description>hifi4_idma_remap_araddr</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_idma_remap_awaddr</name>
-              <description>scfg_hifi4_idma_remap_awaddr</description>
+              <name>hifi4_idma_remap_awaddr</name>
+              <description>hifi4_idma_remap_awaddr</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_sys_remap_araddr</name>
-              <description>scfg_hifi4_sys_remap_araddr</description>
+              <name>hifi4_sys_remap_araddr</name>
+              <description>hifi4_sys_remap_araddr</description>
               <bitRange>[15:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_sys_remap_awaddr</name>
-              <description>scfg_hifi4_sys_remap_awaddr</description>
+              <name>hifi4_sys_remap_awaddr</name>
+              <description>hifi4_sys_remap_awaddr</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_jpg_remap_araddr</name>
-              <description>scfg_jpg_remap_araddr</description>
+              <name>jpg_remap_araddr</name>
+              <description>jpg_remap_araddr</description>
               <bitRange>[23:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_jpg_remap_awaddr</name>
-              <description>scfg_jpg_remap_awaddr</description>
+              <name>jpg_remap_awaddr</name>
+              <description>jpg_remap_awaddr</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_sd0_remap_araddr</name>
-              <description>scfg_sd0_remap_araddr</description>
+              <name>sd0_remap_araddr</name>
+              <description>sd0_remap_araddr</description>
               <bitRange>[31:28]</bitRange>
               <access>read-write</access>
             </field>
@@ -32674,50 +32674,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_sd1_remap_awaddr</name>
-              <description>scfg_sd1_remap_awaddr</description>
+              <name>sd1_remap_awaddr</name>
+              <description>sd1_remap_awaddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_sec_haddr_remap</name>
-              <description>scfg_sec_haddr_remap</description>
+              <name>sec_haddr_remap</name>
+              <description>sec_haddr_remap</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_usb_araddr_remap</name>
-              <description>scfg_usb_araddr_remap</description>
+              <name>usb_araddr_remap</name>
+              <description>usb_araddr_remap</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_usb_awaddr_remap</name>
-              <description>scfg_usb_awaddr_remap</description>
+              <name>usb_awaddr_remap</name>
+              <description>usb_awaddr_remap</description>
               <bitRange>[15:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vdec_remap_awaddr</name>
-              <description>scfg_vdec_remap_awaddr</description>
+              <name>vdec_remap_awaddr</name>
+              <description>vdec_remap_awaddr</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_venc_remap_araddr</name>
-              <description>scfg_venc_remap_araddr</description>
+              <name>venc_remap_araddr</name>
+              <description>venc_remap_araddr</description>
               <bitRange>[23:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_venc_remap_awaddr</name>
-              <description>scfg_venc_remap_awaddr</description>
+              <name>venc_remap_awaddr</name>
+              <description>venc_remap_awaddr</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_araddr</name>
-              <description>scfg_vout0_remap_araddr</description>
+              <name>vout0_remap_araddr</name>
+              <description>vout0_remap_araddr</description>
               <bitRange>[31:28]</bitRange>
               <access>read-write</access>
             </field>
@@ -32731,20 +32731,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_vout0_remap_awaddr</name>
-              <description>scfg_vout0_remap_awaddr</description>
+              <name>vout0_remap_awaddr</name>
+              <description>vout0_remap_awaddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout1_remap_araddr</name>
-              <description>scfg_vout1_remap_araddr</description>
+              <name>vout1_remap_araddr</name>
+              <description>vout1_remap_araddr</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout1_remap_awaddr</name>
-              <description>scfg_vout1_remap_awaddr</description>
+              <name>vout1_remap_awaddr</name>
+              <description>vout1_remap_awaddr</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
@@ -32758,25 +32758,25 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio0</name>
+              <name>vout0_remap_awaddr_gpio0</name>
               <description>0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio1</name>
+              <name>vout0_remap_awaddr_gpio1</name>
               <description>0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio2</name>
+              <name>vout0_remap_awaddr_gpio2</name>
               <description>0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio3</name>
+              <name>vout0_remap_awaddr_gpio3</name>
               <description>0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
@@ -32791,37 +32791,37 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_coda12_o_cur_inst_a</name>
+              <name>coda12_cur_inst</name>
               <description>Tie 0 in JPU internal, do not care</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_wave511_o_vpu_idle</name>
+              <name>wave511_vpu_idle</name>
               <description>VPU monitoring signal</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_can_ctrl_can_fd_enable</name>
-              <description>u0_can_ctrl_can_fd_enable</description>
+              <name>can_ctrl_fd_enable_0</name>
+              <description>can_ctrl_fd_enable_0</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_can_ctrl_host_ecc_disable</name>
-              <description>u0_can_ctrl_host_ecc_disable</description>
+              <name>can_ctrl_host_ecc_disable_0</name>
+              <description>can_ctrl_host_ecc_disable_0</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_can_ctrl_host_if</name>
-              <description>u0_can_ctrl_host_if</description>
+              <name>can_ctrl_host_if_0</name>
+              <description>can_ctrl_host_if_0</description>
               <bitRange>[23:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel</name>
+              <name>qspi_sclk_dlychain_sel</name>
               <description>des_qspi_sclk_dla: clock delay</description>
               <bitRange>[28:24]</bitRange>
               <access>read-only</access>
@@ -32932,25 +32932,25 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdns_spdif_trmodeo</name>
+              <name>spdif_trmodeo</name>
               <description>1 for transmitter 0 for receiver</description>
               <bitRange>[24:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_i2c_ic_en</name>
+              <name>i2c_ic_en</name>
               <description>I2C interface enable</description>
               <bitRange>[25:25]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_sdio_data_strobe_phase_ctrl</name>
+              <name>sdio_data_strobe_phase_ctrl</name>
               <description>Data strobe delay chain select</description>
               <bitRange>[30:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sdio_hbig_endian</name>
+              <name>sdio_hbig_endian</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32965,20 +32965,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_sdio_m_hbig_endian</name>
+              <name>sdio_m_hbig_endian</name>
               <description>AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_i2srx_3ch_adc_ena</name>
-              <description>u0_i2srx_3ch_adc_ena</description>
+              <name>i2srx_adc_en</name>
+              <description>i2srx_adc_en</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_intmem_rom_sram_scfg_disable_rom</name>
-              <description>u0_intmem_rom_sram_scfg_disable_rom</description>
+              <name>intmem_rom_sram_scfg_disable_rom</name>
+              <description>intmem_rom_sram_scfg_disable_rom</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
@@ -33031,20 +33031,20 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_jtag_daisy_chain_jtag_en_0</name>
-              <description>u0_jtag_daisy_chain_jtag_en_0</description>
+              <name>jtag_daisy_chain_en_0</name>
+              <description>jtag_daisy_chain_en_0</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_jtag_daisy_chain_jtag_en_1</name>
-              <description>u0_jtag_daisy_chain_jtag_en_1</description>
+              <name>jtag_daisy_chain_en_1</name>
+              <description>jtag_daisy_chain_en_1</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_pdrstn_split_sw_usbpipe_plugen</name>
-              <description>u0_pdrstn_split_sw_usbpipe_plugen</description>
+              <name>pdrstn_usbpipe_plugen</name>
+              <description>pdrstn_usbpipe_plugen</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -33082,8 +33082,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_pll_wrap_pll0_fbdiv</name>
-              <description>u0_pll_wrap_pll0_fbdiv</description>
+              <name>pll0_fbdiv</name>
+              <description>pll0_fbdiv</description>
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33370,14 +33370,14 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_saif_audio_sdin_mux_scfg_i2sdin_sel</name>
-              <description>u0_saif_audio_sdin_mux_scfg_i2sdin_sel</description>
+              <name>audio_i2sdin_sel</name>
+              <description>audio_i2sdin_sel</description>
               <bitRange>[17:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_clock_gating_off</name>
-              <description>u0_sft7110_noc_bus_clock_gating_off</description>
+              <name>noc_bus_clock_gating_off</name>
+              <description>noc_bus_clock_gating_off</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
@@ -33499,32 +33499,32 @@
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_0</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_0</description>
+              <name>noc_bus_oic_ignore_modifiable_0</name>
+              <description>noc_bus_oic_ignore_modifiable_0</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_1</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_1</description>
+              <name>noc_bus_oic_ignore_modifiable_1</name>
+              <description>noc_bus_oic_ignore_modifiable_1</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_2</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_2</description>
+              <name>noc_bus_oic_ignore_modifiable_2</name>
+              <description>noc_bus_oic_ignore_modifiable_2</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_3</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_3</description>
+              <name>noc_bus_oic_ignore_modifiable_3</name>
+              <description>noc_bus_oic_ignore_modifiable_3</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_4</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_4</description>
+              <name>noc_bus_oic_ignore_modifiable_4</name>
+              <description>noc_bus_oic_ignore_modifiable_4</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
@@ -33538,8 +33538,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_0</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_0</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_0</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33553,8 +33553,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_1</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_1</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_1</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_1</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33568,8 +33568,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_2</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_2</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_2</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_2</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33583,8 +33583,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_3</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_3</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_3</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_3</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33598,8 +33598,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_4</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_4</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_4</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_4</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33613,8 +33613,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_5</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_5</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_5</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_5</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33628,8 +33628,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_6</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_6</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_6</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_6</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33643,8 +33643,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_7</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_7</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_7</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_7</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33658,8 +33658,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_8</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_8</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_8</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_8</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33673,50 +33673,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_tdm16slot_clkpol</name>
-              <description>u0_tdm16slot_clkpol</description>
+              <name>tdm16slot_clkpol</name>
+              <description>tdm16slot_clkpol</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_tdm16slot_pcm_ms</name>
-              <description>u0_tdm16slot_pcm_ms</description>
+              <name>tdm16slot_pcm_ms</name>
+              <description>tdm16slot_pcm_ms</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c0_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c0_in0_ctl</description>
+              <name>u0_trace_mtx_in0_0</name>
+              <description>u0_trace_mtx_in0_0</description>
               <bitRange>[6:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c0_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c0_in1_ctl</description>
+              <name>u0_trace_mtx_in1_0</name>
+              <description>u0_trace_mtx_in1_0</description>
               <bitRange>[11:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c1_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c1_in0_ctl</description>
+              <name>u0_trace_mtx_in0_1</name>
+              <description>u0_trace_mtx_in0_1</description>
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c1_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c1_in1_ctl</description>
+              <name>u0_trace_mtx_in1_1</name>
+              <description>u0_trace_mtx_in1_1</description>
               <bitRange>[21:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c2_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c2_in0_ctl</description>
+              <name>u0_trace_mtx_in0_2</name>
+              <description>u0_trace_mtx_in0_2</description>
               <bitRange>[26:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c2_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c2_in1_ctl</description>
+              <name>u0_trace_mtx_in1_2</name>
+              <description>u0_trace_mtx_in1_2</description>
               <bitRange>[31:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -34909,38 +34909,38 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_current_buffer</name>
+              <name>wave420l_ipu_current_buffer</name>
               <description>This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter.</description>
               <bitRange>[14:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_end_of_row</name>
+              <name>wave420l_ipu_end_of_row</name>
               <description>This signal is flipped every time when the IPU completes writing a row.</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_new_frame</name>
+              <name>wave420l_ipu_new_frame</name>
               <description>This signal is flipped every time when the IPU completes writing a new frame.</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_o_vpu_idle</name>
+              <name>wave420l_vpu_idle</name>
               <description>VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register.</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_can_ctrl_can_fd_enable</name>
-              <description>u1_can_ctrl_can_fd_enable</description>
+              <name>can_ctrl_fd_enable_1</name>
+              <description>can_ctrl_fd_enable_1</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_can_ctrl_host_ecc_disable</name>
-              <description>u1_can_ctrl_host_ecc_disable</description>
+              <name>can_ctrl_host_ecc_disable_1</name>
+              <description>can_ctrl_host_ecc_disable_1</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
@@ -34954,8 +34954,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_can_ctrl_host_if</name>
-              <description>u1_can_ctrl_host_if</description>
+              <name>can_ctrl_host_if_1</name>
+              <description>can_ctrl_host_if_1</description>
               <bitRange>[18:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -35017,13 +35017,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_mac_speed_0</name>
-              <description>u1_gmac5_axi64_mac_speed_0</description>
+              <name>gmac5_axi64_mac_speed</name>
+              <description>gmac5_axi64_mac_speed</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_gmac5_axi64_phy_intf_sel_i</name>
+              <name>gmac5_axi64_phy_intf_sel</name>
               <description>Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII</description>
               <bitRange>[4:2]</bitRange>
               <access>read-write</access>
@@ -35038,8 +35038,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_ptp_timestamp_o_31_0</name>
-              <description>u1_gmac5_axi64_ptp_timestamp_o_31_0</description>
+              <name>gmac5_axi64_ptp_timestamp_0_31</name>
+              <description>gmac5_axi64_ptp_timestamp_0_31</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -35053,8 +35053,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_ptp_timestamp_o_63_32</name>
-              <description>u1_gmac5_axi64_ptp_timestamp_o_63_32</description>
+              <name>gmac5_axi64_ptp_timestamp_32_63</name>
+              <description>gmac5_axi64_ptp_timestamp_32_63</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -35068,50 +35068,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_i2c_ic_en</name>
+              <name>i2c_ic_en_1</name>
               <description>I2C interface enable.</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_sdio_data_strobe_phase_ctrl</name>
+              <name>sdio_data_strobe_phase_ctrl_1</name>
               <description>Data strobe delay chain select.</description>
               <bitRange>[5:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_sdio_hbig_endian</name>
+              <name>sdio_hbig_endian_1</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_sdio_m_hbig_endian</name>
+              <name>sdio_m_hbig_endian_1</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_clr_reset_status</name>
-              <description>u1_reset_ctrl_clr_reset_status</description>
+              <name>reset_ctrl_clr_reset_status_1</name>
+              <description>reset_ctrl_clr_reset_status_1</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_pll_timecnt_finish</name>
-              <description>u1_reset_ctrl_pll_timecnt_finish</description>
+              <name>reset_ctrl_pll_timecnt_finish_1</name>
+              <description>reset_ctrl_pll_timecnt_finish_1</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_rstn_sw</name>
-              <description>u1_reset_ctrl_rstn_sw</description>
+              <name>reset_ctrl_rstn_sw_1</name>
+              <description>reset_ctrl_rstn_sw_1</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_sys_reset_status</name>
-              <description>u1_reset_ctrl_sys_reset_status</description>
+              <name>reset_ctrl_sys_reset_status_1</name>
+              <description>reset_ctrl_sys_reset_status_1</description>
               <bitRange>[14:11]</bitRange>
               <access>read-only</access>
             </field>

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_0.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_0.rs
@@ -2,136 +2,128 @@
 pub type R = crate::R<SYS_SYSCFG_0_SPEC>;
 #[doc = "Register `sys_syscfg_0` writer"]
 pub type W = crate::W<SYS_SYSCFG_0_SPEC>;
-#[doc = "Field `scfg_e24_remap_haddr` reader - scfg_e24_remap_haddr"]
-pub type SCFG_E24_REMAP_HADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_e24_remap_haddr` writer - scfg_e24_remap_haddr"]
-pub type SCFG_E24_REMAP_HADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_idma_remap_araddr` reader - scfg_hifi4_idma_remap_araddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_idma_remap_araddr` writer - scfg_hifi4_idma_remap_araddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_idma_remap_awaddr` reader - scfg_hifi4_idma_remap_awaddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_idma_remap_awaddr` writer - scfg_hifi4_idma_remap_awaddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_sys_remap_araddr` reader - scfg_hifi4_sys_remap_araddr"]
-pub type SCFG_HIFI4_SYS_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_sys_remap_araddr` writer - scfg_hifi4_sys_remap_araddr"]
-pub type SCFG_HIFI4_SYS_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_sys_remap_awaddr` reader - scfg_hifi4_sys_remap_awaddr"]
-pub type SCFG_HIFI4_SYS_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_sys_remap_awaddr` writer - scfg_hifi4_sys_remap_awaddr"]
-pub type SCFG_HIFI4_SYS_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_jpg_remap_araddr` reader - scfg_jpg_remap_araddr"]
-pub type SCFG_JPG_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_jpg_remap_araddr` writer - scfg_jpg_remap_araddr"]
-pub type SCFG_JPG_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_jpg_remap_awaddr` reader - scfg_jpg_remap_awaddr"]
-pub type SCFG_JPG_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_jpg_remap_awaddr` writer - scfg_jpg_remap_awaddr"]
-pub type SCFG_JPG_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_sd0_remap_araddr` reader - scfg_sd0_remap_araddr"]
-pub type SCFG_SD0_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_sd0_remap_araddr` writer - scfg_sd0_remap_araddr"]
-pub type SCFG_SD0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `e24_remap_haddr` reader - e24_remap_haddr"]
+pub type E24_REMAP_HADDR_R = crate::FieldReader;
+#[doc = "Field `e24_remap_haddr` writer - e24_remap_haddr"]
+pub type E24_REMAP_HADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_idma_remap_araddr` reader - hifi4_idma_remap_araddr"]
+pub type HIFI4_IDMA_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_idma_remap_araddr` writer - hifi4_idma_remap_araddr"]
+pub type HIFI4_IDMA_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_idma_remap_awaddr` reader - hifi4_idma_remap_awaddr"]
+pub type HIFI4_IDMA_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_idma_remap_awaddr` writer - hifi4_idma_remap_awaddr"]
+pub type HIFI4_IDMA_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_sys_remap_araddr` reader - hifi4_sys_remap_araddr"]
+pub type HIFI4_SYS_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_sys_remap_araddr` writer - hifi4_sys_remap_araddr"]
+pub type HIFI4_SYS_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_sys_remap_awaddr` reader - hifi4_sys_remap_awaddr"]
+pub type HIFI4_SYS_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_sys_remap_awaddr` writer - hifi4_sys_remap_awaddr"]
+pub type HIFI4_SYS_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `jpg_remap_araddr` reader - jpg_remap_araddr"]
+pub type JPG_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `jpg_remap_araddr` writer - jpg_remap_araddr"]
+pub type JPG_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `jpg_remap_awaddr` reader - jpg_remap_awaddr"]
+pub type JPG_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `jpg_remap_awaddr` writer - jpg_remap_awaddr"]
+pub type JPG_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sd0_remap_araddr` reader - sd0_remap_araddr"]
+pub type SD0_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `sd0_remap_araddr` writer - sd0_remap_araddr"]
+pub type SD0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_e24_remap_haddr"]
+    #[doc = "Bits 0:3 - e24_remap_haddr"]
     #[inline(always)]
-    pub fn scfg_e24_remap_haddr(&self) -> SCFG_E24_REMAP_HADDR_R {
-        SCFG_E24_REMAP_HADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn e24_remap_haddr(&self) -> E24_REMAP_HADDR_R {
+        E24_REMAP_HADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_hifi4_idma_remap_araddr"]
+    #[doc = "Bits 4:7 - hifi4_idma_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_idma_remap_araddr(&self) -> SCFG_HIFI4_IDMA_REMAP_ARADDR_R {
-        SCFG_HIFI4_IDMA_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn hifi4_idma_remap_araddr(&self) -> HIFI4_IDMA_REMAP_ARADDR_R {
+        HIFI4_IDMA_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_hifi4_idma_remap_awaddr"]
+    #[doc = "Bits 8:11 - hifi4_idma_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_idma_remap_awaddr(&self) -> SCFG_HIFI4_IDMA_REMAP_AWADDR_R {
-        SCFG_HIFI4_IDMA_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn hifi4_idma_remap_awaddr(&self) -> HIFI4_IDMA_REMAP_AWADDR_R {
+        HIFI4_IDMA_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
-    #[doc = "Bits 12:15 - scfg_hifi4_sys_remap_araddr"]
+    #[doc = "Bits 12:15 - hifi4_sys_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_sys_remap_araddr(&self) -> SCFG_HIFI4_SYS_REMAP_ARADDR_R {
-        SCFG_HIFI4_SYS_REMAP_ARADDR_R::new(((self.bits >> 12) & 0x0f) as u8)
+    pub fn hifi4_sys_remap_araddr(&self) -> HIFI4_SYS_REMAP_ARADDR_R {
+        HIFI4_SYS_REMAP_ARADDR_R::new(((self.bits >> 12) & 0x0f) as u8)
     }
-    #[doc = "Bits 16:19 - scfg_hifi4_sys_remap_awaddr"]
+    #[doc = "Bits 16:19 - hifi4_sys_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_sys_remap_awaddr(&self) -> SCFG_HIFI4_SYS_REMAP_AWADDR_R {
-        SCFG_HIFI4_SYS_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    pub fn hifi4_sys_remap_awaddr(&self) -> HIFI4_SYS_REMAP_AWADDR_R {
+        HIFI4_SYS_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
     }
-    #[doc = "Bits 20:23 - scfg_jpg_remap_araddr"]
+    #[doc = "Bits 20:23 - jpg_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_jpg_remap_araddr(&self) -> SCFG_JPG_REMAP_ARADDR_R {
-        SCFG_JPG_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    pub fn jpg_remap_araddr(&self) -> JPG_REMAP_ARADDR_R {
+        JPG_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
     }
-    #[doc = "Bits 24:27 - scfg_jpg_remap_awaddr"]
+    #[doc = "Bits 24:27 - jpg_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_jpg_remap_awaddr(&self) -> SCFG_JPG_REMAP_AWADDR_R {
-        SCFG_JPG_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn jpg_remap_awaddr(&self) -> JPG_REMAP_AWADDR_R {
+        JPG_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
-    #[doc = "Bits 28:31 - scfg_sd0_remap_araddr"]
+    #[doc = "Bits 28:31 - sd0_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_sd0_remap_araddr(&self) -> SCFG_SD0_REMAP_ARADDR_R {
-        SCFG_SD0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    pub fn sd0_remap_araddr(&self) -> SD0_REMAP_ARADDR_R {
+        SD0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_e24_remap_haddr"]
+    #[doc = "Bits 0:3 - e24_remap_haddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_e24_remap_haddr(&mut self) -> SCFG_E24_REMAP_HADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_E24_REMAP_HADDR_W::new(self, 0)
+    pub fn e24_remap_haddr(&mut self) -> E24_REMAP_HADDR_W<SYS_SYSCFG_0_SPEC> {
+        E24_REMAP_HADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_hifi4_idma_remap_araddr"]
+    #[doc = "Bits 4:7 - hifi4_idma_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_idma_remap_araddr(
-        &mut self,
-    ) -> SCFG_HIFI4_IDMA_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_IDMA_REMAP_ARADDR_W::new(self, 4)
+    pub fn hifi4_idma_remap_araddr(&mut self) -> HIFI4_IDMA_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_IDMA_REMAP_ARADDR_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_hifi4_idma_remap_awaddr"]
+    #[doc = "Bits 8:11 - hifi4_idma_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_idma_remap_awaddr(
-        &mut self,
-    ) -> SCFG_HIFI4_IDMA_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_IDMA_REMAP_AWADDR_W::new(self, 8)
+    pub fn hifi4_idma_remap_awaddr(&mut self) -> HIFI4_IDMA_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_IDMA_REMAP_AWADDR_W::new(self, 8)
     }
-    #[doc = "Bits 12:15 - scfg_hifi4_sys_remap_araddr"]
+    #[doc = "Bits 12:15 - hifi4_sys_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_sys_remap_araddr(
-        &mut self,
-    ) -> SCFG_HIFI4_SYS_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_SYS_REMAP_ARADDR_W::new(self, 12)
+    pub fn hifi4_sys_remap_araddr(&mut self) -> HIFI4_SYS_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_SYS_REMAP_ARADDR_W::new(self, 12)
     }
-    #[doc = "Bits 16:19 - scfg_hifi4_sys_remap_awaddr"]
+    #[doc = "Bits 16:19 - hifi4_sys_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_sys_remap_awaddr(
-        &mut self,
-    ) -> SCFG_HIFI4_SYS_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_SYS_REMAP_AWADDR_W::new(self, 16)
+    pub fn hifi4_sys_remap_awaddr(&mut self) -> HIFI4_SYS_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_SYS_REMAP_AWADDR_W::new(self, 16)
     }
-    #[doc = "Bits 20:23 - scfg_jpg_remap_araddr"]
+    #[doc = "Bits 20:23 - jpg_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_jpg_remap_araddr(&mut self) -> SCFG_JPG_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_JPG_REMAP_ARADDR_W::new(self, 20)
+    pub fn jpg_remap_araddr(&mut self) -> JPG_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        JPG_REMAP_ARADDR_W::new(self, 20)
     }
-    #[doc = "Bits 24:27 - scfg_jpg_remap_awaddr"]
+    #[doc = "Bits 24:27 - jpg_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_jpg_remap_awaddr(&mut self) -> SCFG_JPG_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_JPG_REMAP_AWADDR_W::new(self, 24)
+    pub fn jpg_remap_awaddr(&mut self) -> JPG_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        JPG_REMAP_AWADDR_W::new(self, 24)
     }
-    #[doc = "Bits 28:31 - scfg_sd0_remap_araddr"]
+    #[doc = "Bits 28:31 - sd0_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sd0_remap_araddr(&mut self) -> SCFG_SD0_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_SD0_REMAP_ARADDR_W::new(self, 28)
+    pub fn sd0_remap_araddr(&mut self) -> SD0_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        SD0_REMAP_ARADDR_W::new(self, 28)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_1.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_1.rs
@@ -2,128 +2,128 @@
 pub type R = crate::R<SYS_SYSCFG_1_SPEC>;
 #[doc = "Register `sys_syscfg_1` writer"]
 pub type W = crate::W<SYS_SYSCFG_1_SPEC>;
-#[doc = "Field `scfg_sd1_remap_awaddr` reader - scfg_sd1_remap_awaddr"]
-pub type SCFG_SD1_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_sd1_remap_awaddr` writer - scfg_sd1_remap_awaddr"]
-pub type SCFG_SD1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_sec_haddr_remap` reader - scfg_sec_haddr_remap"]
-pub type SCFG_SEC_HADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_sec_haddr_remap` writer - scfg_sec_haddr_remap"]
-pub type SCFG_SEC_HADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_usb_araddr_remap` reader - scfg_usb_araddr_remap"]
-pub type SCFG_USB_ARADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_usb_araddr_remap` writer - scfg_usb_araddr_remap"]
-pub type SCFG_USB_ARADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_usb_awaddr_remap` reader - scfg_usb_awaddr_remap"]
-pub type SCFG_USB_AWADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_usb_awaddr_remap` writer - scfg_usb_awaddr_remap"]
-pub type SCFG_USB_AWADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vdec_remap_awaddr` reader - scfg_vdec_remap_awaddr"]
-pub type SCFG_VDEC_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vdec_remap_awaddr` writer - scfg_vdec_remap_awaddr"]
-pub type SCFG_VDEC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_venc_remap_araddr` reader - scfg_venc_remap_araddr"]
-pub type SCFG_VENC_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_venc_remap_araddr` writer - scfg_venc_remap_araddr"]
-pub type SCFG_VENC_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_venc_remap_awaddr` reader - scfg_venc_remap_awaddr"]
-pub type SCFG_VENC_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_venc_remap_awaddr` writer - scfg_venc_remap_awaddr"]
-pub type SCFG_VENC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout0_remap_araddr` reader - scfg_vout0_remap_araddr"]
-pub type SCFG_VOUT0_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout0_remap_araddr` writer - scfg_vout0_remap_araddr"]
-pub type SCFG_VOUT0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sd1_remap_awaddr` reader - sd1_remap_awaddr"]
+pub type SD1_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `sd1_remap_awaddr` writer - sd1_remap_awaddr"]
+pub type SD1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sec_haddr_remap` reader - sec_haddr_remap"]
+pub type SEC_HADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `sec_haddr_remap` writer - sec_haddr_remap"]
+pub type SEC_HADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `usb_araddr_remap` reader - usb_araddr_remap"]
+pub type USB_ARADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `usb_araddr_remap` writer - usb_araddr_remap"]
+pub type USB_ARADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `usb_awaddr_remap` reader - usb_awaddr_remap"]
+pub type USB_AWADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `usb_awaddr_remap` writer - usb_awaddr_remap"]
+pub type USB_AWADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vdec_remap_awaddr` reader - vdec_remap_awaddr"]
+pub type VDEC_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vdec_remap_awaddr` writer - vdec_remap_awaddr"]
+pub type VDEC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `venc_remap_araddr` reader - venc_remap_araddr"]
+pub type VENC_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `venc_remap_araddr` writer - venc_remap_araddr"]
+pub type VENC_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `venc_remap_awaddr` reader - venc_remap_awaddr"]
+pub type VENC_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `venc_remap_awaddr` writer - venc_remap_awaddr"]
+pub type VENC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout0_remap_araddr` reader - vout0_remap_araddr"]
+pub type VOUT0_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `vout0_remap_araddr` writer - vout0_remap_araddr"]
+pub type VOUT0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_sd1_remap_awaddr"]
+    #[doc = "Bits 0:3 - sd1_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_sd1_remap_awaddr(&self) -> SCFG_SD1_REMAP_AWADDR_R {
-        SCFG_SD1_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn sd1_remap_awaddr(&self) -> SD1_REMAP_AWADDR_R {
+        SD1_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_sec_haddr_remap"]
+    #[doc = "Bits 4:7 - sec_haddr_remap"]
     #[inline(always)]
-    pub fn scfg_sec_haddr_remap(&self) -> SCFG_SEC_HADDR_REMAP_R {
-        SCFG_SEC_HADDR_REMAP_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn sec_haddr_remap(&self) -> SEC_HADDR_REMAP_R {
+        SEC_HADDR_REMAP_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_usb_araddr_remap"]
+    #[doc = "Bits 8:11 - usb_araddr_remap"]
     #[inline(always)]
-    pub fn scfg_usb_araddr_remap(&self) -> SCFG_USB_ARADDR_REMAP_R {
-        SCFG_USB_ARADDR_REMAP_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn usb_araddr_remap(&self) -> USB_ARADDR_REMAP_R {
+        USB_ARADDR_REMAP_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
-    #[doc = "Bits 12:15 - scfg_usb_awaddr_remap"]
+    #[doc = "Bits 12:15 - usb_awaddr_remap"]
     #[inline(always)]
-    pub fn scfg_usb_awaddr_remap(&self) -> SCFG_USB_AWADDR_REMAP_R {
-        SCFG_USB_AWADDR_REMAP_R::new(((self.bits >> 12) & 0x0f) as u8)
+    pub fn usb_awaddr_remap(&self) -> USB_AWADDR_REMAP_R {
+        USB_AWADDR_REMAP_R::new(((self.bits >> 12) & 0x0f) as u8)
     }
-    #[doc = "Bits 16:19 - scfg_vdec_remap_awaddr"]
+    #[doc = "Bits 16:19 - vdec_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vdec_remap_awaddr(&self) -> SCFG_VDEC_REMAP_AWADDR_R {
-        SCFG_VDEC_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    pub fn vdec_remap_awaddr(&self) -> VDEC_REMAP_AWADDR_R {
+        VDEC_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
     }
-    #[doc = "Bits 20:23 - scfg_venc_remap_araddr"]
+    #[doc = "Bits 20:23 - venc_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_venc_remap_araddr(&self) -> SCFG_VENC_REMAP_ARADDR_R {
-        SCFG_VENC_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    pub fn venc_remap_araddr(&self) -> VENC_REMAP_ARADDR_R {
+        VENC_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
     }
-    #[doc = "Bits 24:27 - scfg_venc_remap_awaddr"]
+    #[doc = "Bits 24:27 - venc_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_venc_remap_awaddr(&self) -> SCFG_VENC_REMAP_AWADDR_R {
-        SCFG_VENC_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn venc_remap_awaddr(&self) -> VENC_REMAP_AWADDR_R {
+        VENC_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
-    #[doc = "Bits 28:31 - scfg_vout0_remap_araddr"]
+    #[doc = "Bits 28:31 - vout0_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_araddr(&self) -> SCFG_VOUT0_REMAP_ARADDR_R {
-        SCFG_VOUT0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    pub fn vout0_remap_araddr(&self) -> VOUT0_REMAP_ARADDR_R {
+        VOUT0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_sd1_remap_awaddr"]
+    #[doc = "Bits 0:3 - sd1_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sd1_remap_awaddr(&mut self) -> SCFG_SD1_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_SD1_REMAP_AWADDR_W::new(self, 0)
+    pub fn sd1_remap_awaddr(&mut self) -> SD1_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        SD1_REMAP_AWADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_sec_haddr_remap"]
+    #[doc = "Bits 4:7 - sec_haddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sec_haddr_remap(&mut self) -> SCFG_SEC_HADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_SEC_HADDR_REMAP_W::new(self, 4)
+    pub fn sec_haddr_remap(&mut self) -> SEC_HADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        SEC_HADDR_REMAP_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_usb_araddr_remap"]
+    #[doc = "Bits 8:11 - usb_araddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_usb_araddr_remap(&mut self) -> SCFG_USB_ARADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_USB_ARADDR_REMAP_W::new(self, 8)
+    pub fn usb_araddr_remap(&mut self) -> USB_ARADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        USB_ARADDR_REMAP_W::new(self, 8)
     }
-    #[doc = "Bits 12:15 - scfg_usb_awaddr_remap"]
+    #[doc = "Bits 12:15 - usb_awaddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_usb_awaddr_remap(&mut self) -> SCFG_USB_AWADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_USB_AWADDR_REMAP_W::new(self, 12)
+    pub fn usb_awaddr_remap(&mut self) -> USB_AWADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        USB_AWADDR_REMAP_W::new(self, 12)
     }
-    #[doc = "Bits 16:19 - scfg_vdec_remap_awaddr"]
+    #[doc = "Bits 16:19 - vdec_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vdec_remap_awaddr(&mut self) -> SCFG_VDEC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VDEC_REMAP_AWADDR_W::new(self, 16)
+    pub fn vdec_remap_awaddr(&mut self) -> VDEC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        VDEC_REMAP_AWADDR_W::new(self, 16)
     }
-    #[doc = "Bits 20:23 - scfg_venc_remap_araddr"]
+    #[doc = "Bits 20:23 - venc_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_venc_remap_araddr(&mut self) -> SCFG_VENC_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VENC_REMAP_ARADDR_W::new(self, 20)
+    pub fn venc_remap_araddr(&mut self) -> VENC_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
+        VENC_REMAP_ARADDR_W::new(self, 20)
     }
-    #[doc = "Bits 24:27 - scfg_venc_remap_awaddr"]
+    #[doc = "Bits 24:27 - venc_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_venc_remap_awaddr(&mut self) -> SCFG_VENC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VENC_REMAP_AWADDR_W::new(self, 24)
+    pub fn venc_remap_awaddr(&mut self) -> VENC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        VENC_REMAP_AWADDR_W::new(self, 24)
     }
-    #[doc = "Bits 28:31 - scfg_vout0_remap_araddr"]
+    #[doc = "Bits 28:31 - vout0_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_araddr(&mut self) -> SCFG_VOUT0_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VOUT0_REMAP_ARADDR_W::new(self, 28)
+    pub fn vout0_remap_araddr(&mut self) -> VOUT0_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
+        VOUT0_REMAP_ARADDR_W::new(self, 28)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_13.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_13.rs
@@ -18,14 +18,14 @@ pub type PLL2_TESTSEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
 pub type PLL_TEST_MODE_R = crate::BitReader;
 #[doc = "Field `pll_test_mode` writer - PLL test mode, only used for PLL BIST through jtag2apb"]
 pub type PLL_TEST_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_saif_audio_sdin_mux_scfg_i2sdin_sel` reader - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
-pub type U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_saif_audio_sdin_mux_scfg_i2sdin_sel` writer - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
-pub type U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_sft7110_noc_bus_clock_gating_off` reader - u0_sft7110_noc_bus_clock_gating_off"]
-pub type U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_clock_gating_off` writer - u0_sft7110_noc_bus_clock_gating_off"]
-pub type U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `audio_i2sdin_sel` reader - audio_i2sdin_sel"]
+pub type AUDIO_I2SDIN_SEL_R = crate::FieldReader;
+#[doc = "Field `audio_i2sdin_sel` writer - audio_i2sdin_sel"]
+pub type AUDIO_I2SDIN_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `noc_bus_clock_gating_off` reader - noc_bus_clock_gating_off"]
+pub type NOC_BUS_CLOCK_GATING_OFF_R = crate::BitReader;
+#[doc = "Field `noc_bus_clock_gating_off` writer - noc_bus_clock_gating_off"]
+pub type NOC_BUS_CLOCK_GATING_OFF_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `noc_bus_oic_evemon_start_0` reader - noc_bus_oic_evemon_start_0"]
 pub type NOC_BUS_OIC_EVEMON_START_0_R = crate::BitReader;
 #[doc = "Field `noc_bus_oic_evemon_start_0` writer - noc_bus_oic_evemon_start_0"]
@@ -87,17 +87,15 @@ impl R {
     pub fn pll_test_mode(&self) -> PLL_TEST_MODE_R {
         PLL_TEST_MODE_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bits 10:17 - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
+    #[doc = "Bits 10:17 - audio_i2sdin_sel"]
     #[inline(always)]
-    pub fn u0_saif_audio_sdin_mux_scfg_i2sdin_sel(
-        &self,
-    ) -> U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R {
-        U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R::new(((self.bits >> 10) & 0xff) as u8)
+    pub fn audio_i2sdin_sel(&self) -> AUDIO_I2SDIN_SEL_R {
+        AUDIO_I2SDIN_SEL_R::new(((self.bits >> 10) & 0xff) as u8)
     }
-    #[doc = "Bit 18 - u0_sft7110_noc_bus_clock_gating_off"]
+    #[doc = "Bit 18 - noc_bus_clock_gating_off"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_clock_gating_off(&self) -> U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R {
-        U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn noc_bus_clock_gating_off(&self) -> NOC_BUS_CLOCK_GATING_OFF_R {
+        NOC_BUS_CLOCK_GATING_OFF_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - noc_bus_oic_evemon_start_0"]
     #[inline(always)]
@@ -190,21 +188,17 @@ impl W {
     pub fn pll_test_mode(&mut self) -> PLL_TEST_MODE_W<SYS_SYSCFG_13_SPEC> {
         PLL_TEST_MODE_W::new(self, 9)
     }
-    #[doc = "Bits 10:17 - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
+    #[doc = "Bits 10:17 - audio_i2sdin_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_saif_audio_sdin_mux_scfg_i2sdin_sel(
-        &mut self,
-    ) -> U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W<SYS_SYSCFG_13_SPEC> {
-        U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W::new(self, 10)
+    pub fn audio_i2sdin_sel(&mut self) -> AUDIO_I2SDIN_SEL_W<SYS_SYSCFG_13_SPEC> {
+        AUDIO_I2SDIN_SEL_W::new(self, 10)
     }
-    #[doc = "Bit 18 - u0_sft7110_noc_bus_clock_gating_off"]
+    #[doc = "Bit 18 - noc_bus_clock_gating_off"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_clock_gating_off(
-        &mut self,
-    ) -> U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W<SYS_SYSCFG_13_SPEC> {
-        U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W::new(self, 18)
+    pub fn noc_bus_clock_gating_off(&mut self) -> NOC_BUS_CLOCK_GATING_OFF_W<SYS_SYSCFG_13_SPEC> {
+        NOC_BUS_CLOCK_GATING_OFF_W::new(self, 18)
     }
     #[doc = "Bit 19 - noc_bus_oic_evemon_start_0"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_14.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_14.rs
@@ -4,26 +4,26 @@ pub type R = crate::R<SYS_SYSCFG_14_SPEC>;
 pub type W = crate::W<SYS_SYSCFG_14_SPEC>;
 #[doc = "Field `noc_bus_oic_evemon_trigger_6` reader - noc_bus_oic_evemon_trigger_6"]
 pub type NOC_BUS_OIC_EVEMON_TRIGGER_6_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_0` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_0` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_1` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_1` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_2` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_2` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_3` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_3` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_4` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_4` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_0` reader - noc_bus_oic_ignore_modifiable_0"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_0` writer - noc_bus_oic_ignore_modifiable_0"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_1` reader - noc_bus_oic_ignore_modifiable_1"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_1` writer - noc_bus_oic_ignore_modifiable_1"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_2` reader - noc_bus_oic_ignore_modifiable_2"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_2` writer - noc_bus_oic_ignore_modifiable_2"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_3` reader - noc_bus_oic_ignore_modifiable_3"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_3` writer - noc_bus_oic_ignore_modifiable_3"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_4` reader - noc_bus_oic_ignore_modifiable_4"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_4` writer - noc_bus_oic_ignore_modifiable_4"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `noc_bus_oic_evemon_start_7` reader - noc_bus_oic_evemon_start_7"]
 pub type NOC_BUS_OIC_EVEMON_START_7_R = crate::BitReader;
 #[doc = "Field `noc_bus_oic_evemon_start_7` writer - noc_bus_oic_evemon_start_7"]
@@ -42,40 +42,30 @@ impl R {
     pub fn noc_bus_oic_evemon_trigger_6(&self) -> NOC_BUS_OIC_EVEMON_TRIGGER_6_R {
         NOC_BUS_OIC_EVEMON_TRIGGER_6_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
+    #[doc = "Bit 5 - noc_bus_oic_ignore_modifiable_0"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_0(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_0(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
+    #[doc = "Bit 6 - noc_bus_oic_ignore_modifiable_1"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_1(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_1(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
+    #[doc = "Bit 7 - noc_bus_oic_ignore_modifiable_2"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_2(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_2(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
+    #[doc = "Bit 8 - noc_bus_oic_ignore_modifiable_3"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_3(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_3(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
+    #[doc = "Bit 9 - noc_bus_oic_ignore_modifiable_4"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_4(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_4(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 15 - noc_bus_oic_evemon_start_7"]
     #[inline(always)]
@@ -99,45 +89,45 @@ impl R {
     }
 }
 impl W {
-    #[doc = "Bit 5 - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
+    #[doc = "Bit 5 - noc_bus_oic_ignore_modifiable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_0(
+    pub fn noc_bus_oic_ignore_modifiable_0(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W::new(self, 5)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W::new(self, 5)
     }
-    #[doc = "Bit 6 - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
+    #[doc = "Bit 6 - noc_bus_oic_ignore_modifiable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_1(
+    pub fn noc_bus_oic_ignore_modifiable_1(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W::new(self, 6)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W::new(self, 6)
     }
-    #[doc = "Bit 7 - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
+    #[doc = "Bit 7 - noc_bus_oic_ignore_modifiable_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_2(
+    pub fn noc_bus_oic_ignore_modifiable_2(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W::new(self, 7)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W::new(self, 7)
     }
-    #[doc = "Bit 8 - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
+    #[doc = "Bit 8 - noc_bus_oic_ignore_modifiable_3"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_3(
+    pub fn noc_bus_oic_ignore_modifiable_3(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W::new(self, 8)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W::new(self, 8)
     }
-    #[doc = "Bit 9 - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
+    #[doc = "Bit 9 - noc_bus_oic_ignore_modifiable_4"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_4(
+    pub fn noc_bus_oic_ignore_modifiable_4(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W::new(self, 9)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W::new(self, 9)
     }
     #[doc = "Bit 15 - noc_bus_oic_evemon_start_7"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_15.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_15.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_15_SPEC>;
 #[doc = "Register `sys_syscfg_15` writer"]
 pub type W = crate::W<SYS_SYSCFG_15_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_0` reader - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_0` writer - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_0` reader - noc_bus_oic_qch_clock_stop_threshold_0"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_0` writer - noc_bus_oic_qch_clock_stop_threshold_0"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_0"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_0(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_0(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_0(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_0(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<SYS_SYSCFG_15_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<SYS_SYSCFG_15_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_16.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_16.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_16_SPEC>;
 #[doc = "Register `sys_syscfg_16` writer"]
 pub type W = crate::W<SYS_SYSCFG_16_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_1` reader - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_1` writer - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_1` reader - noc_bus_oic_qch_clock_stop_threshold_1"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_1` writer - noc_bus_oic_qch_clock_stop_threshold_1"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_1"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_1(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_1(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_1(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_1(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<SYS_SYSCFG_16_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<SYS_SYSCFG_16_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_17.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_17.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_17_SPEC>;
 #[doc = "Register `sys_syscfg_17` writer"]
 pub type W = crate::W<SYS_SYSCFG_17_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_2` reader - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_2` writer - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_2` reader - noc_bus_oic_qch_clock_stop_threshold_2"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_2` writer - noc_bus_oic_qch_clock_stop_threshold_2"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_2"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_2(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_2(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_2(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_2(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<SYS_SYSCFG_17_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<SYS_SYSCFG_17_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_18.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_18.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_18_SPEC>;
 #[doc = "Register `sys_syscfg_18` writer"]
 pub type W = crate::W<SYS_SYSCFG_18_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_3` reader - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_3` writer - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_3` reader - noc_bus_oic_qch_clock_stop_threshold_3"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_3` writer - noc_bus_oic_qch_clock_stop_threshold_3"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_3"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_3(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_3(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_3"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_3(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_3(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<SYS_SYSCFG_18_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<SYS_SYSCFG_18_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_19.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_19.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_19_SPEC>;
 #[doc = "Register `sys_syscfg_19` writer"]
 pub type W = crate::W<SYS_SYSCFG_19_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_4` reader - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_4` writer - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_4` reader - noc_bus_oic_qch_clock_stop_threshold_4"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_4` writer - noc_bus_oic_qch_clock_stop_threshold_4"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_4"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_4(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_4(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_4"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_4(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_4(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<SYS_SYSCFG_19_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<SYS_SYSCFG_19_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_2.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_2.rs
@@ -2,53 +2,53 @@
 pub type R = crate::R<SYS_SYSCFG_2_SPEC>;
 #[doc = "Register `sys_syscfg_2` writer"]
 pub type W = crate::W<SYS_SYSCFG_2_SPEC>;
-#[doc = "Field `scfg_vout0_remap_awaddr` reader - scfg_vout0_remap_awaddr"]
-pub type SCFG_VOUT0_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout0_remap_awaddr` writer - scfg_vout0_remap_awaddr"]
-pub type SCFG_VOUT0_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout1_remap_araddr` reader - scfg_vout1_remap_araddr"]
-pub type SCFG_VOUT1_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout1_remap_araddr` writer - scfg_vout1_remap_araddr"]
-pub type SCFG_VOUT1_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout1_remap_awaddr` reader - scfg_vout1_remap_awaddr"]
-pub type SCFG_VOUT1_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout1_remap_awaddr` writer - scfg_vout1_remap_awaddr"]
-pub type SCFG_VOUT1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout0_remap_awaddr` reader - vout0_remap_awaddr"]
+pub type VOUT0_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vout0_remap_awaddr` writer - vout0_remap_awaddr"]
+pub type VOUT0_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout1_remap_araddr` reader - vout1_remap_araddr"]
+pub type VOUT1_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `vout1_remap_araddr` writer - vout1_remap_araddr"]
+pub type VOUT1_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout1_remap_awaddr` reader - vout1_remap_awaddr"]
+pub type VOUT1_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vout1_remap_awaddr` writer - vout1_remap_awaddr"]
+pub type VOUT1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_vout0_remap_awaddr"]
+    #[doc = "Bits 0:3 - vout0_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr(&self) -> SCFG_VOUT0_REMAP_AWADDR_R {
-        SCFG_VOUT0_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn vout0_remap_awaddr(&self) -> VOUT0_REMAP_AWADDR_R {
+        VOUT0_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_vout1_remap_araddr"]
+    #[doc = "Bits 4:7 - vout1_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_vout1_remap_araddr(&self) -> SCFG_VOUT1_REMAP_ARADDR_R {
-        SCFG_VOUT1_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn vout1_remap_araddr(&self) -> VOUT1_REMAP_ARADDR_R {
+        VOUT1_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_vout1_remap_awaddr"]
+    #[doc = "Bits 8:11 - vout1_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vout1_remap_awaddr(&self) -> SCFG_VOUT1_REMAP_AWADDR_R {
-        SCFG_VOUT1_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn vout1_remap_awaddr(&self) -> VOUT1_REMAP_AWADDR_R {
+        VOUT1_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_vout0_remap_awaddr"]
+    #[doc = "Bits 0:3 - vout0_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr(&mut self) -> SCFG_VOUT0_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_W::new(self, 0)
+    pub fn vout0_remap_awaddr(&mut self) -> VOUT0_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT0_REMAP_AWADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_vout1_remap_araddr"]
+    #[doc = "Bits 4:7 - vout1_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout1_remap_araddr(&mut self) -> SCFG_VOUT1_REMAP_ARADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT1_REMAP_ARADDR_W::new(self, 4)
+    pub fn vout1_remap_araddr(&mut self) -> VOUT1_REMAP_ARADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT1_REMAP_ARADDR_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_vout1_remap_awaddr"]
+    #[doc = "Bits 8:11 - vout1_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout1_remap_awaddr(&mut self) -> SCFG_VOUT1_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT1_REMAP_AWADDR_W::new(self, 8)
+    pub fn vout1_remap_awaddr(&mut self) -> VOUT1_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT1_REMAP_AWADDR_W::new(self, 8)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_20.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_20.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_20_SPEC>;
 #[doc = "Register `sys_syscfg_20` writer"]
 pub type W = crate::W<SYS_SYSCFG_20_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_5` reader - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_5` writer - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_5` reader - noc_bus_oic_qch_clock_stop_threshold_5"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_5` writer - noc_bus_oic_qch_clock_stop_threshold_5"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_5"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_5(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_5(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_5"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_5(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_5(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<SYS_SYSCFG_20_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<SYS_SYSCFG_20_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_21.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_21.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_21_SPEC>;
 #[doc = "Register `sys_syscfg_21` writer"]
 pub type W = crate::W<SYS_SYSCFG_21_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_6` reader - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_6` writer - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_6` reader - noc_bus_oic_qch_clock_stop_threshold_6"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_6` writer - noc_bus_oic_qch_clock_stop_threshold_6"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_6"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_6(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_6(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_6"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_6(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_6(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<SYS_SYSCFG_21_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<SYS_SYSCFG_21_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_22.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_22.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_22_SPEC>;
 #[doc = "Register `sys_syscfg_22` writer"]
 pub type W = crate::W<SYS_SYSCFG_22_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_7` reader - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_7` writer - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_7` reader - noc_bus_oic_qch_clock_stop_threshold_7"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_7` writer - noc_bus_oic_qch_clock_stop_threshold_7"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_7"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_7(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_7(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_7"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_7(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_7(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<SYS_SYSCFG_22_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<SYS_SYSCFG_22_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_23.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_23.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_23_SPEC>;
 #[doc = "Register `sys_syscfg_23` writer"]
 pub type W = crate::W<SYS_SYSCFG_23_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_8` reader - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_8` writer - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_8` reader - noc_bus_oic_qch_clock_stop_threshold_8"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_8` writer - noc_bus_oic_qch_clock_stop_threshold_8"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_8"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_8(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_8(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_8"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_8(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_8(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<SYS_SYSCFG_23_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<SYS_SYSCFG_23_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_24.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_24.rs
@@ -2,124 +2,112 @@
 pub type R = crate::R<SYS_SYSCFG_24_SPEC>;
 #[doc = "Register `sys_syscfg_24` writer"]
 pub type W = crate::W<SYS_SYSCFG_24_SPEC>;
-#[doc = "Field `u0_tdm16slot_clkpol` reader - u0_tdm16slot_clkpol"]
-pub type U0_TDM16SLOT_CLKPOL_R = crate::BitReader;
-#[doc = "Field `u0_tdm16slot_pcm_ms` reader - u0_tdm16slot_pcm_ms"]
-pub type U0_TDM16SLOT_PCM_MS_R = crate::BitReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in0_ctl` reader - u0_trace_mtx_scfg_c0_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in0_ctl` writer - u0_trace_mtx_scfg_c0_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in1_ctl` reader - u0_trace_mtx_scfg_c0_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in1_ctl` writer - u0_trace_mtx_scfg_c0_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in0_ctl` reader - u0_trace_mtx_scfg_c1_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in0_ctl` writer - u0_trace_mtx_scfg_c1_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in1_ctl` reader - u0_trace_mtx_scfg_c1_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in1_ctl` writer - u0_trace_mtx_scfg_c1_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in0_ctl` reader - u0_trace_mtx_scfg_c2_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in0_ctl` writer - u0_trace_mtx_scfg_c2_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in1_ctl` reader - u0_trace_mtx_scfg_c2_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in1_ctl` writer - u0_trace_mtx_scfg_c2_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `tdm16slot_clkpol` reader - tdm16slot_clkpol"]
+pub type TDM16SLOT_CLKPOL_R = crate::BitReader;
+#[doc = "Field `tdm16slot_pcm_ms` reader - tdm16slot_pcm_ms"]
+pub type TDM16SLOT_PCM_MS_R = crate::BitReader;
+#[doc = "Field `u0_trace_mtx_in0_0` reader - u0_trace_mtx_in0_0"]
+pub type U0_TRACE_MTX_IN0_0_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_0` writer - u0_trace_mtx_in0_0"]
+pub type U0_TRACE_MTX_IN0_0_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_0` reader - u0_trace_mtx_in1_0"]
+pub type U0_TRACE_MTX_IN1_0_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_0` writer - u0_trace_mtx_in1_0"]
+pub type U0_TRACE_MTX_IN1_0_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in0_1` reader - u0_trace_mtx_in0_1"]
+pub type U0_TRACE_MTX_IN0_1_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_1` writer - u0_trace_mtx_in0_1"]
+pub type U0_TRACE_MTX_IN0_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_1` reader - u0_trace_mtx_in1_1"]
+pub type U0_TRACE_MTX_IN1_1_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_1` writer - u0_trace_mtx_in1_1"]
+pub type U0_TRACE_MTX_IN1_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in0_2` reader - u0_trace_mtx_in0_2"]
+pub type U0_TRACE_MTX_IN0_2_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_2` writer - u0_trace_mtx_in0_2"]
+pub type U0_TRACE_MTX_IN0_2_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_2` reader - u0_trace_mtx_in1_2"]
+pub type U0_TRACE_MTX_IN1_2_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_2` writer - u0_trace_mtx_in1_2"]
+pub type U0_TRACE_MTX_IN1_2_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
-    #[doc = "Bit 0 - u0_tdm16slot_clkpol"]
+    #[doc = "Bit 0 - tdm16slot_clkpol"]
     #[inline(always)]
-    pub fn u0_tdm16slot_clkpol(&self) -> U0_TDM16SLOT_CLKPOL_R {
-        U0_TDM16SLOT_CLKPOL_R::new((self.bits & 1) != 0)
+    pub fn tdm16slot_clkpol(&self) -> TDM16SLOT_CLKPOL_R {
+        TDM16SLOT_CLKPOL_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_tdm16slot_pcm_ms"]
+    #[doc = "Bit 1 - tdm16slot_pcm_ms"]
     #[inline(always)]
-    pub fn u0_tdm16slot_pcm_ms(&self) -> U0_TDM16SLOT_PCM_MS_R {
-        U0_TDM16SLOT_PCM_MS_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn tdm16slot_pcm_ms(&self) -> TDM16SLOT_PCM_MS_R {
+        TDM16SLOT_PCM_MS_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:6 - u0_trace_mtx_scfg_c0_in0_ctl"]
+    #[doc = "Bits 2:6 - u0_trace_mtx_in0_0"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c0_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C0_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C0_IN0_CTL_R::new(((self.bits >> 2) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_0(&self) -> U0_TRACE_MTX_IN0_0_R {
+        U0_TRACE_MTX_IN0_0_R::new(((self.bits >> 2) & 0x1f) as u8)
     }
-    #[doc = "Bits 7:11 - u0_trace_mtx_scfg_c0_in1_ctl"]
+    #[doc = "Bits 7:11 - u0_trace_mtx_in1_0"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c0_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C0_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C0_IN1_CTL_R::new(((self.bits >> 7) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_0(&self) -> U0_TRACE_MTX_IN1_0_R {
+        U0_TRACE_MTX_IN1_0_R::new(((self.bits >> 7) & 0x1f) as u8)
     }
-    #[doc = "Bits 12:16 - u0_trace_mtx_scfg_c1_in0_ctl"]
+    #[doc = "Bits 12:16 - u0_trace_mtx_in0_1"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c1_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C1_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C1_IN0_CTL_R::new(((self.bits >> 12) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_1(&self) -> U0_TRACE_MTX_IN0_1_R {
+        U0_TRACE_MTX_IN0_1_R::new(((self.bits >> 12) & 0x1f) as u8)
     }
-    #[doc = "Bits 17:21 - u0_trace_mtx_scfg_c1_in1_ctl"]
+    #[doc = "Bits 17:21 - u0_trace_mtx_in1_1"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c1_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C1_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C1_IN1_CTL_R::new(((self.bits >> 17) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_1(&self) -> U0_TRACE_MTX_IN1_1_R {
+        U0_TRACE_MTX_IN1_1_R::new(((self.bits >> 17) & 0x1f) as u8)
     }
-    #[doc = "Bits 22:26 - u0_trace_mtx_scfg_c2_in0_ctl"]
+    #[doc = "Bits 22:26 - u0_trace_mtx_in0_2"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c2_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C2_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C2_IN0_CTL_R::new(((self.bits >> 22) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_2(&self) -> U0_TRACE_MTX_IN0_2_R {
+        U0_TRACE_MTX_IN0_2_R::new(((self.bits >> 22) & 0x1f) as u8)
     }
-    #[doc = "Bits 27:31 - u0_trace_mtx_scfg_c2_in1_ctl"]
+    #[doc = "Bits 27:31 - u0_trace_mtx_in1_2"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c2_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C2_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C2_IN1_CTL_R::new(((self.bits >> 27) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_2(&self) -> U0_TRACE_MTX_IN1_2_R {
+        U0_TRACE_MTX_IN1_2_R::new(((self.bits >> 27) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 2:6 - u0_trace_mtx_scfg_c0_in0_ctl"]
+    #[doc = "Bits 2:6 - u0_trace_mtx_in0_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c0_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C0_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C0_IN0_CTL_W::new(self, 2)
+    pub fn u0_trace_mtx_in0_0(&mut self) -> U0_TRACE_MTX_IN0_0_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_0_W::new(self, 2)
     }
-    #[doc = "Bits 7:11 - u0_trace_mtx_scfg_c0_in1_ctl"]
+    #[doc = "Bits 7:11 - u0_trace_mtx_in1_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c0_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C0_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C0_IN1_CTL_W::new(self, 7)
+    pub fn u0_trace_mtx_in1_0(&mut self) -> U0_TRACE_MTX_IN1_0_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_0_W::new(self, 7)
     }
-    #[doc = "Bits 12:16 - u0_trace_mtx_scfg_c1_in0_ctl"]
+    #[doc = "Bits 12:16 - u0_trace_mtx_in0_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c1_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C1_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C1_IN0_CTL_W::new(self, 12)
+    pub fn u0_trace_mtx_in0_1(&mut self) -> U0_TRACE_MTX_IN0_1_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_1_W::new(self, 12)
     }
-    #[doc = "Bits 17:21 - u0_trace_mtx_scfg_c1_in1_ctl"]
+    #[doc = "Bits 17:21 - u0_trace_mtx_in1_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c1_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C1_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C1_IN1_CTL_W::new(self, 17)
+    pub fn u0_trace_mtx_in1_1(&mut self) -> U0_TRACE_MTX_IN1_1_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_1_W::new(self, 17)
     }
-    #[doc = "Bits 22:26 - u0_trace_mtx_scfg_c2_in0_ctl"]
+    #[doc = "Bits 22:26 - u0_trace_mtx_in0_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c2_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C2_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C2_IN0_CTL_W::new(self, 22)
+    pub fn u0_trace_mtx_in0_2(&mut self) -> U0_TRACE_MTX_IN0_2_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_2_W::new(self, 22)
     }
-    #[doc = "Bits 27:31 - u0_trace_mtx_scfg_c2_in1_ctl"]
+    #[doc = "Bits 27:31 - u0_trace_mtx_in1_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c2_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C2_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C2_IN1_CTL_W::new(self, 27)
+    pub fn u0_trace_mtx_in1_2(&mut self) -> U0_TRACE_MTX_IN1_2_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_2_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_3.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_3.rs
@@ -2,76 +2,68 @@
 pub type R = crate::R<SYS_SYSCFG_3_SPEC>;
 #[doc = "Register `sys_syscfg_3` writer"]
 pub type W = crate::W<SYS_SYSCFG_3_SPEC>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio0` reader - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO0_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio0` writer - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio1` reader - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO1_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio1` writer - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio2` reader - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO2_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio2` writer - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio3` reader - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO3_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio3` writer - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio0` reader - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO0_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio0` writer - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio1` reader - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO1_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio1` writer - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio2` reader - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO2_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio2` writer - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio3` reader - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO3_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio3` writer - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO3_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio0(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO0_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO0_R::new((self.bits & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio0(&self) -> VOUT0_REMAP_AWADDR_GPIO0_R {
+        VOUT0_REMAP_AWADDR_GPIO0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio1(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO1_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO1_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio1(&self) -> VOUT0_REMAP_AWADDR_GPIO1_R {
+        VOUT0_REMAP_AWADDR_GPIO1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio2(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO2_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO2_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio2(&self) -> VOUT0_REMAP_AWADDR_GPIO2_R {
+        VOUT0_REMAP_AWADDR_GPIO2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio3(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO3_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO3_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio3(&self) -> VOUT0_REMAP_AWADDR_GPIO3_R {
+        VOUT0_REMAP_AWADDR_GPIO3_R::new(((self.bits >> 3) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio0(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO0_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO0_W::new(self, 0)
+    pub fn vout0_remap_awaddr_gpio0(&mut self) -> VOUT0_REMAP_AWADDR_GPIO0_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO0_W::new(self, 0)
     }
     #[doc = "Bit 1 - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio1(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO1_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO1_W::new(self, 1)
+    pub fn vout0_remap_awaddr_gpio1(&mut self) -> VOUT0_REMAP_AWADDR_GPIO1_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO1_W::new(self, 1)
     }
     #[doc = "Bit 2 - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio2(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO2_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO2_W::new(self, 2)
+    pub fn vout0_remap_awaddr_gpio2(&mut self) -> VOUT0_REMAP_AWADDR_GPIO2_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO2_W::new(self, 2)
     }
     #[doc = "Bit 3 - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio3(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO3_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO3_W::new(self, 3)
+    pub fn vout0_remap_awaddr_gpio3(&mut self) -> VOUT0_REMAP_AWADDR_GPIO3_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO3_W::new(self, 3)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_34.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_34.rs
@@ -34,28 +34,28 @@ pub type U0_VENC_INTSRAM_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_VENC_INTSRAM_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_venc_intsram_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_VENC_INTSRAM_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_i_ipu_current_buffer` reader - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
-pub type U0_WAVE420L_I_IPU_CURRENT_BUFFER_R = crate::FieldReader;
-#[doc = "Field `u0_wave420l_i_ipu_current_buffer` writer - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
-pub type U0_WAVE420L_I_IPU_CURRENT_BUFFER_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `u0_wave420l_i_ipu_end_of_row` reader - This signal is flipped every time when the IPU completes writing a row."]
-pub type U0_WAVE420L_I_IPU_END_OF_ROW_R = crate::BitReader;
-#[doc = "Field `u0_wave420l_i_ipu_end_of_row` writer - This signal is flipped every time when the IPU completes writing a row."]
-pub type U0_WAVE420L_I_IPU_END_OF_ROW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_i_ipu_new_frame` reader - This signal is flipped every time when the IPU completes writing a new frame."]
-pub type U0_WAVE420L_I_IPU_NEW_FRAME_R = crate::BitReader;
-#[doc = "Field `u0_wave420l_i_ipu_new_frame` writer - This signal is flipped every time when the IPU completes writing a new frame."]
-pub type U0_WAVE420L_I_IPU_NEW_FRAME_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_o_vpu_idle` reader - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
-pub type U0_WAVE420L_O_VPU_IDLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_can_fd_enable` reader - u1_can_ctrl_can_fd_enable"]
-pub type U1_CAN_CTRL_CAN_FD_ENABLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_can_fd_enable` writer - u1_can_ctrl_can_fd_enable"]
-pub type U1_CAN_CTRL_CAN_FD_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_can_ctrl_host_ecc_disable` reader - u1_can_ctrl_host_ecc_disable"]
-pub type U1_CAN_CTRL_HOST_ECC_DISABLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_host_ecc_disable` writer - u1_can_ctrl_host_ecc_disable"]
-pub type U1_CAN_CTRL_HOST_ECC_DISABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_ipu_current_buffer` reader - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
+pub type WAVE420L_IPU_CURRENT_BUFFER_R = crate::FieldReader;
+#[doc = "Field `wave420l_ipu_current_buffer` writer - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
+pub type WAVE420L_IPU_CURRENT_BUFFER_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `wave420l_ipu_end_of_row` reader - This signal is flipped every time when the IPU completes writing a row."]
+pub type WAVE420L_IPU_END_OF_ROW_R = crate::BitReader;
+#[doc = "Field `wave420l_ipu_end_of_row` writer - This signal is flipped every time when the IPU completes writing a row."]
+pub type WAVE420L_IPU_END_OF_ROW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_ipu_new_frame` reader - This signal is flipped every time when the IPU completes writing a new frame."]
+pub type WAVE420L_IPU_NEW_FRAME_R = crate::BitReader;
+#[doc = "Field `wave420l_ipu_new_frame` writer - This signal is flipped every time when the IPU completes writing a new frame."]
+pub type WAVE420L_IPU_NEW_FRAME_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_vpu_idle` reader - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
+pub type WAVE420L_VPU_IDLE_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_1` reader - can_ctrl_fd_enable_1"]
+pub type CAN_CTRL_FD_ENABLE_1_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_1` writer - can_ctrl_fd_enable_1"]
+pub type CAN_CTRL_FD_ENABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_ecc_disable_1` reader - can_ctrl_host_ecc_disable_1"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_1_R = crate::BitReader;
+#[doc = "Field `can_ctrl_host_ecc_disable_1` writer - can_ctrl_host_ecc_disable_1"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -99,33 +99,33 @@ impl R {
     }
     #[doc = "Bits 12:14 - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_current_buffer(&self) -> U0_WAVE420L_I_IPU_CURRENT_BUFFER_R {
-        U0_WAVE420L_I_IPU_CURRENT_BUFFER_R::new(((self.bits >> 12) & 7) as u8)
+    pub fn wave420l_ipu_current_buffer(&self) -> WAVE420L_IPU_CURRENT_BUFFER_R {
+        WAVE420L_IPU_CURRENT_BUFFER_R::new(((self.bits >> 12) & 7) as u8)
     }
     #[doc = "Bit 15 - This signal is flipped every time when the IPU completes writing a row."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_end_of_row(&self) -> U0_WAVE420L_I_IPU_END_OF_ROW_R {
-        U0_WAVE420L_I_IPU_END_OF_ROW_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn wave420l_ipu_end_of_row(&self) -> WAVE420L_IPU_END_OF_ROW_R {
+        WAVE420L_IPU_END_OF_ROW_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - This signal is flipped every time when the IPU completes writing a new frame."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_new_frame(&self) -> U0_WAVE420L_I_IPU_NEW_FRAME_R {
-        U0_WAVE420L_I_IPU_NEW_FRAME_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn wave420l_ipu_new_frame(&self) -> WAVE420L_IPU_NEW_FRAME_R {
+        WAVE420L_IPU_NEW_FRAME_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
     #[inline(always)]
-    pub fn u0_wave420l_o_vpu_idle(&self) -> U0_WAVE420L_O_VPU_IDLE_R {
-        U0_WAVE420L_O_VPU_IDLE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn wave420l_vpu_idle(&self) -> WAVE420L_VPU_IDLE_R {
+        WAVE420L_VPU_IDLE_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u1_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 18 - can_ctrl_fd_enable_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_can_fd_enable(&self) -> U1_CAN_CTRL_CAN_FD_ENABLE_R {
-        U1_CAN_CTRL_CAN_FD_ENABLE_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn can_ctrl_fd_enable_1(&self) -> CAN_CTRL_FD_ENABLE_1_R {
+        CAN_CTRL_FD_ENABLE_1_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u1_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 19 - can_ctrl_host_ecc_disable_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_host_ecc_disable(&self) -> U1_CAN_CTRL_HOST_ECC_DISABLE_R {
-        U1_CAN_CTRL_HOST_ECC_DISABLE_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn can_ctrl_host_ecc_disable_1(&self) -> CAN_CTRL_HOST_ECC_DISABLE_1_R {
+        CAN_CTRL_HOST_ECC_DISABLE_1_R::new(((self.bits >> 19) & 1) != 0)
     }
 }
 impl W {
@@ -196,40 +196,36 @@ impl W {
     #[doc = "Bits 12:14 - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_current_buffer(
+    pub fn wave420l_ipu_current_buffer(
         &mut self,
-    ) -> U0_WAVE420L_I_IPU_CURRENT_BUFFER_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_CURRENT_BUFFER_W::new(self, 12)
+    ) -> WAVE420L_IPU_CURRENT_BUFFER_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_CURRENT_BUFFER_W::new(self, 12)
     }
     #[doc = "Bit 15 - This signal is flipped every time when the IPU completes writing a row."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_end_of_row(
-        &mut self,
-    ) -> U0_WAVE420L_I_IPU_END_OF_ROW_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_END_OF_ROW_W::new(self, 15)
+    pub fn wave420l_ipu_end_of_row(&mut self) -> WAVE420L_IPU_END_OF_ROW_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_END_OF_ROW_W::new(self, 15)
     }
     #[doc = "Bit 16 - This signal is flipped every time when the IPU completes writing a new frame."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_new_frame(
-        &mut self,
-    ) -> U0_WAVE420L_I_IPU_NEW_FRAME_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_NEW_FRAME_W::new(self, 16)
+    pub fn wave420l_ipu_new_frame(&mut self) -> WAVE420L_IPU_NEW_FRAME_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_NEW_FRAME_W::new(self, 16)
     }
-    #[doc = "Bit 18 - u1_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 18 - can_ctrl_fd_enable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_can_ctrl_can_fd_enable(&mut self) -> U1_CAN_CTRL_CAN_FD_ENABLE_W<SYS_SYSCFG_34_SPEC> {
-        U1_CAN_CTRL_CAN_FD_ENABLE_W::new(self, 18)
+    pub fn can_ctrl_fd_enable_1(&mut self) -> CAN_CTRL_FD_ENABLE_1_W<SYS_SYSCFG_34_SPEC> {
+        CAN_CTRL_FD_ENABLE_1_W::new(self, 18)
     }
-    #[doc = "Bit 19 - u1_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 19 - can_ctrl_host_ecc_disable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_can_ctrl_host_ecc_disable(
+    pub fn can_ctrl_host_ecc_disable_1(
         &mut self,
-    ) -> U1_CAN_CTRL_HOST_ECC_DISABLE_W<SYS_SYSCFG_34_SPEC> {
-        U1_CAN_CTRL_HOST_ECC_DISABLE_W::new(self, 19)
+    ) -> CAN_CTRL_HOST_ECC_DISABLE_1_W<SYS_SYSCFG_34_SPEC> {
+        CAN_CTRL_HOST_ECC_DISABLE_1_W::new(self, 19)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_35.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_35.rs
@@ -2,8 +2,8 @@
 pub type R = crate::R<SYS_SYSCFG_35_SPEC>;
 #[doc = "Register `sys_syscfg_35` writer"]
 pub type W = crate::W<SYS_SYSCFG_35_SPEC>;
-#[doc = "Field `u1_can_ctrl_host_if` reader - u1_can_ctrl_host_if"]
-pub type U1_CAN_CTRL_HOST_IF_R = crate::FieldReader<u32>;
+#[doc = "Field `can_ctrl_host_if_1` reader - can_ctrl_host_if_1"]
+pub type CAN_CTRL_HOST_IF_1_R = crate::FieldReader<u32>;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_SLP_R = crate::BitReader;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -37,10 +37,10 @@ pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_VG_R = crate::BitReader;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:18 - u1_can_ctrl_host_if"]
+    #[doc = "Bits 0:18 - can_ctrl_host_if_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_host_if(&self) -> U1_CAN_CTRL_HOST_IF_R {
-        U1_CAN_CTRL_HOST_IF_R::new(self.bits & 0x0007_ffff)
+    pub fn can_ctrl_host_if_1(&self) -> CAN_CTRL_HOST_IF_1_R {
+        CAN_CTRL_HOST_IF_1_R::new(self.bits & 0x0007_ffff)
     }
     #[doc = "Bit 19 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_36.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_36.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<SYS_SYSCFG_36_SPEC>;
 #[doc = "Register `sys_syscfg_36` writer"]
 pub type W = crate::W<SYS_SYSCFG_36_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_mac_speed_0` reader - u1_gmac5_axi64_mac_speed_0"]
-pub type U1_GMAC5_AXI64_MAC_SPEED_0_R = crate::FieldReader;
-#[doc = "Field `u1_gmac5_axi64_phy_intf_sel_i` reader - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
-pub type U1_GMAC5_AXI64_PHY_INTF_SEL_I_R = crate::FieldReader;
-#[doc = "Field `u1_gmac5_axi64_phy_intf_sel_i` writer - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
-pub type U1_GMAC5_AXI64_PHY_INTF_SEL_I_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `gmac5_axi64_mac_speed` reader - gmac5_axi64_mac_speed"]
+pub type GMAC5_AXI64_MAC_SPEED_R = crate::FieldReader;
+#[doc = "Field `gmac5_axi64_phy_intf_sel` reader - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
+pub type GMAC5_AXI64_PHY_INTF_SEL_R = crate::FieldReader;
+#[doc = "Field `gmac5_axi64_phy_intf_sel` writer - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
+pub type GMAC5_AXI64_PHY_INTF_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
 impl R {
-    #[doc = "Bits 0:1 - u1_gmac5_axi64_mac_speed_0"]
+    #[doc = "Bits 0:1 - gmac5_axi64_mac_speed"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_mac_speed_0(&self) -> U1_GMAC5_AXI64_MAC_SPEED_0_R {
-        U1_GMAC5_AXI64_MAC_SPEED_0_R::new((self.bits & 3) as u8)
+    pub fn gmac5_axi64_mac_speed(&self) -> GMAC5_AXI64_MAC_SPEED_R {
+        GMAC5_AXI64_MAC_SPEED_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bits 2:4 - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_phy_intf_sel_i(&self) -> U1_GMAC5_AXI64_PHY_INTF_SEL_I_R {
-        U1_GMAC5_AXI64_PHY_INTF_SEL_I_R::new(((self.bits >> 2) & 7) as u8)
+    pub fn gmac5_axi64_phy_intf_sel(&self) -> GMAC5_AXI64_PHY_INTF_SEL_R {
+        GMAC5_AXI64_PHY_INTF_SEL_R::new(((self.bits >> 2) & 7) as u8)
     }
 }
 impl W {
     #[doc = "Bits 2:4 - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_gmac5_axi64_phy_intf_sel_i(
-        &mut self,
-    ) -> U1_GMAC5_AXI64_PHY_INTF_SEL_I_W<SYS_SYSCFG_36_SPEC> {
-        U1_GMAC5_AXI64_PHY_INTF_SEL_I_W::new(self, 2)
+    pub fn gmac5_axi64_phy_intf_sel(&mut self) -> GMAC5_AXI64_PHY_INTF_SEL_W<SYS_SYSCFG_36_SPEC> {
+        GMAC5_AXI64_PHY_INTF_SEL_W::new(self, 2)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_37.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_37.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<SYS_SYSCFG_37_SPEC>;
 #[doc = "Register `sys_syscfg_37` writer"]
 pub type W = crate::W<SYS_SYSCFG_37_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_ptp_timestamp_o_31_0` reader - u1_gmac5_axi64_ptp_timestamp_o_31_0"]
-pub type U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `gmac5_axi64_ptp_timestamp_0_31` reader - gmac5_axi64_ptp_timestamp_0_31"]
+pub type GMAC5_AXI64_PTP_TIMESTAMP_0_31_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_gmac5_axi64_ptp_timestamp_o_31_0"]
+    #[doc = "Bits 0:31 - gmac5_axi64_ptp_timestamp_0_31"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_ptp_timestamp_o_31_0(&self) -> U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R {
-        U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R::new(self.bits)
+    pub fn gmac5_axi64_ptp_timestamp_0_31(&self) -> GMAC5_AXI64_PTP_TIMESTAMP_0_31_R {
+        GMAC5_AXI64_PTP_TIMESTAMP_0_31_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_38.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_38.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<SYS_SYSCFG_38_SPEC>;
 #[doc = "Register `sys_syscfg_38` writer"]
 pub type W = crate::W<SYS_SYSCFG_38_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_ptp_timestamp_o_63_32` reader - u1_gmac5_axi64_ptp_timestamp_o_63_32"]
-pub type U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `gmac5_axi64_ptp_timestamp_32_63` reader - gmac5_axi64_ptp_timestamp_32_63"]
+pub type GMAC5_AXI64_PTP_TIMESTAMP_32_63_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_gmac5_axi64_ptp_timestamp_o_63_32"]
+    #[doc = "Bits 0:31 - gmac5_axi64_ptp_timestamp_32_63"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_ptp_timestamp_o_63_32(&self) -> U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R {
-        U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R::new(self.bits)
+    pub fn gmac5_axi64_ptp_timestamp_32_63(&self) -> GMAC5_AXI64_PTP_TIMESTAMP_32_63_R {
+        GMAC5_AXI64_PTP_TIMESTAMP_32_63_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_39.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_39.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<SYS_SYSCFG_39_SPEC>;
 #[doc = "Register `sys_syscfg_39` writer"]
 pub type W = crate::W<SYS_SYSCFG_39_SPEC>;
-#[doc = "Field `u1_i2c_ic_en` reader - I2C interface enable."]
-pub type U1_I2C_IC_EN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select."]
-pub type U1_SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
-#[doc = "Field `u1_sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select."]
-pub type U1_SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u1_sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_sdio_m_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_m_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_clr_reset_status` reader - u1_reset_ctrl_clr_reset_status"]
-pub type U1_RESET_CTRL_CLR_RESET_STATUS_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_clr_reset_status` writer - u1_reset_ctrl_clr_reset_status"]
-pub type U1_RESET_CTRL_CLR_RESET_STATUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_pll_timecnt_finish` reader - u1_reset_ctrl_pll_timecnt_finish"]
-pub type U1_RESET_CTRL_PLL_TIMECNT_FINISH_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_rstn_sw` reader - u1_reset_ctrl_rstn_sw"]
-pub type U1_RESET_CTRL_RSTN_SW_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_rstn_sw` writer - u1_reset_ctrl_rstn_sw"]
-pub type U1_RESET_CTRL_RSTN_SW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_sys_reset_status` reader - u1_reset_ctrl_sys_reset_status"]
-pub type U1_RESET_CTRL_SYS_RESET_STATUS_R = crate::FieldReader;
+#[doc = "Field `i2c_ic_en_1` reader - I2C interface enable."]
+pub type I2C_IC_EN_1_R = crate::BitReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl_1` reader - Data strobe delay chain select."]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_1_R = crate::FieldReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl_1` writer - Data strobe delay chain select."]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `sdio_hbig_endian_1` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_1_R = crate::BitReader;
+#[doc = "Field `sdio_hbig_endian_1` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `sdio_m_hbig_endian_1` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_1_R = crate::BitReader;
+#[doc = "Field `sdio_m_hbig_endian_1` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_clr_reset_status_1` reader - reset_ctrl_clr_reset_status_1"]
+pub type RESET_CTRL_CLR_RESET_STATUS_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_clr_reset_status_1` writer - reset_ctrl_clr_reset_status_1"]
+pub type RESET_CTRL_CLR_RESET_STATUS_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_pll_timecnt_finish_1` reader - reset_ctrl_pll_timecnt_finish_1"]
+pub type RESET_CTRL_PLL_TIMECNT_FINISH_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_rstn_sw_1` reader - reset_ctrl_rstn_sw_1"]
+pub type RESET_CTRL_RSTN_SW_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_rstn_sw_1` writer - reset_ctrl_rstn_sw_1"]
+pub type RESET_CTRL_RSTN_SW_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_sys_reset_status_1` reader - reset_ctrl_sys_reset_status_1"]
+pub type RESET_CTRL_SYS_RESET_STATUS_1_R = crate::FieldReader;
 #[doc = "Field `i2c_ic_en_2` reader - I2C interface enable."]
 pub type I2C_IC_EN_2_R = crate::BitReader;
 #[doc = "Field `i2c_ic_en_3` reader - I2C interface enable."]
@@ -41,43 +41,43 @@ pub type I2C_IC_EN_6_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - I2C interface enable."]
     #[inline(always)]
-    pub fn u1_i2c_ic_en(&self) -> U1_I2C_IC_EN_R {
-        U1_I2C_IC_EN_R::new((self.bits & 1) != 0)
+    pub fn i2c_ic_en_1(&self) -> I2C_IC_EN_1_R {
+        I2C_IC_EN_1_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bits 1:5 - Data strobe delay chain select."]
     #[inline(always)]
-    pub fn u1_sdio_data_strobe_phase_ctrl(&self) -> U1_SDIO_DATA_STROBE_PHASE_CTRL_R {
-        U1_SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 1) & 0x1f) as u8)
+    pub fn sdio_data_strobe_phase_ctrl_1(&self) -> SDIO_DATA_STROBE_PHASE_CTRL_1_R {
+        SDIO_DATA_STROBE_PHASE_CTRL_1_R::new(((self.bits >> 1) & 0x1f) as u8)
     }
     #[doc = "Bit 6 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u1_sdio_hbig_endian(&self) -> U1_SDIO_HBIG_ENDIAN_R {
-        U1_SDIO_HBIG_ENDIAN_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn sdio_hbig_endian_1(&self) -> SDIO_HBIG_ENDIAN_1_R {
+        SDIO_HBIG_ENDIAN_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u1_sdio_m_hbig_endian(&self) -> U1_SDIO_M_HBIG_ENDIAN_R {
-        U1_SDIO_M_HBIG_ENDIAN_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn sdio_m_hbig_endian_1(&self) -> SDIO_M_HBIG_ENDIAN_1_R {
+        SDIO_M_HBIG_ENDIAN_1_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u1_reset_ctrl_clr_reset_status"]
+    #[doc = "Bit 8 - reset_ctrl_clr_reset_status_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_clr_reset_status(&self) -> U1_RESET_CTRL_CLR_RESET_STATUS_R {
-        U1_RESET_CTRL_CLR_RESET_STATUS_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn reset_ctrl_clr_reset_status_1(&self) -> RESET_CTRL_CLR_RESET_STATUS_1_R {
+        RESET_CTRL_CLR_RESET_STATUS_1_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_reset_ctrl_pll_timecnt_finish"]
+    #[doc = "Bit 9 - reset_ctrl_pll_timecnt_finish_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_pll_timecnt_finish(&self) -> U1_RESET_CTRL_PLL_TIMECNT_FINISH_R {
-        U1_RESET_CTRL_PLL_TIMECNT_FINISH_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn reset_ctrl_pll_timecnt_finish_1(&self) -> RESET_CTRL_PLL_TIMECNT_FINISH_1_R {
+        RESET_CTRL_PLL_TIMECNT_FINISH_1_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_reset_ctrl_rstn_sw"]
+    #[doc = "Bit 10 - reset_ctrl_rstn_sw_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_rstn_sw(&self) -> U1_RESET_CTRL_RSTN_SW_R {
-        U1_RESET_CTRL_RSTN_SW_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn reset_ctrl_rstn_sw_1(&self) -> RESET_CTRL_RSTN_SW_1_R {
+        RESET_CTRL_RSTN_SW_1_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bits 11:14 - u1_reset_ctrl_sys_reset_status"]
+    #[doc = "Bits 11:14 - reset_ctrl_sys_reset_status_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_sys_reset_status(&self) -> U1_RESET_CTRL_SYS_RESET_STATUS_R {
-        U1_RESET_CTRL_SYS_RESET_STATUS_R::new(((self.bits >> 11) & 0x0f) as u8)
+    pub fn reset_ctrl_sys_reset_status_1(&self) -> RESET_CTRL_SYS_RESET_STATUS_1_R {
+        RESET_CTRL_SYS_RESET_STATUS_1_R::new(((self.bits >> 11) & 0x0f) as u8)
     }
     #[doc = "Bit 15 - I2C interface enable."]
     #[inline(always)]
@@ -109,36 +109,36 @@ impl W {
     #[doc = "Bits 1:5 - Data strobe delay chain select."]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_data_strobe_phase_ctrl(
+    pub fn sdio_data_strobe_phase_ctrl_1(
         &mut self,
-    ) -> U1_SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 1)
+    ) -> SDIO_DATA_STROBE_PHASE_CTRL_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_DATA_STROBE_PHASE_CTRL_1_W::new(self, 1)
     }
     #[doc = "Bit 6 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_hbig_endian(&mut self) -> U1_SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_HBIG_ENDIAN_W::new(self, 6)
+    pub fn sdio_hbig_endian_1(&mut self) -> SDIO_HBIG_ENDIAN_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_HBIG_ENDIAN_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_m_hbig_endian(&mut self) -> U1_SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_M_HBIG_ENDIAN_W::new(self, 7)
+    pub fn sdio_m_hbig_endian_1(&mut self) -> SDIO_M_HBIG_ENDIAN_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_M_HBIG_ENDIAN_1_W::new(self, 7)
     }
-    #[doc = "Bit 8 - u1_reset_ctrl_clr_reset_status"]
+    #[doc = "Bit 8 - reset_ctrl_clr_reset_status_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_reset_ctrl_clr_reset_status(
+    pub fn reset_ctrl_clr_reset_status_1(
         &mut self,
-    ) -> U1_RESET_CTRL_CLR_RESET_STATUS_W<SYS_SYSCFG_39_SPEC> {
-        U1_RESET_CTRL_CLR_RESET_STATUS_W::new(self, 8)
+    ) -> RESET_CTRL_CLR_RESET_STATUS_1_W<SYS_SYSCFG_39_SPEC> {
+        RESET_CTRL_CLR_RESET_STATUS_1_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u1_reset_ctrl_rstn_sw"]
+    #[doc = "Bit 10 - reset_ctrl_rstn_sw_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_reset_ctrl_rstn_sw(&mut self) -> U1_RESET_CTRL_RSTN_SW_W<SYS_SYSCFG_39_SPEC> {
-        U1_RESET_CTRL_RSTN_SW_W::new(self, 10)
+    pub fn reset_ctrl_rstn_sw_1(&mut self) -> RESET_CTRL_RSTN_SW_1_W<SYS_SYSCFG_39_SPEC> {
+        RESET_CTRL_RSTN_SW_1_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_4.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_4.rs
@@ -2,70 +2,68 @@
 pub type R = crate::R<SYS_SYSCFG_4_SPEC>;
 #[doc = "Register `sys_syscfg_4` writer"]
 pub type W = crate::W<SYS_SYSCFG_4_SPEC>;
-#[doc = "Field `u0_coda12_o_cur_inst_a` reader - Tie 0 in JPU internal, do not care"]
-pub type U0_CODA12_O_CUR_INST_A_R = crate::FieldReader;
-#[doc = "Field `u0_wave511_o_vpu_idle` reader - VPU monitoring signal"]
-pub type U0_WAVE511_O_VPU_IDLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_can_fd_enable` reader - u0_can_ctrl_can_fd_enable"]
-pub type U0_CAN_CTRL_CAN_FD_ENABLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_can_fd_enable` writer - u0_can_ctrl_can_fd_enable"]
-pub type U0_CAN_CTRL_CAN_FD_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_can_ctrl_host_ecc_disable` reader - u0_can_ctrl_host_ecc_disable"]
-pub type U0_CAN_CTRL_HOST_ECC_DISABLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_host_ecc_disable` writer - u0_can_ctrl_host_ecc_disable"]
-pub type U0_CAN_CTRL_HOST_ECC_DISABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_can_ctrl_host_if` reader - u0_can_ctrl_host_if"]
-pub type U0_CAN_CTRL_HOST_IF_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel` reader - des_qspi_sclk_dla: clock delay"]
-pub type U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R = crate::FieldReader;
+#[doc = "Field `coda12_cur_inst` reader - Tie 0 in JPU internal, do not care"]
+pub type CODA12_CUR_INST_R = crate::FieldReader;
+#[doc = "Field `wave511_vpu_idle` reader - VPU monitoring signal"]
+pub type WAVE511_VPU_IDLE_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_0` reader - can_ctrl_fd_enable_0"]
+pub type CAN_CTRL_FD_ENABLE_0_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_0` writer - can_ctrl_fd_enable_0"]
+pub type CAN_CTRL_FD_ENABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_ecc_disable_0` reader - can_ctrl_host_ecc_disable_0"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_0_R = crate::BitReader;
+#[doc = "Field `can_ctrl_host_ecc_disable_0` writer - can_ctrl_host_ecc_disable_0"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_if_0` reader - can_ctrl_host_if_0"]
+pub type CAN_CTRL_HOST_IF_0_R = crate::FieldReader<u32>;
+#[doc = "Field `qspi_sclk_dlychain_sel` reader - des_qspi_sclk_dla: clock delay"]
+pub type QSPI_SCLK_DLYCHAIN_SEL_R = crate::FieldReader;
 impl R {
     #[doc = "Bits 0:1 - Tie 0 in JPU internal, do not care"]
     #[inline(always)]
-    pub fn u0_coda12_o_cur_inst_a(&self) -> U0_CODA12_O_CUR_INST_A_R {
-        U0_CODA12_O_CUR_INST_A_R::new((self.bits & 3) as u8)
+    pub fn coda12_cur_inst(&self) -> CODA12_CUR_INST_R {
+        CODA12_CUR_INST_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bit 2 - VPU monitoring signal"]
     #[inline(always)]
-    pub fn u0_wave511_o_vpu_idle(&self) -> U0_WAVE511_O_VPU_IDLE_R {
-        U0_WAVE511_O_VPU_IDLE_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn wave511_vpu_idle(&self) -> WAVE511_VPU_IDLE_R {
+        WAVE511_VPU_IDLE_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 3 - can_ctrl_fd_enable_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_can_fd_enable(&self) -> U0_CAN_CTRL_CAN_FD_ENABLE_R {
-        U0_CAN_CTRL_CAN_FD_ENABLE_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn can_ctrl_fd_enable_0(&self) -> CAN_CTRL_FD_ENABLE_0_R {
+        CAN_CTRL_FD_ENABLE_0_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 4 - can_ctrl_host_ecc_disable_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_host_ecc_disable(&self) -> U0_CAN_CTRL_HOST_ECC_DISABLE_R {
-        U0_CAN_CTRL_HOST_ECC_DISABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn can_ctrl_host_ecc_disable_0(&self) -> CAN_CTRL_HOST_ECC_DISABLE_0_R {
+        CAN_CTRL_HOST_ECC_DISABLE_0_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:23 - u0_can_ctrl_host_if"]
+    #[doc = "Bits 5:23 - can_ctrl_host_if_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_host_if(&self) -> U0_CAN_CTRL_HOST_IF_R {
-        U0_CAN_CTRL_HOST_IF_R::new((self.bits >> 5) & 0x0007_ffff)
+    pub fn can_ctrl_host_if_0(&self) -> CAN_CTRL_HOST_IF_0_R {
+        CAN_CTRL_HOST_IF_0_R::new((self.bits >> 5) & 0x0007_ffff)
     }
     #[doc = "Bits 24:28 - des_qspi_sclk_dla: clock delay"]
     #[inline(always)]
-    pub fn u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel(
-        &self,
-    ) -> U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R {
-        U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R::new(((self.bits >> 24) & 0x1f) as u8)
+    pub fn qspi_sclk_dlychain_sel(&self) -> QSPI_SCLK_DLYCHAIN_SEL_R {
+        QSPI_SCLK_DLYCHAIN_SEL_R::new(((self.bits >> 24) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bit 3 - u0_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 3 - can_ctrl_fd_enable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_can_ctrl_can_fd_enable(&mut self) -> U0_CAN_CTRL_CAN_FD_ENABLE_W<SYS_SYSCFG_4_SPEC> {
-        U0_CAN_CTRL_CAN_FD_ENABLE_W::new(self, 3)
+    pub fn can_ctrl_fd_enable_0(&mut self) -> CAN_CTRL_FD_ENABLE_0_W<SYS_SYSCFG_4_SPEC> {
+        CAN_CTRL_FD_ENABLE_0_W::new(self, 3)
     }
-    #[doc = "Bit 4 - u0_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 4 - can_ctrl_host_ecc_disable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_can_ctrl_host_ecc_disable(
+    pub fn can_ctrl_host_ecc_disable_0(
         &mut self,
-    ) -> U0_CAN_CTRL_HOST_ECC_DISABLE_W<SYS_SYSCFG_4_SPEC> {
-        U0_CAN_CTRL_HOST_ECC_DISABLE_W::new(self, 4)
+    ) -> CAN_CTRL_HOST_ECC_DISABLE_0_W<SYS_SYSCFG_4_SPEC> {
+        CAN_CTRL_HOST_ECC_DISABLE_0_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_5.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_5.rs
@@ -66,18 +66,18 @@ pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG
 pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_cdns_spdif_scfg_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdns_spdif_trmodeo` reader - 1 for transmitter 0 for receiver"]
-pub type U0_CDNS_SPDIF_TRMODEO_R = crate::BitReader;
-#[doc = "Field `u0_i2c_ic_en` reader - I2C interface enable"]
-pub type U0_I2C_IC_EN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select"]
-pub type U0_SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
-#[doc = "Field `u0_sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select"]
-pub type U0_SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `spdif_trmodeo` reader - 1 for transmitter 0 for receiver"]
+pub type SPDIF_TRMODEO_R = crate::BitReader;
+#[doc = "Field `i2c_ic_en` reader - I2C interface enable"]
+pub type I2C_IC_EN_R = crate::BitReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select"]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select"]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_R = crate::BitReader;
+#[doc = "Field `sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -161,23 +161,23 @@ impl R {
     }
     #[doc = "Bit 24 - 1 for transmitter 0 for receiver"]
     #[inline(always)]
-    pub fn u0_cdns_spdif_trmodeo(&self) -> U0_CDNS_SPDIF_TRMODEO_R {
-        U0_CDNS_SPDIF_TRMODEO_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn spdif_trmodeo(&self) -> SPDIF_TRMODEO_R {
+        SPDIF_TRMODEO_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - I2C interface enable"]
     #[inline(always)]
-    pub fn u0_i2c_ic_en(&self) -> U0_I2C_IC_EN_R {
-        U0_I2C_IC_EN_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn i2c_ic_en(&self) -> I2C_IC_EN_R {
+        I2C_IC_EN_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bits 26:30 - Data strobe delay chain select"]
     #[inline(always)]
-    pub fn u0_sdio_data_strobe_phase_ctrl(&self) -> U0_SDIO_DATA_STROBE_PHASE_CTRL_R {
-        U0_SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn sdio_data_strobe_phase_ctrl(&self) -> SDIO_DATA_STROBE_PHASE_CTRL_R {
+        SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
     #[doc = "Bit 31 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u0_sdio_hbig_endian(&self) -> U0_SDIO_HBIG_ENDIAN_R {
-        U0_SDIO_HBIG_ENDIAN_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn sdio_hbig_endian(&self) -> SDIO_HBIG_ENDIAN_R {
+        SDIO_HBIG_ENDIAN_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
@@ -312,16 +312,16 @@ impl W {
     #[doc = "Bits 26:30 - Data strobe delay chain select"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_data_strobe_phase_ctrl(
+    pub fn sdio_data_strobe_phase_ctrl(
         &mut self,
-    ) -> U0_SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_5_SPEC> {
-        U0_SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 26)
+    ) -> SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_5_SPEC> {
+        SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 26)
     }
     #[doc = "Bit 31 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_hbig_endian(&mut self) -> U0_SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_5_SPEC> {
-        U0_SDIO_HBIG_ENDIAN_W::new(self, 31)
+    pub fn sdio_hbig_endian(&mut self) -> SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_5_SPEC> {
+        SDIO_HBIG_ENDIAN_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_6.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_6.rs
@@ -2,18 +2,18 @@
 pub type R = crate::R<SYS_SYSCFG_6_SPEC>;
 #[doc = "Register `sys_syscfg_6` writer"]
 pub type W = crate::W<SYS_SYSCFG_6_SPEC>;
-#[doc = "Field `u0_sdio_m_hbig_endian` reader - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_m_hbig_endian` writer - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_i2srx_3ch_adc_ena` reader - u0_i2srx_3ch_adc_ena"]
-pub type U0_I2SRX_3CH_ADC_ENA_R = crate::BitReader;
-#[doc = "Field `u0_i2srx_3ch_adc_ena` writer - u0_i2srx_3ch_adc_ena"]
-pub type U0_I2SRX_3CH_ADC_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_intmem_rom_sram_scfg_disable_rom` reader - u0_intmem_rom_sram_scfg_disable_rom"]
-pub type U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R = crate::BitReader;
-#[doc = "Field `u0_intmem_rom_sram_scfg_disable_rom` writer - u0_intmem_rom_sram_scfg_disable_rom"]
-pub type U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `sdio_m_hbig_endian` reader - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
+#[doc = "Field `sdio_m_hbig_endian` writer - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `i2srx_adc_en` reader - i2srx_adc_en"]
+pub type I2SRX_ADC_EN_R = crate::BitReader;
+#[doc = "Field `i2srx_adc_en` writer - i2srx_adc_en"]
+pub type I2SRX_ADC_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `intmem_rom_sram_scfg_disable_rom` reader - intmem_rom_sram_scfg_disable_rom"]
+pub type INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R = crate::BitReader;
+#[doc = "Field `intmem_rom_sram_scfg_disable_rom` writer - intmem_rom_sram_scfg_disable_rom"]
+pub type INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_SLP_R = crate::BitReader;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -46,18 +46,18 @@ pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_0` reader - u0_jtag_daisy_chain_jtag_en_0"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R = crate::BitReader;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_0` writer - u0_jtag_daisy_chain_jtag_en_0"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_1` reader - u0_jtag_daisy_chain_jtag_en_1"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R = crate::BitReader;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_1` writer - u0_jtag_daisy_chain_jtag_en_1"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_pdrstn_split_sw_usbpipe_plugen` reader - u0_pdrstn_split_sw_usbpipe_plugen"]
-pub type U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R = crate::BitReader;
-#[doc = "Field `u0_pdrstn_split_sw_usbpipe_plugen` writer - u0_pdrstn_split_sw_usbpipe_plugen"]
-pub type U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `jtag_daisy_chain_en_0` reader - jtag_daisy_chain_en_0"]
+pub type JTAG_DAISY_CHAIN_EN_0_R = crate::BitReader;
+#[doc = "Field `jtag_daisy_chain_en_0` writer - jtag_daisy_chain_en_0"]
+pub type JTAG_DAISY_CHAIN_EN_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `jtag_daisy_chain_en_1` reader - jtag_daisy_chain_en_1"]
+pub type JTAG_DAISY_CHAIN_EN_1_R = crate::BitReader;
+#[doc = "Field `jtag_daisy_chain_en_1` writer - jtag_daisy_chain_en_1"]
+pub type JTAG_DAISY_CHAIN_EN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pdrstn_usbpipe_plugen` reader - pdrstn_usbpipe_plugen"]
+pub type PDRSTN_USBPIPE_PLUGEN_R = crate::BitReader;
+#[doc = "Field `pdrstn_usbpipe_plugen` writer - pdrstn_usbpipe_plugen"]
+pub type PDRSTN_USBPIPE_PLUGEN_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `pll0_cpi_bias` reader - pll0_cpi_bias"]
 pub type PLL0_CPI_BIAS_R = crate::FieldReader;
 #[doc = "Field `pll0_cpi_bias` writer - pll0_cpi_bias"]
@@ -77,18 +77,18 @@ pub type PLL0_DSMPD_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u0_sdio_m_hbig_endian(&self) -> U0_SDIO_M_HBIG_ENDIAN_R {
-        U0_SDIO_M_HBIG_ENDIAN_R::new((self.bits & 1) != 0)
+    pub fn sdio_m_hbig_endian(&self) -> SDIO_M_HBIG_ENDIAN_R {
+        SDIO_M_HBIG_ENDIAN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_i2srx_3ch_adc_ena"]
+    #[doc = "Bit 1 - i2srx_adc_en"]
     #[inline(always)]
-    pub fn u0_i2srx_3ch_adc_ena(&self) -> U0_I2SRX_3CH_ADC_ENA_R {
-        U0_I2SRX_3CH_ADC_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn i2srx_adc_en(&self) -> I2SRX_ADC_EN_R {
+        I2SRX_ADC_EN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_intmem_rom_sram_scfg_disable_rom"]
+    #[doc = "Bit 2 - intmem_rom_sram_scfg_disable_rom"]
     #[inline(always)]
-    pub fn u0_intmem_rom_sram_scfg_disable_rom(&self) -> U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R {
-        U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn intmem_rom_sram_scfg_disable_rom(&self) -> INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R {
+        INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -130,20 +130,20 @@ impl R {
     pub fn u0_intmem_rom_sram_sram_config_vg(&self) -> U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R {
         U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_jtag_daisy_chain_jtag_en_0"]
+    #[doc = "Bit 15 - jtag_daisy_chain_en_0"]
     #[inline(always)]
-    pub fn u0_jtag_daisy_chain_jtag_en_0(&self) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn jtag_daisy_chain_en_0(&self) -> JTAG_DAISY_CHAIN_EN_0_R {
+        JTAG_DAISY_CHAIN_EN_0_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_jtag_daisy_chain_jtag_en_1"]
+    #[doc = "Bit 16 - jtag_daisy_chain_en_1"]
     #[inline(always)]
-    pub fn u0_jtag_daisy_chain_jtag_en_1(&self) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn jtag_daisy_chain_en_1(&self) -> JTAG_DAISY_CHAIN_EN_1_R {
+        JTAG_DAISY_CHAIN_EN_1_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_pdrstn_split_sw_usbpipe_plugen"]
+    #[doc = "Bit 17 - pdrstn_usbpipe_plugen"]
     #[inline(always)]
-    pub fn u0_pdrstn_split_sw_usbpipe_plugen(&self) -> U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R {
-        U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn pdrstn_usbpipe_plugen(&self) -> PDRSTN_USBPIPE_PLUGEN_R {
+        PDRSTN_USBPIPE_PLUGEN_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bits 18:20 - pll0_cpi_bias"]
     #[inline(always)]
@@ -170,22 +170,22 @@ impl W {
     #[doc = "Bit 0 - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_m_hbig_endian(&mut self) -> U0_SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_6_SPEC> {
-        U0_SDIO_M_HBIG_ENDIAN_W::new(self, 0)
+    pub fn sdio_m_hbig_endian(&mut self) -> SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_6_SPEC> {
+        SDIO_M_HBIG_ENDIAN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u0_i2srx_3ch_adc_ena"]
+    #[doc = "Bit 1 - i2srx_adc_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_i2srx_3ch_adc_ena(&mut self) -> U0_I2SRX_3CH_ADC_ENA_W<SYS_SYSCFG_6_SPEC> {
-        U0_I2SRX_3CH_ADC_ENA_W::new(self, 1)
+    pub fn i2srx_adc_en(&mut self) -> I2SRX_ADC_EN_W<SYS_SYSCFG_6_SPEC> {
+        I2SRX_ADC_EN_W::new(self, 1)
     }
-    #[doc = "Bit 2 - u0_intmem_rom_sram_scfg_disable_rom"]
+    #[doc = "Bit 2 - intmem_rom_sram_scfg_disable_rom"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_intmem_rom_sram_scfg_disable_rom(
+    pub fn intmem_rom_sram_scfg_disable_rom(
         &mut self,
-    ) -> U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<SYS_SYSCFG_6_SPEC> {
-        U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W::new(self, 2)
+    ) -> INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<SYS_SYSCFG_6_SPEC> {
+        INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W::new(self, 2)
     }
     #[doc = "Bit 3 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -251,29 +251,23 @@ impl W {
     ) -> U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W<SYS_SYSCFG_6_SPEC> {
         U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W::new(self, 14)
     }
-    #[doc = "Bit 15 - u0_jtag_daisy_chain_jtag_en_0"]
+    #[doc = "Bit 15 - jtag_daisy_chain_en_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_jtag_daisy_chain_jtag_en_0(
-        &mut self,
-    ) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W<SYS_SYSCFG_6_SPEC> {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W::new(self, 15)
+    pub fn jtag_daisy_chain_en_0(&mut self) -> JTAG_DAISY_CHAIN_EN_0_W<SYS_SYSCFG_6_SPEC> {
+        JTAG_DAISY_CHAIN_EN_0_W::new(self, 15)
     }
-    #[doc = "Bit 16 - u0_jtag_daisy_chain_jtag_en_1"]
+    #[doc = "Bit 16 - jtag_daisy_chain_en_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_jtag_daisy_chain_jtag_en_1(
-        &mut self,
-    ) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W<SYS_SYSCFG_6_SPEC> {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W::new(self, 16)
+    pub fn jtag_daisy_chain_en_1(&mut self) -> JTAG_DAISY_CHAIN_EN_1_W<SYS_SYSCFG_6_SPEC> {
+        JTAG_DAISY_CHAIN_EN_1_W::new(self, 16)
     }
-    #[doc = "Bit 17 - u0_pdrstn_split_sw_usbpipe_plugen"]
+    #[doc = "Bit 17 - pdrstn_usbpipe_plugen"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_pdrstn_split_sw_usbpipe_plugen(
-        &mut self,
-    ) -> U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W<SYS_SYSCFG_6_SPEC> {
-        U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W::new(self, 17)
+    pub fn pdrstn_usbpipe_plugen(&mut self) -> PDRSTN_USBPIPE_PLUGEN_W<SYS_SYSCFG_6_SPEC> {
+        PDRSTN_USBPIPE_PLUGEN_W::new(self, 17)
     }
     #[doc = "Bits 18:20 - pll0_cpi_bias"]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_7.rs
+++ b/jh7110-vf2-12a-pac/src/sys_syscon/sys_syscfg_7.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<SYS_SYSCFG_7_SPEC>;
 #[doc = "Register `sys_syscfg_7` writer"]
 pub type W = crate::W<SYS_SYSCFG_7_SPEC>;
-#[doc = "Field `u0_pll_wrap_pll0_fbdiv` reader - u0_pll_wrap_pll0_fbdiv"]
-pub type U0_PLL_WRAP_PLL0_FBDIV_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_pll_wrap_pll0_fbdiv` writer - u0_pll_wrap_pll0_fbdiv"]
-pub type U0_PLL_WRAP_PLL0_FBDIV_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
+#[doc = "Field `pll0_fbdiv` reader - pll0_fbdiv"]
+pub type PLL0_FBDIV_R = crate::FieldReader<u16>;
+#[doc = "Field `pll0_fbdiv` writer - pll0_fbdiv"]
+pub type PLL0_FBDIV_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
 impl R {
-    #[doc = "Bits 0:11 - u0_pll_wrap_pll0_fbdiv"]
+    #[doc = "Bits 0:11 - pll0_fbdiv"]
     #[inline(always)]
-    pub fn u0_pll_wrap_pll0_fbdiv(&self) -> U0_PLL_WRAP_PLL0_FBDIV_R {
-        U0_PLL_WRAP_PLL0_FBDIV_R::new((self.bits & 0x0fff) as u16)
+    pub fn pll0_fbdiv(&self) -> PLL0_FBDIV_R {
+        PLL0_FBDIV_R::new((self.bits & 0x0fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:11 - u0_pll_wrap_pll0_fbdiv"]
+    #[doc = "Bits 0:11 - pll0_fbdiv"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_pll_wrap_pll0_fbdiv(&mut self) -> U0_PLL_WRAP_PLL0_FBDIV_W<SYS_SYSCFG_7_SPEC> {
-        U0_PLL_WRAP_PLL0_FBDIV_W::new(self, 0)
+    pub fn pll0_fbdiv(&mut self) -> PLL0_FBDIV_W<SYS_SYSCFG_7_SPEC> {
+        PLL0_FBDIV_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -32515,50 +32515,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_e24_remap_haddr</name>
-              <description>scfg_e24_remap_haddr</description>
+              <name>e24_remap_haddr</name>
+              <description>e24_remap_haddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_idma_remap_araddr</name>
-              <description>scfg_hifi4_idma_remap_araddr</description>
+              <name>hifi4_idma_remap_araddr</name>
+              <description>hifi4_idma_remap_araddr</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_idma_remap_awaddr</name>
-              <description>scfg_hifi4_idma_remap_awaddr</description>
+              <name>hifi4_idma_remap_awaddr</name>
+              <description>hifi4_idma_remap_awaddr</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_sys_remap_araddr</name>
-              <description>scfg_hifi4_sys_remap_araddr</description>
+              <name>hifi4_sys_remap_araddr</name>
+              <description>hifi4_sys_remap_araddr</description>
               <bitRange>[15:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_hifi4_sys_remap_awaddr</name>
-              <description>scfg_hifi4_sys_remap_awaddr</description>
+              <name>hifi4_sys_remap_awaddr</name>
+              <description>hifi4_sys_remap_awaddr</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_jpg_remap_araddr</name>
-              <description>scfg_jpg_remap_araddr</description>
+              <name>jpg_remap_araddr</name>
+              <description>jpg_remap_araddr</description>
               <bitRange>[23:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_jpg_remap_awaddr</name>
-              <description>scfg_jpg_remap_awaddr</description>
+              <name>jpg_remap_awaddr</name>
+              <description>jpg_remap_awaddr</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_sd0_remap_araddr</name>
-              <description>scfg_sd0_remap_araddr</description>
+              <name>sd0_remap_araddr</name>
+              <description>sd0_remap_araddr</description>
               <bitRange>[31:28]</bitRange>
               <access>read-write</access>
             </field>
@@ -32572,50 +32572,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_sd1_remap_awaddr</name>
-              <description>scfg_sd1_remap_awaddr</description>
+              <name>sd1_remap_awaddr</name>
+              <description>sd1_remap_awaddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_sec_haddr_remap</name>
-              <description>scfg_sec_haddr_remap</description>
+              <name>sec_haddr_remap</name>
+              <description>sec_haddr_remap</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_usb_araddr_remap</name>
-              <description>scfg_usb_araddr_remap</description>
+              <name>usb_araddr_remap</name>
+              <description>usb_araddr_remap</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_usb_awaddr_remap</name>
-              <description>scfg_usb_awaddr_remap</description>
+              <name>usb_awaddr_remap</name>
+              <description>usb_awaddr_remap</description>
               <bitRange>[15:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vdec_remap_awaddr</name>
-              <description>scfg_vdec_remap_awaddr</description>
+              <name>vdec_remap_awaddr</name>
+              <description>vdec_remap_awaddr</description>
               <bitRange>[19:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_venc_remap_araddr</name>
-              <description>scfg_venc_remap_araddr</description>
+              <name>venc_remap_araddr</name>
+              <description>venc_remap_araddr</description>
               <bitRange>[23:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_venc_remap_awaddr</name>
-              <description>scfg_venc_remap_awaddr</description>
+              <name>venc_remap_awaddr</name>
+              <description>venc_remap_awaddr</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_araddr</name>
-              <description>scfg_vout0_remap_araddr</description>
+              <name>vout0_remap_araddr</name>
+              <description>vout0_remap_araddr</description>
               <bitRange>[31:28]</bitRange>
               <access>read-write</access>
             </field>
@@ -32629,20 +32629,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_vout0_remap_awaddr</name>
-              <description>scfg_vout0_remap_awaddr</description>
+              <name>vout0_remap_awaddr</name>
+              <description>vout0_remap_awaddr</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout1_remap_araddr</name>
-              <description>scfg_vout1_remap_araddr</description>
+              <name>vout1_remap_araddr</name>
+              <description>vout1_remap_araddr</description>
               <bitRange>[7:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout1_remap_awaddr</name>
-              <description>scfg_vout1_remap_awaddr</description>
+              <name>vout1_remap_awaddr</name>
+              <description>vout1_remap_awaddr</description>
               <bitRange>[11:8]</bitRange>
               <access>read-write</access>
             </field>
@@ -32656,25 +32656,25 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio0</name>
+              <name>vout0_remap_awaddr_gpio0</name>
               <description>0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio1</name>
+              <name>vout0_remap_awaddr_gpio1</name>
               <description>0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio2</name>
+              <name>vout0_remap_awaddr_gpio2</name>
               <description>0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>scfg_vout0_remap_awaddr_gpio3</name>
+              <name>vout0_remap_awaddr_gpio3</name>
               <description>0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
@@ -32689,37 +32689,37 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_coda12_o_cur_inst_a</name>
+              <name>coda12_cur_inst</name>
               <description>Tie 0 in JPU internal, do not care</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_wave511_o_vpu_idle</name>
+              <name>wave511_vpu_idle</name>
               <description>VPU monitoring signal</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_can_ctrl_can_fd_enable</name>
-              <description>u0_can_ctrl_can_fd_enable</description>
+              <name>can_ctrl_fd_enable_0</name>
+              <description>can_ctrl_fd_enable_0</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_can_ctrl_host_ecc_disable</name>
-              <description>u0_can_ctrl_host_ecc_disable</description>
+              <name>can_ctrl_host_ecc_disable_0</name>
+              <description>can_ctrl_host_ecc_disable_0</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_can_ctrl_host_if</name>
-              <description>u0_can_ctrl_host_if</description>
+              <name>can_ctrl_host_if_0</name>
+              <description>can_ctrl_host_if_0</description>
               <bitRange>[23:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel</name>
+              <name>qspi_sclk_dlychain_sel</name>
               <description>des_qspi_sclk_dla: clock delay</description>
               <bitRange>[28:24]</bitRange>
               <access>read-only</access>
@@ -32830,25 +32830,25 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdns_spdif_trmodeo</name>
+              <name>spdif_trmodeo</name>
               <description>1 for transmitter 0 for receiver</description>
               <bitRange>[24:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_i2c_ic_en</name>
+              <name>i2c_ic_en</name>
               <description>I2C interface enable</description>
               <bitRange>[25:25]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_sdio_data_strobe_phase_ctrl</name>
+              <name>sdio_data_strobe_phase_ctrl</name>
               <description>Data strobe delay chain select</description>
               <bitRange>[30:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sdio_hbig_endian</name>
+              <name>sdio_hbig_endian</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32863,20 +32863,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_sdio_m_hbig_endian</name>
+              <name>sdio_m_hbig_endian</name>
               <description>AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_i2srx_3ch_adc_ena</name>
-              <description>u0_i2srx_3ch_adc_ena</description>
+              <name>i2srx_adc_en</name>
+              <description>i2srx_adc_en</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_intmem_rom_sram_scfg_disable_rom</name>
-              <description>u0_intmem_rom_sram_scfg_disable_rom</description>
+              <name>intmem_rom_sram_scfg_disable_rom</name>
+              <description>intmem_rom_sram_scfg_disable_rom</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
@@ -32929,20 +32929,20 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_jtag_daisy_chain_jtag_en_0</name>
-              <description>u0_jtag_daisy_chain_jtag_en_0</description>
+              <name>jtag_daisy_chain_en_0</name>
+              <description>jtag_daisy_chain_en_0</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_jtag_daisy_chain_jtag_en_1</name>
-              <description>u0_jtag_daisy_chain_jtag_en_1</description>
+              <name>jtag_daisy_chain_en_1</name>
+              <description>jtag_daisy_chain_en_1</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_pdrstn_split_sw_usbpipe_plugen</name>
-              <description>u0_pdrstn_split_sw_usbpipe_plugen</description>
+              <name>pdrstn_usbpipe_plugen</name>
+              <description>pdrstn_usbpipe_plugen</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -32980,8 +32980,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_pll_wrap_pll0_fbdiv</name>
-              <description>u0_pll_wrap_pll0_fbdiv</description>
+              <name>pll0_fbdiv</name>
+              <description>pll0_fbdiv</description>
               <bitRange>[11:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33268,14 +33268,14 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_saif_audio_sdin_mux_scfg_i2sdin_sel</name>
-              <description>u0_saif_audio_sdin_mux_scfg_i2sdin_sel</description>
+              <name>audio_i2sdin_sel</name>
+              <description>audio_i2sdin_sel</description>
               <bitRange>[17:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_clock_gating_off</name>
-              <description>u0_sft7110_noc_bus_clock_gating_off</description>
+              <name>noc_bus_clock_gating_off</name>
+              <description>noc_bus_clock_gating_off</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
@@ -33397,32 +33397,32 @@
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_0</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_0</description>
+              <name>noc_bus_oic_ignore_modifiable_0</name>
+              <description>noc_bus_oic_ignore_modifiable_0</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_1</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_1</description>
+              <name>noc_bus_oic_ignore_modifiable_1</name>
+              <description>noc_bus_oic_ignore_modifiable_1</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_2</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_2</description>
+              <name>noc_bus_oic_ignore_modifiable_2</name>
+              <description>noc_bus_oic_ignore_modifiable_2</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_3</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_3</description>
+              <name>noc_bus_oic_ignore_modifiable_3</name>
+              <description>noc_bus_oic_ignore_modifiable_3</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_sft7110_noc_bus_oic_ignore_modifiable_4</name>
-              <description>u0_sft7110_noc_bus_oic_ignore_modifiable_4</description>
+              <name>noc_bus_oic_ignore_modifiable_4</name>
+              <description>noc_bus_oic_ignore_modifiable_4</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
@@ -33436,8 +33436,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_0</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_0</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_0</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33451,8 +33451,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_1</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_1</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_1</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_1</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33466,8 +33466,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_2</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_2</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_2</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_2</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33481,8 +33481,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_3</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_3</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_3</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_3</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33496,8 +33496,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_4</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_4</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_4</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_4</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33511,8 +33511,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_5</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_5</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_5</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_5</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33526,8 +33526,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_6</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_6</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_6</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_6</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33541,8 +33541,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_7</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_7</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_7</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_7</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33556,8 +33556,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_noc_bus_oic_qch_clock_stop_threshold_8</name>
-              <description>u0_noc_bus_oic_qch_clock_stop_threshold_8</description>
+              <name>noc_bus_oic_qch_clock_stop_threshold_8</name>
+              <description>noc_bus_oic_qch_clock_stop_threshold_8</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -33571,50 +33571,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_tdm16slot_clkpol</name>
-              <description>u0_tdm16slot_clkpol</description>
+              <name>tdm16slot_clkpol</name>
+              <description>tdm16slot_clkpol</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_tdm16slot_pcm_ms</name>
-              <description>u0_tdm16slot_pcm_ms</description>
+              <name>tdm16slot_pcm_ms</name>
+              <description>tdm16slot_pcm_ms</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c0_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c0_in0_ctl</description>
+              <name>u0_trace_mtx_in0_0</name>
+              <description>u0_trace_mtx_in0_0</description>
               <bitRange>[6:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c0_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c0_in1_ctl</description>
+              <name>u0_trace_mtx_in1_0</name>
+              <description>u0_trace_mtx_in1_0</description>
               <bitRange>[11:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c1_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c1_in0_ctl</description>
+              <name>u0_trace_mtx_in0_1</name>
+              <description>u0_trace_mtx_in0_1</description>
               <bitRange>[16:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c1_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c1_in1_ctl</description>
+              <name>u0_trace_mtx_in1_1</name>
+              <description>u0_trace_mtx_in1_1</description>
               <bitRange>[21:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c2_in0_ctl</name>
-              <description>u0_trace_mtx_scfg_c2_in0_ctl</description>
+              <name>u0_trace_mtx_in0_2</name>
+              <description>u0_trace_mtx_in0_2</description>
               <bitRange>[26:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_trace_mtx_scfg_c2_in1_ctl</name>
-              <description>u0_trace_mtx_scfg_c2_in1_ctl</description>
+              <name>u0_trace_mtx_in1_2</name>
+              <description>u0_trace_mtx_in1_2</description>
               <bitRange>[31:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -34807,38 +34807,38 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_current_buffer</name>
+              <name>wave420l_ipu_current_buffer</name>
               <description>This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter.</description>
               <bitRange>[14:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_end_of_row</name>
+              <name>wave420l_ipu_end_of_row</name>
               <description>This signal is flipped every time when the IPU completes writing a row.</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_i_ipu_new_frame</name>
+              <name>wave420l_ipu_new_frame</name>
               <description>This signal is flipped every time when the IPU completes writing a new frame.</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_wave420l_o_vpu_idle</name>
+              <name>wave420l_vpu_idle</name>
               <description>VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register.</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_can_ctrl_can_fd_enable</name>
-              <description>u1_can_ctrl_can_fd_enable</description>
+              <name>can_ctrl_fd_enable_1</name>
+              <description>can_ctrl_fd_enable_1</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_can_ctrl_host_ecc_disable</name>
-              <description>u1_can_ctrl_host_ecc_disable</description>
+              <name>can_ctrl_host_ecc_disable_1</name>
+              <description>can_ctrl_host_ecc_disable_1</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
@@ -34852,8 +34852,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_can_ctrl_host_if</name>
-              <description>u1_can_ctrl_host_if</description>
+              <name>can_ctrl_host_if_1</name>
+              <description>can_ctrl_host_if_1</description>
               <bitRange>[18:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -34915,13 +34915,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_mac_speed_0</name>
-              <description>u1_gmac5_axi64_mac_speed_0</description>
+              <name>gmac5_axi64_mac_speed</name>
+              <description>gmac5_axi64_mac_speed</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_gmac5_axi64_phy_intf_sel_i</name>
+              <name>gmac5_axi64_phy_intf_sel</name>
               <description>Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII</description>
               <bitRange>[4:2]</bitRange>
               <access>read-write</access>
@@ -34936,8 +34936,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_ptp_timestamp_o_31_0</name>
-              <description>u1_gmac5_axi64_ptp_timestamp_o_31_0</description>
+              <name>gmac5_axi64_ptp_timestamp_0_31</name>
+              <description>gmac5_axi64_ptp_timestamp_0_31</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -34951,8 +34951,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_gmac5_axi64_ptp_timestamp_o_63_32</name>
-              <description>u1_gmac5_axi64_ptp_timestamp_o_63_32</description>
+              <name>gmac5_axi64_ptp_timestamp_32_63</name>
+              <description>gmac5_axi64_ptp_timestamp_32_63</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -34966,50 +34966,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_i2c_ic_en</name>
+              <name>i2c_ic_en_1</name>
               <description>I2C interface enable.</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_sdio_data_strobe_phase_ctrl</name>
+              <name>sdio_data_strobe_phase_ctrl_1</name>
               <description>Data strobe delay chain select.</description>
               <bitRange>[5:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_sdio_hbig_endian</name>
+              <name>sdio_hbig_endian_1</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_sdio_m_hbig_endian</name>
+              <name>sdio_m_hbig_endian_1</name>
               <description>AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_clr_reset_status</name>
-              <description>u1_reset_ctrl_clr_reset_status</description>
+              <name>reset_ctrl_clr_reset_status_1</name>
+              <description>reset_ctrl_clr_reset_status_1</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_pll_timecnt_finish</name>
-              <description>u1_reset_ctrl_pll_timecnt_finish</description>
+              <name>reset_ctrl_pll_timecnt_finish_1</name>
+              <description>reset_ctrl_pll_timecnt_finish_1</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_rstn_sw</name>
-              <description>u1_reset_ctrl_rstn_sw</description>
+              <name>reset_ctrl_rstn_sw_1</name>
+              <description>reset_ctrl_rstn_sw_1</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_reset_ctrl_sys_reset_status</name>
-              <description>u1_reset_ctrl_sys_reset_status</description>
+              <name>reset_ctrl_sys_reset_status_1</name>
+              <description>reset_ctrl_sys_reset_status_1</description>
               <bitRange>[14:11]</bitRange>
               <access>read-only</access>
             </field>

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_0.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_0.rs
@@ -2,136 +2,128 @@
 pub type R = crate::R<SYS_SYSCFG_0_SPEC>;
 #[doc = "Register `sys_syscfg_0` writer"]
 pub type W = crate::W<SYS_SYSCFG_0_SPEC>;
-#[doc = "Field `scfg_e24_remap_haddr` reader - scfg_e24_remap_haddr"]
-pub type SCFG_E24_REMAP_HADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_e24_remap_haddr` writer - scfg_e24_remap_haddr"]
-pub type SCFG_E24_REMAP_HADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_idma_remap_araddr` reader - scfg_hifi4_idma_remap_araddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_idma_remap_araddr` writer - scfg_hifi4_idma_remap_araddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_idma_remap_awaddr` reader - scfg_hifi4_idma_remap_awaddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_idma_remap_awaddr` writer - scfg_hifi4_idma_remap_awaddr"]
-pub type SCFG_HIFI4_IDMA_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_sys_remap_araddr` reader - scfg_hifi4_sys_remap_araddr"]
-pub type SCFG_HIFI4_SYS_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_sys_remap_araddr` writer - scfg_hifi4_sys_remap_araddr"]
-pub type SCFG_HIFI4_SYS_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_hifi4_sys_remap_awaddr` reader - scfg_hifi4_sys_remap_awaddr"]
-pub type SCFG_HIFI4_SYS_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_hifi4_sys_remap_awaddr` writer - scfg_hifi4_sys_remap_awaddr"]
-pub type SCFG_HIFI4_SYS_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_jpg_remap_araddr` reader - scfg_jpg_remap_araddr"]
-pub type SCFG_JPG_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_jpg_remap_araddr` writer - scfg_jpg_remap_araddr"]
-pub type SCFG_JPG_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_jpg_remap_awaddr` reader - scfg_jpg_remap_awaddr"]
-pub type SCFG_JPG_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_jpg_remap_awaddr` writer - scfg_jpg_remap_awaddr"]
-pub type SCFG_JPG_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_sd0_remap_araddr` reader - scfg_sd0_remap_araddr"]
-pub type SCFG_SD0_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_sd0_remap_araddr` writer - scfg_sd0_remap_araddr"]
-pub type SCFG_SD0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `e24_remap_haddr` reader - e24_remap_haddr"]
+pub type E24_REMAP_HADDR_R = crate::FieldReader;
+#[doc = "Field `e24_remap_haddr` writer - e24_remap_haddr"]
+pub type E24_REMAP_HADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_idma_remap_araddr` reader - hifi4_idma_remap_araddr"]
+pub type HIFI4_IDMA_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_idma_remap_araddr` writer - hifi4_idma_remap_araddr"]
+pub type HIFI4_IDMA_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_idma_remap_awaddr` reader - hifi4_idma_remap_awaddr"]
+pub type HIFI4_IDMA_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_idma_remap_awaddr` writer - hifi4_idma_remap_awaddr"]
+pub type HIFI4_IDMA_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_sys_remap_araddr` reader - hifi4_sys_remap_araddr"]
+pub type HIFI4_SYS_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_sys_remap_araddr` writer - hifi4_sys_remap_araddr"]
+pub type HIFI4_SYS_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `hifi4_sys_remap_awaddr` reader - hifi4_sys_remap_awaddr"]
+pub type HIFI4_SYS_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `hifi4_sys_remap_awaddr` writer - hifi4_sys_remap_awaddr"]
+pub type HIFI4_SYS_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `jpg_remap_araddr` reader - jpg_remap_araddr"]
+pub type JPG_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `jpg_remap_araddr` writer - jpg_remap_araddr"]
+pub type JPG_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `jpg_remap_awaddr` reader - jpg_remap_awaddr"]
+pub type JPG_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `jpg_remap_awaddr` writer - jpg_remap_awaddr"]
+pub type JPG_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sd0_remap_araddr` reader - sd0_remap_araddr"]
+pub type SD0_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `sd0_remap_araddr` writer - sd0_remap_araddr"]
+pub type SD0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_e24_remap_haddr"]
+    #[doc = "Bits 0:3 - e24_remap_haddr"]
     #[inline(always)]
-    pub fn scfg_e24_remap_haddr(&self) -> SCFG_E24_REMAP_HADDR_R {
-        SCFG_E24_REMAP_HADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn e24_remap_haddr(&self) -> E24_REMAP_HADDR_R {
+        E24_REMAP_HADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_hifi4_idma_remap_araddr"]
+    #[doc = "Bits 4:7 - hifi4_idma_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_idma_remap_araddr(&self) -> SCFG_HIFI4_IDMA_REMAP_ARADDR_R {
-        SCFG_HIFI4_IDMA_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn hifi4_idma_remap_araddr(&self) -> HIFI4_IDMA_REMAP_ARADDR_R {
+        HIFI4_IDMA_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_hifi4_idma_remap_awaddr"]
+    #[doc = "Bits 8:11 - hifi4_idma_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_idma_remap_awaddr(&self) -> SCFG_HIFI4_IDMA_REMAP_AWADDR_R {
-        SCFG_HIFI4_IDMA_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn hifi4_idma_remap_awaddr(&self) -> HIFI4_IDMA_REMAP_AWADDR_R {
+        HIFI4_IDMA_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
-    #[doc = "Bits 12:15 - scfg_hifi4_sys_remap_araddr"]
+    #[doc = "Bits 12:15 - hifi4_sys_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_sys_remap_araddr(&self) -> SCFG_HIFI4_SYS_REMAP_ARADDR_R {
-        SCFG_HIFI4_SYS_REMAP_ARADDR_R::new(((self.bits >> 12) & 0x0f) as u8)
+    pub fn hifi4_sys_remap_araddr(&self) -> HIFI4_SYS_REMAP_ARADDR_R {
+        HIFI4_SYS_REMAP_ARADDR_R::new(((self.bits >> 12) & 0x0f) as u8)
     }
-    #[doc = "Bits 16:19 - scfg_hifi4_sys_remap_awaddr"]
+    #[doc = "Bits 16:19 - hifi4_sys_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_hifi4_sys_remap_awaddr(&self) -> SCFG_HIFI4_SYS_REMAP_AWADDR_R {
-        SCFG_HIFI4_SYS_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    pub fn hifi4_sys_remap_awaddr(&self) -> HIFI4_SYS_REMAP_AWADDR_R {
+        HIFI4_SYS_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
     }
-    #[doc = "Bits 20:23 - scfg_jpg_remap_araddr"]
+    #[doc = "Bits 20:23 - jpg_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_jpg_remap_araddr(&self) -> SCFG_JPG_REMAP_ARADDR_R {
-        SCFG_JPG_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    pub fn jpg_remap_araddr(&self) -> JPG_REMAP_ARADDR_R {
+        JPG_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
     }
-    #[doc = "Bits 24:27 - scfg_jpg_remap_awaddr"]
+    #[doc = "Bits 24:27 - jpg_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_jpg_remap_awaddr(&self) -> SCFG_JPG_REMAP_AWADDR_R {
-        SCFG_JPG_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn jpg_remap_awaddr(&self) -> JPG_REMAP_AWADDR_R {
+        JPG_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
-    #[doc = "Bits 28:31 - scfg_sd0_remap_araddr"]
+    #[doc = "Bits 28:31 - sd0_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_sd0_remap_araddr(&self) -> SCFG_SD0_REMAP_ARADDR_R {
-        SCFG_SD0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    pub fn sd0_remap_araddr(&self) -> SD0_REMAP_ARADDR_R {
+        SD0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_e24_remap_haddr"]
+    #[doc = "Bits 0:3 - e24_remap_haddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_e24_remap_haddr(&mut self) -> SCFG_E24_REMAP_HADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_E24_REMAP_HADDR_W::new(self, 0)
+    pub fn e24_remap_haddr(&mut self) -> E24_REMAP_HADDR_W<SYS_SYSCFG_0_SPEC> {
+        E24_REMAP_HADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_hifi4_idma_remap_araddr"]
+    #[doc = "Bits 4:7 - hifi4_idma_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_idma_remap_araddr(
-        &mut self,
-    ) -> SCFG_HIFI4_IDMA_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_IDMA_REMAP_ARADDR_W::new(self, 4)
+    pub fn hifi4_idma_remap_araddr(&mut self) -> HIFI4_IDMA_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_IDMA_REMAP_ARADDR_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_hifi4_idma_remap_awaddr"]
+    #[doc = "Bits 8:11 - hifi4_idma_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_idma_remap_awaddr(
-        &mut self,
-    ) -> SCFG_HIFI4_IDMA_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_IDMA_REMAP_AWADDR_W::new(self, 8)
+    pub fn hifi4_idma_remap_awaddr(&mut self) -> HIFI4_IDMA_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_IDMA_REMAP_AWADDR_W::new(self, 8)
     }
-    #[doc = "Bits 12:15 - scfg_hifi4_sys_remap_araddr"]
+    #[doc = "Bits 12:15 - hifi4_sys_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_sys_remap_araddr(
-        &mut self,
-    ) -> SCFG_HIFI4_SYS_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_SYS_REMAP_ARADDR_W::new(self, 12)
+    pub fn hifi4_sys_remap_araddr(&mut self) -> HIFI4_SYS_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_SYS_REMAP_ARADDR_W::new(self, 12)
     }
-    #[doc = "Bits 16:19 - scfg_hifi4_sys_remap_awaddr"]
+    #[doc = "Bits 16:19 - hifi4_sys_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_hifi4_sys_remap_awaddr(
-        &mut self,
-    ) -> SCFG_HIFI4_SYS_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_HIFI4_SYS_REMAP_AWADDR_W::new(self, 16)
+    pub fn hifi4_sys_remap_awaddr(&mut self) -> HIFI4_SYS_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        HIFI4_SYS_REMAP_AWADDR_W::new(self, 16)
     }
-    #[doc = "Bits 20:23 - scfg_jpg_remap_araddr"]
+    #[doc = "Bits 20:23 - jpg_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_jpg_remap_araddr(&mut self) -> SCFG_JPG_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_JPG_REMAP_ARADDR_W::new(self, 20)
+    pub fn jpg_remap_araddr(&mut self) -> JPG_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        JPG_REMAP_ARADDR_W::new(self, 20)
     }
-    #[doc = "Bits 24:27 - scfg_jpg_remap_awaddr"]
+    #[doc = "Bits 24:27 - jpg_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_jpg_remap_awaddr(&mut self) -> SCFG_JPG_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_JPG_REMAP_AWADDR_W::new(self, 24)
+    pub fn jpg_remap_awaddr(&mut self) -> JPG_REMAP_AWADDR_W<SYS_SYSCFG_0_SPEC> {
+        JPG_REMAP_AWADDR_W::new(self, 24)
     }
-    #[doc = "Bits 28:31 - scfg_sd0_remap_araddr"]
+    #[doc = "Bits 28:31 - sd0_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sd0_remap_araddr(&mut self) -> SCFG_SD0_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
-        SCFG_SD0_REMAP_ARADDR_W::new(self, 28)
+    pub fn sd0_remap_araddr(&mut self) -> SD0_REMAP_ARADDR_W<SYS_SYSCFG_0_SPEC> {
+        SD0_REMAP_ARADDR_W::new(self, 28)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_1.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_1.rs
@@ -2,128 +2,128 @@
 pub type R = crate::R<SYS_SYSCFG_1_SPEC>;
 #[doc = "Register `sys_syscfg_1` writer"]
 pub type W = crate::W<SYS_SYSCFG_1_SPEC>;
-#[doc = "Field `scfg_sd1_remap_awaddr` reader - scfg_sd1_remap_awaddr"]
-pub type SCFG_SD1_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_sd1_remap_awaddr` writer - scfg_sd1_remap_awaddr"]
-pub type SCFG_SD1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_sec_haddr_remap` reader - scfg_sec_haddr_remap"]
-pub type SCFG_SEC_HADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_sec_haddr_remap` writer - scfg_sec_haddr_remap"]
-pub type SCFG_SEC_HADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_usb_araddr_remap` reader - scfg_usb_araddr_remap"]
-pub type SCFG_USB_ARADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_usb_araddr_remap` writer - scfg_usb_araddr_remap"]
-pub type SCFG_USB_ARADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_usb_awaddr_remap` reader - scfg_usb_awaddr_remap"]
-pub type SCFG_USB_AWADDR_REMAP_R = crate::FieldReader;
-#[doc = "Field `scfg_usb_awaddr_remap` writer - scfg_usb_awaddr_remap"]
-pub type SCFG_USB_AWADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vdec_remap_awaddr` reader - scfg_vdec_remap_awaddr"]
-pub type SCFG_VDEC_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vdec_remap_awaddr` writer - scfg_vdec_remap_awaddr"]
-pub type SCFG_VDEC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_venc_remap_araddr` reader - scfg_venc_remap_araddr"]
-pub type SCFG_VENC_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_venc_remap_araddr` writer - scfg_venc_remap_araddr"]
-pub type SCFG_VENC_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_venc_remap_awaddr` reader - scfg_venc_remap_awaddr"]
-pub type SCFG_VENC_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_venc_remap_awaddr` writer - scfg_venc_remap_awaddr"]
-pub type SCFG_VENC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout0_remap_araddr` reader - scfg_vout0_remap_araddr"]
-pub type SCFG_VOUT0_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout0_remap_araddr` writer - scfg_vout0_remap_araddr"]
-pub type SCFG_VOUT0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sd1_remap_awaddr` reader - sd1_remap_awaddr"]
+pub type SD1_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `sd1_remap_awaddr` writer - sd1_remap_awaddr"]
+pub type SD1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `sec_haddr_remap` reader - sec_haddr_remap"]
+pub type SEC_HADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `sec_haddr_remap` writer - sec_haddr_remap"]
+pub type SEC_HADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `usb_araddr_remap` reader - usb_araddr_remap"]
+pub type USB_ARADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `usb_araddr_remap` writer - usb_araddr_remap"]
+pub type USB_ARADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `usb_awaddr_remap` reader - usb_awaddr_remap"]
+pub type USB_AWADDR_REMAP_R = crate::FieldReader;
+#[doc = "Field `usb_awaddr_remap` writer - usb_awaddr_remap"]
+pub type USB_AWADDR_REMAP_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vdec_remap_awaddr` reader - vdec_remap_awaddr"]
+pub type VDEC_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vdec_remap_awaddr` writer - vdec_remap_awaddr"]
+pub type VDEC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `venc_remap_araddr` reader - venc_remap_araddr"]
+pub type VENC_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `venc_remap_araddr` writer - venc_remap_araddr"]
+pub type VENC_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `venc_remap_awaddr` reader - venc_remap_awaddr"]
+pub type VENC_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `venc_remap_awaddr` writer - venc_remap_awaddr"]
+pub type VENC_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout0_remap_araddr` reader - vout0_remap_araddr"]
+pub type VOUT0_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `vout0_remap_araddr` writer - vout0_remap_araddr"]
+pub type VOUT0_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_sd1_remap_awaddr"]
+    #[doc = "Bits 0:3 - sd1_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_sd1_remap_awaddr(&self) -> SCFG_SD1_REMAP_AWADDR_R {
-        SCFG_SD1_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn sd1_remap_awaddr(&self) -> SD1_REMAP_AWADDR_R {
+        SD1_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_sec_haddr_remap"]
+    #[doc = "Bits 4:7 - sec_haddr_remap"]
     #[inline(always)]
-    pub fn scfg_sec_haddr_remap(&self) -> SCFG_SEC_HADDR_REMAP_R {
-        SCFG_SEC_HADDR_REMAP_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn sec_haddr_remap(&self) -> SEC_HADDR_REMAP_R {
+        SEC_HADDR_REMAP_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_usb_araddr_remap"]
+    #[doc = "Bits 8:11 - usb_araddr_remap"]
     #[inline(always)]
-    pub fn scfg_usb_araddr_remap(&self) -> SCFG_USB_ARADDR_REMAP_R {
-        SCFG_USB_ARADDR_REMAP_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn usb_araddr_remap(&self) -> USB_ARADDR_REMAP_R {
+        USB_ARADDR_REMAP_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
-    #[doc = "Bits 12:15 - scfg_usb_awaddr_remap"]
+    #[doc = "Bits 12:15 - usb_awaddr_remap"]
     #[inline(always)]
-    pub fn scfg_usb_awaddr_remap(&self) -> SCFG_USB_AWADDR_REMAP_R {
-        SCFG_USB_AWADDR_REMAP_R::new(((self.bits >> 12) & 0x0f) as u8)
+    pub fn usb_awaddr_remap(&self) -> USB_AWADDR_REMAP_R {
+        USB_AWADDR_REMAP_R::new(((self.bits >> 12) & 0x0f) as u8)
     }
-    #[doc = "Bits 16:19 - scfg_vdec_remap_awaddr"]
+    #[doc = "Bits 16:19 - vdec_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vdec_remap_awaddr(&self) -> SCFG_VDEC_REMAP_AWADDR_R {
-        SCFG_VDEC_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    pub fn vdec_remap_awaddr(&self) -> VDEC_REMAP_AWADDR_R {
+        VDEC_REMAP_AWADDR_R::new(((self.bits >> 16) & 0x0f) as u8)
     }
-    #[doc = "Bits 20:23 - scfg_venc_remap_araddr"]
+    #[doc = "Bits 20:23 - venc_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_venc_remap_araddr(&self) -> SCFG_VENC_REMAP_ARADDR_R {
-        SCFG_VENC_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    pub fn venc_remap_araddr(&self) -> VENC_REMAP_ARADDR_R {
+        VENC_REMAP_ARADDR_R::new(((self.bits >> 20) & 0x0f) as u8)
     }
-    #[doc = "Bits 24:27 - scfg_venc_remap_awaddr"]
+    #[doc = "Bits 24:27 - venc_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_venc_remap_awaddr(&self) -> SCFG_VENC_REMAP_AWADDR_R {
-        SCFG_VENC_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn venc_remap_awaddr(&self) -> VENC_REMAP_AWADDR_R {
+        VENC_REMAP_AWADDR_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
-    #[doc = "Bits 28:31 - scfg_vout0_remap_araddr"]
+    #[doc = "Bits 28:31 - vout0_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_araddr(&self) -> SCFG_VOUT0_REMAP_ARADDR_R {
-        SCFG_VOUT0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    pub fn vout0_remap_araddr(&self) -> VOUT0_REMAP_ARADDR_R {
+        VOUT0_REMAP_ARADDR_R::new(((self.bits >> 28) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_sd1_remap_awaddr"]
+    #[doc = "Bits 0:3 - sd1_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sd1_remap_awaddr(&mut self) -> SCFG_SD1_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_SD1_REMAP_AWADDR_W::new(self, 0)
+    pub fn sd1_remap_awaddr(&mut self) -> SD1_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        SD1_REMAP_AWADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_sec_haddr_remap"]
+    #[doc = "Bits 4:7 - sec_haddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_sec_haddr_remap(&mut self) -> SCFG_SEC_HADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_SEC_HADDR_REMAP_W::new(self, 4)
+    pub fn sec_haddr_remap(&mut self) -> SEC_HADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        SEC_HADDR_REMAP_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_usb_araddr_remap"]
+    #[doc = "Bits 8:11 - usb_araddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_usb_araddr_remap(&mut self) -> SCFG_USB_ARADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_USB_ARADDR_REMAP_W::new(self, 8)
+    pub fn usb_araddr_remap(&mut self) -> USB_ARADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        USB_ARADDR_REMAP_W::new(self, 8)
     }
-    #[doc = "Bits 12:15 - scfg_usb_awaddr_remap"]
+    #[doc = "Bits 12:15 - usb_awaddr_remap"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_usb_awaddr_remap(&mut self) -> SCFG_USB_AWADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_USB_AWADDR_REMAP_W::new(self, 12)
+    pub fn usb_awaddr_remap(&mut self) -> USB_AWADDR_REMAP_W<SYS_SYSCFG_1_SPEC> {
+        USB_AWADDR_REMAP_W::new(self, 12)
     }
-    #[doc = "Bits 16:19 - scfg_vdec_remap_awaddr"]
+    #[doc = "Bits 16:19 - vdec_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vdec_remap_awaddr(&mut self) -> SCFG_VDEC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VDEC_REMAP_AWADDR_W::new(self, 16)
+    pub fn vdec_remap_awaddr(&mut self) -> VDEC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        VDEC_REMAP_AWADDR_W::new(self, 16)
     }
-    #[doc = "Bits 20:23 - scfg_venc_remap_araddr"]
+    #[doc = "Bits 20:23 - venc_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_venc_remap_araddr(&mut self) -> SCFG_VENC_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VENC_REMAP_ARADDR_W::new(self, 20)
+    pub fn venc_remap_araddr(&mut self) -> VENC_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
+        VENC_REMAP_ARADDR_W::new(self, 20)
     }
-    #[doc = "Bits 24:27 - scfg_venc_remap_awaddr"]
+    #[doc = "Bits 24:27 - venc_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_venc_remap_awaddr(&mut self) -> SCFG_VENC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VENC_REMAP_AWADDR_W::new(self, 24)
+    pub fn venc_remap_awaddr(&mut self) -> VENC_REMAP_AWADDR_W<SYS_SYSCFG_1_SPEC> {
+        VENC_REMAP_AWADDR_W::new(self, 24)
     }
-    #[doc = "Bits 28:31 - scfg_vout0_remap_araddr"]
+    #[doc = "Bits 28:31 - vout0_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_araddr(&mut self) -> SCFG_VOUT0_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
-        SCFG_VOUT0_REMAP_ARADDR_W::new(self, 28)
+    pub fn vout0_remap_araddr(&mut self) -> VOUT0_REMAP_ARADDR_W<SYS_SYSCFG_1_SPEC> {
+        VOUT0_REMAP_ARADDR_W::new(self, 28)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_13.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_13.rs
@@ -18,14 +18,14 @@ pub type PLL2_TESTSEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
 pub type PLL_TEST_MODE_R = crate::BitReader;
 #[doc = "Field `pll_test_mode` writer - PLL test mode, only used for PLL BIST through jtag2apb"]
 pub type PLL_TEST_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_saif_audio_sdin_mux_scfg_i2sdin_sel` reader - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
-pub type U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_saif_audio_sdin_mux_scfg_i2sdin_sel` writer - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
-pub type U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_sft7110_noc_bus_clock_gating_off` reader - u0_sft7110_noc_bus_clock_gating_off"]
-pub type U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_clock_gating_off` writer - u0_sft7110_noc_bus_clock_gating_off"]
-pub type U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `audio_i2sdin_sel` reader - audio_i2sdin_sel"]
+pub type AUDIO_I2SDIN_SEL_R = crate::FieldReader;
+#[doc = "Field `audio_i2sdin_sel` writer - audio_i2sdin_sel"]
+pub type AUDIO_I2SDIN_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `noc_bus_clock_gating_off` reader - noc_bus_clock_gating_off"]
+pub type NOC_BUS_CLOCK_GATING_OFF_R = crate::BitReader;
+#[doc = "Field `noc_bus_clock_gating_off` writer - noc_bus_clock_gating_off"]
+pub type NOC_BUS_CLOCK_GATING_OFF_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `noc_bus_oic_evemon_start_0` reader - noc_bus_oic_evemon_start_0"]
 pub type NOC_BUS_OIC_EVEMON_START_0_R = crate::BitReader;
 #[doc = "Field `noc_bus_oic_evemon_start_0` writer - noc_bus_oic_evemon_start_0"]
@@ -87,17 +87,15 @@ impl R {
     pub fn pll_test_mode(&self) -> PLL_TEST_MODE_R {
         PLL_TEST_MODE_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bits 10:17 - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
+    #[doc = "Bits 10:17 - audio_i2sdin_sel"]
     #[inline(always)]
-    pub fn u0_saif_audio_sdin_mux_scfg_i2sdin_sel(
-        &self,
-    ) -> U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R {
-        U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_R::new(((self.bits >> 10) & 0xff) as u8)
+    pub fn audio_i2sdin_sel(&self) -> AUDIO_I2SDIN_SEL_R {
+        AUDIO_I2SDIN_SEL_R::new(((self.bits >> 10) & 0xff) as u8)
     }
-    #[doc = "Bit 18 - u0_sft7110_noc_bus_clock_gating_off"]
+    #[doc = "Bit 18 - noc_bus_clock_gating_off"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_clock_gating_off(&self) -> U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R {
-        U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn noc_bus_clock_gating_off(&self) -> NOC_BUS_CLOCK_GATING_OFF_R {
+        NOC_BUS_CLOCK_GATING_OFF_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - noc_bus_oic_evemon_start_0"]
     #[inline(always)]
@@ -190,21 +188,17 @@ impl W {
     pub fn pll_test_mode(&mut self) -> PLL_TEST_MODE_W<SYS_SYSCFG_13_SPEC> {
         PLL_TEST_MODE_W::new(self, 9)
     }
-    #[doc = "Bits 10:17 - u0_saif_audio_sdin_mux_scfg_i2sdin_sel"]
+    #[doc = "Bits 10:17 - audio_i2sdin_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_saif_audio_sdin_mux_scfg_i2sdin_sel(
-        &mut self,
-    ) -> U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W<SYS_SYSCFG_13_SPEC> {
-        U0_SAIF_AUDIO_SDIN_MUX_SCFG_I2SDIN_SEL_W::new(self, 10)
+    pub fn audio_i2sdin_sel(&mut self) -> AUDIO_I2SDIN_SEL_W<SYS_SYSCFG_13_SPEC> {
+        AUDIO_I2SDIN_SEL_W::new(self, 10)
     }
-    #[doc = "Bit 18 - u0_sft7110_noc_bus_clock_gating_off"]
+    #[doc = "Bit 18 - noc_bus_clock_gating_off"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_clock_gating_off(
-        &mut self,
-    ) -> U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W<SYS_SYSCFG_13_SPEC> {
-        U0_SFT7110_NOC_BUS_CLOCK_GATING_OFF_W::new(self, 18)
+    pub fn noc_bus_clock_gating_off(&mut self) -> NOC_BUS_CLOCK_GATING_OFF_W<SYS_SYSCFG_13_SPEC> {
+        NOC_BUS_CLOCK_GATING_OFF_W::new(self, 18)
     }
     #[doc = "Bit 19 - noc_bus_oic_evemon_start_0"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_14.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_14.rs
@@ -4,26 +4,26 @@ pub type R = crate::R<SYS_SYSCFG_14_SPEC>;
 pub type W = crate::W<SYS_SYSCFG_14_SPEC>;
 #[doc = "Field `noc_bus_oic_evemon_trigger_6` reader - noc_bus_oic_evemon_trigger_6"]
 pub type NOC_BUS_OIC_EVEMON_TRIGGER_6_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_0` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_0` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_1` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_1` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_2` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_2` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_3` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_3` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_4` reader - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R = crate::BitReader;
-#[doc = "Field `u0_sft7110_noc_bus_oic_ignore_modifiable_4` writer - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
-pub type U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_0` reader - noc_bus_oic_ignore_modifiable_0"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_0` writer - noc_bus_oic_ignore_modifiable_0"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_1` reader - noc_bus_oic_ignore_modifiable_1"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_1` writer - noc_bus_oic_ignore_modifiable_1"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_2` reader - noc_bus_oic_ignore_modifiable_2"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_2` writer - noc_bus_oic_ignore_modifiable_2"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_3` reader - noc_bus_oic_ignore_modifiable_3"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_3` writer - noc_bus_oic_ignore_modifiable_3"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_4` reader - noc_bus_oic_ignore_modifiable_4"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R = crate::BitReader;
+#[doc = "Field `noc_bus_oic_ignore_modifiable_4` writer - noc_bus_oic_ignore_modifiable_4"]
+pub type NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `noc_bus_oic_evemon_start_7` reader - noc_bus_oic_evemon_start_7"]
 pub type NOC_BUS_OIC_EVEMON_START_7_R = crate::BitReader;
 #[doc = "Field `noc_bus_oic_evemon_start_7` writer - noc_bus_oic_evemon_start_7"]
@@ -42,40 +42,30 @@ impl R {
     pub fn noc_bus_oic_evemon_trigger_6(&self) -> NOC_BUS_OIC_EVEMON_TRIGGER_6_R {
         NOC_BUS_OIC_EVEMON_TRIGGER_6_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
+    #[doc = "Bit 5 - noc_bus_oic_ignore_modifiable_0"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_0(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_0(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
+    #[doc = "Bit 6 - noc_bus_oic_ignore_modifiable_1"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_1(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_1(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
+    #[doc = "Bit 7 - noc_bus_oic_ignore_modifiable_2"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_2(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_2(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
+    #[doc = "Bit 8 - noc_bus_oic_ignore_modifiable_3"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_3(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_3(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_3_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
+    #[doc = "Bit 9 - noc_bus_oic_ignore_modifiable_4"]
     #[inline(always)]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_4(
-        &self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn noc_bus_oic_ignore_modifiable_4(&self) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 15 - noc_bus_oic_evemon_start_7"]
     #[inline(always)]
@@ -99,45 +89,45 @@ impl R {
     }
 }
 impl W {
-    #[doc = "Bit 5 - u0_sft7110_noc_bus_oic_ignore_modifiable_0"]
+    #[doc = "Bit 5 - noc_bus_oic_ignore_modifiable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_0(
+    pub fn noc_bus_oic_ignore_modifiable_0(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W::new(self, 5)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_0_W::new(self, 5)
     }
-    #[doc = "Bit 6 - u0_sft7110_noc_bus_oic_ignore_modifiable_1"]
+    #[doc = "Bit 6 - noc_bus_oic_ignore_modifiable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_1(
+    pub fn noc_bus_oic_ignore_modifiable_1(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W::new(self, 6)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_1_W::new(self, 6)
     }
-    #[doc = "Bit 7 - u0_sft7110_noc_bus_oic_ignore_modifiable_2"]
+    #[doc = "Bit 7 - noc_bus_oic_ignore_modifiable_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_2(
+    pub fn noc_bus_oic_ignore_modifiable_2(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W::new(self, 7)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_2_W::new(self, 7)
     }
-    #[doc = "Bit 8 - u0_sft7110_noc_bus_oic_ignore_modifiable_3"]
+    #[doc = "Bit 8 - noc_bus_oic_ignore_modifiable_3"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_3(
+    pub fn noc_bus_oic_ignore_modifiable_3(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W::new(self, 8)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_3_W::new(self, 8)
     }
-    #[doc = "Bit 9 - u0_sft7110_noc_bus_oic_ignore_modifiable_4"]
+    #[doc = "Bit 9 - noc_bus_oic_ignore_modifiable_4"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sft7110_noc_bus_oic_ignore_modifiable_4(
+    pub fn noc_bus_oic_ignore_modifiable_4(
         &mut self,
-    ) -> U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<SYS_SYSCFG_14_SPEC> {
-        U0_SFT7110_NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W::new(self, 9)
+    ) -> NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W<SYS_SYSCFG_14_SPEC> {
+        NOC_BUS_OIC_IGNORE_MODIFIABLE_4_W::new(self, 9)
     }
     #[doc = "Bit 15 - noc_bus_oic_evemon_start_7"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_15.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_15.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_15_SPEC>;
 #[doc = "Register `sys_syscfg_15` writer"]
 pub type W = crate::W<SYS_SYSCFG_15_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_0` reader - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_0` writer - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_0` reader - noc_bus_oic_qch_clock_stop_threshold_0"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_0` writer - noc_bus_oic_qch_clock_stop_threshold_0"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_0"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_0(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_0(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_0"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_0(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_0(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<SYS_SYSCFG_15_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W<SYS_SYSCFG_15_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_16.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_16.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_16_SPEC>;
 #[doc = "Register `sys_syscfg_16` writer"]
 pub type W = crate::W<SYS_SYSCFG_16_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_1` reader - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_1` writer - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_1` reader - noc_bus_oic_qch_clock_stop_threshold_1"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_1` writer - noc_bus_oic_qch_clock_stop_threshold_1"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_1"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_1(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_1(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_1"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_1(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_1(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<SYS_SYSCFG_16_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W<SYS_SYSCFG_16_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_1_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_17.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_17.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_17_SPEC>;
 #[doc = "Register `sys_syscfg_17` writer"]
 pub type W = crate::W<SYS_SYSCFG_17_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_2` reader - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_2` writer - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_2` reader - noc_bus_oic_qch_clock_stop_threshold_2"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_2` writer - noc_bus_oic_qch_clock_stop_threshold_2"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_2"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_2(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_2(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_2"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_2(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_2(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<SYS_SYSCFG_17_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W<SYS_SYSCFG_17_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_2_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_18.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_18.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_18_SPEC>;
 #[doc = "Register `sys_syscfg_18` writer"]
 pub type W = crate::W<SYS_SYSCFG_18_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_3` reader - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_3` writer - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_3` reader - noc_bus_oic_qch_clock_stop_threshold_3"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_3` writer - noc_bus_oic_qch_clock_stop_threshold_3"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_3"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_3(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_3(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_3"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_3"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_3(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_3(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<SYS_SYSCFG_18_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W<SYS_SYSCFG_18_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_3_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_19.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_19.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_19_SPEC>;
 #[doc = "Register `sys_syscfg_19` writer"]
 pub type W = crate::W<SYS_SYSCFG_19_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_4` reader - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_4` writer - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_4` reader - noc_bus_oic_qch_clock_stop_threshold_4"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_4` writer - noc_bus_oic_qch_clock_stop_threshold_4"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_4"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_4(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_4(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_4"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_4"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_4(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_4(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<SYS_SYSCFG_19_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W<SYS_SYSCFG_19_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_4_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_2.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_2.rs
@@ -2,53 +2,53 @@
 pub type R = crate::R<SYS_SYSCFG_2_SPEC>;
 #[doc = "Register `sys_syscfg_2` writer"]
 pub type W = crate::W<SYS_SYSCFG_2_SPEC>;
-#[doc = "Field `scfg_vout0_remap_awaddr` reader - scfg_vout0_remap_awaddr"]
-pub type SCFG_VOUT0_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout0_remap_awaddr` writer - scfg_vout0_remap_awaddr"]
-pub type SCFG_VOUT0_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout1_remap_araddr` reader - scfg_vout1_remap_araddr"]
-pub type SCFG_VOUT1_REMAP_ARADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout1_remap_araddr` writer - scfg_vout1_remap_araddr"]
-pub type SCFG_VOUT1_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `scfg_vout1_remap_awaddr` reader - scfg_vout1_remap_awaddr"]
-pub type SCFG_VOUT1_REMAP_AWADDR_R = crate::FieldReader;
-#[doc = "Field `scfg_vout1_remap_awaddr` writer - scfg_vout1_remap_awaddr"]
-pub type SCFG_VOUT1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout0_remap_awaddr` reader - vout0_remap_awaddr"]
+pub type VOUT0_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vout0_remap_awaddr` writer - vout0_remap_awaddr"]
+pub type VOUT0_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout1_remap_araddr` reader - vout1_remap_araddr"]
+pub type VOUT1_REMAP_ARADDR_R = crate::FieldReader;
+#[doc = "Field `vout1_remap_araddr` writer - vout1_remap_araddr"]
+pub type VOUT1_REMAP_ARADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `vout1_remap_awaddr` reader - vout1_remap_awaddr"]
+pub type VOUT1_REMAP_AWADDR_R = crate::FieldReader;
+#[doc = "Field `vout1_remap_awaddr` writer - vout1_remap_awaddr"]
+pub type VOUT1_REMAP_AWADDR_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:3 - scfg_vout0_remap_awaddr"]
+    #[doc = "Bits 0:3 - vout0_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr(&self) -> SCFG_VOUT0_REMAP_AWADDR_R {
-        SCFG_VOUT0_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
+    pub fn vout0_remap_awaddr(&self) -> VOUT0_REMAP_AWADDR_R {
+        VOUT0_REMAP_AWADDR_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:7 - scfg_vout1_remap_araddr"]
+    #[doc = "Bits 4:7 - vout1_remap_araddr"]
     #[inline(always)]
-    pub fn scfg_vout1_remap_araddr(&self) -> SCFG_VOUT1_REMAP_ARADDR_R {
-        SCFG_VOUT1_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    pub fn vout1_remap_araddr(&self) -> VOUT1_REMAP_ARADDR_R {
+        VOUT1_REMAP_ARADDR_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bits 8:11 - scfg_vout1_remap_awaddr"]
+    #[doc = "Bits 8:11 - vout1_remap_awaddr"]
     #[inline(always)]
-    pub fn scfg_vout1_remap_awaddr(&self) -> SCFG_VOUT1_REMAP_AWADDR_R {
-        SCFG_VOUT1_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    pub fn vout1_remap_awaddr(&self) -> VOUT1_REMAP_AWADDR_R {
+        VOUT1_REMAP_AWADDR_R::new(((self.bits >> 8) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - scfg_vout0_remap_awaddr"]
+    #[doc = "Bits 0:3 - vout0_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr(&mut self) -> SCFG_VOUT0_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_W::new(self, 0)
+    pub fn vout0_remap_awaddr(&mut self) -> VOUT0_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT0_REMAP_AWADDR_W::new(self, 0)
     }
-    #[doc = "Bits 4:7 - scfg_vout1_remap_araddr"]
+    #[doc = "Bits 4:7 - vout1_remap_araddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout1_remap_araddr(&mut self) -> SCFG_VOUT1_REMAP_ARADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT1_REMAP_ARADDR_W::new(self, 4)
+    pub fn vout1_remap_araddr(&mut self) -> VOUT1_REMAP_ARADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT1_REMAP_ARADDR_W::new(self, 4)
     }
-    #[doc = "Bits 8:11 - scfg_vout1_remap_awaddr"]
+    #[doc = "Bits 8:11 - vout1_remap_awaddr"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout1_remap_awaddr(&mut self) -> SCFG_VOUT1_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
-        SCFG_VOUT1_REMAP_AWADDR_W::new(self, 8)
+    pub fn vout1_remap_awaddr(&mut self) -> VOUT1_REMAP_AWADDR_W<SYS_SYSCFG_2_SPEC> {
+        VOUT1_REMAP_AWADDR_W::new(self, 8)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_20.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_20.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_20_SPEC>;
 #[doc = "Register `sys_syscfg_20` writer"]
 pub type W = crate::W<SYS_SYSCFG_20_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_5` reader - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_5` writer - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_5` reader - noc_bus_oic_qch_clock_stop_threshold_5"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_5` writer - noc_bus_oic_qch_clock_stop_threshold_5"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_5"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_5(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_5(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_5"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_5"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_5(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_5(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<SYS_SYSCFG_20_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W<SYS_SYSCFG_20_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_5_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_21.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_21.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_21_SPEC>;
 #[doc = "Register `sys_syscfg_21` writer"]
 pub type W = crate::W<SYS_SYSCFG_21_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_6` reader - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_6` writer - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_6` reader - noc_bus_oic_qch_clock_stop_threshold_6"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_6` writer - noc_bus_oic_qch_clock_stop_threshold_6"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_6"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_6(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_6(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_6"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_6"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_6(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_6(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<SYS_SYSCFG_21_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W<SYS_SYSCFG_21_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_6_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_22.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_22.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_22_SPEC>;
 #[doc = "Register `sys_syscfg_22` writer"]
 pub type W = crate::W<SYS_SYSCFG_22_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_7` reader - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_7` writer - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_7` reader - noc_bus_oic_qch_clock_stop_threshold_7"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_7` writer - noc_bus_oic_qch_clock_stop_threshold_7"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_7"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_7(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_7(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_7"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_7"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_7(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_7(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<SYS_SYSCFG_22_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W<SYS_SYSCFG_22_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_7_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_23.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_23.rs
@@ -2,28 +2,27 @@
 pub type R = crate::R<SYS_SYSCFG_23_SPEC>;
 #[doc = "Register `sys_syscfg_23` writer"]
 pub type W = crate::W<SYS_SYSCFG_23_SPEC>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_8` reader - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_noc_bus_oic_qch_clock_stop_threshold_8` writer - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
-pub type U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_8` reader - noc_bus_oic_qch_clock_stop_threshold_8"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R = crate::FieldReader<u32>;
+#[doc = "Field `noc_bus_oic_qch_clock_stop_threshold_8` writer - noc_bus_oic_qch_clock_stop_threshold_8"]
+pub type NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_8"]
     #[inline(always)]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_8(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_8(
         &self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R::new(self.bits)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_noc_bus_oic_qch_clock_stop_threshold_8"]
+    #[doc = "Bits 0:31 - noc_bus_oic_qch_clock_stop_threshold_8"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_noc_bus_oic_qch_clock_stop_threshold_8(
+    pub fn noc_bus_oic_qch_clock_stop_threshold_8(
         &mut self,
-    ) -> U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<SYS_SYSCFG_23_SPEC> {
-        U0_NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W::new(self, 0)
+    ) -> NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W<SYS_SYSCFG_23_SPEC> {
+        NOC_BUS_OIC_QCH_CLOCK_STOP_THRESHOLD_8_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_24.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_24.rs
@@ -2,124 +2,112 @@
 pub type R = crate::R<SYS_SYSCFG_24_SPEC>;
 #[doc = "Register `sys_syscfg_24` writer"]
 pub type W = crate::W<SYS_SYSCFG_24_SPEC>;
-#[doc = "Field `u0_tdm16slot_clkpol` reader - u0_tdm16slot_clkpol"]
-pub type U0_TDM16SLOT_CLKPOL_R = crate::BitReader;
-#[doc = "Field `u0_tdm16slot_pcm_ms` reader - u0_tdm16slot_pcm_ms"]
-pub type U0_TDM16SLOT_PCM_MS_R = crate::BitReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in0_ctl` reader - u0_trace_mtx_scfg_c0_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in0_ctl` writer - u0_trace_mtx_scfg_c0_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in1_ctl` reader - u0_trace_mtx_scfg_c0_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c0_in1_ctl` writer - u0_trace_mtx_scfg_c0_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C0_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in0_ctl` reader - u0_trace_mtx_scfg_c1_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in0_ctl` writer - u0_trace_mtx_scfg_c1_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in1_ctl` reader - u0_trace_mtx_scfg_c1_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c1_in1_ctl` writer - u0_trace_mtx_scfg_c1_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C1_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in0_ctl` reader - u0_trace_mtx_scfg_c2_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN0_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in0_ctl` writer - u0_trace_mtx_scfg_c2_in0_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN0_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in1_ctl` reader - u0_trace_mtx_scfg_c2_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN1_CTL_R = crate::FieldReader;
-#[doc = "Field `u0_trace_mtx_scfg_c2_in1_ctl` writer - u0_trace_mtx_scfg_c2_in1_ctl"]
-pub type U0_TRACE_MTX_SCFG_C2_IN1_CTL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `tdm16slot_clkpol` reader - tdm16slot_clkpol"]
+pub type TDM16SLOT_CLKPOL_R = crate::BitReader;
+#[doc = "Field `tdm16slot_pcm_ms` reader - tdm16slot_pcm_ms"]
+pub type TDM16SLOT_PCM_MS_R = crate::BitReader;
+#[doc = "Field `u0_trace_mtx_in0_0` reader - u0_trace_mtx_in0_0"]
+pub type U0_TRACE_MTX_IN0_0_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_0` writer - u0_trace_mtx_in0_0"]
+pub type U0_TRACE_MTX_IN0_0_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_0` reader - u0_trace_mtx_in1_0"]
+pub type U0_TRACE_MTX_IN1_0_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_0` writer - u0_trace_mtx_in1_0"]
+pub type U0_TRACE_MTX_IN1_0_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in0_1` reader - u0_trace_mtx_in0_1"]
+pub type U0_TRACE_MTX_IN0_1_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_1` writer - u0_trace_mtx_in0_1"]
+pub type U0_TRACE_MTX_IN0_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_1` reader - u0_trace_mtx_in1_1"]
+pub type U0_TRACE_MTX_IN1_1_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_1` writer - u0_trace_mtx_in1_1"]
+pub type U0_TRACE_MTX_IN1_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in0_2` reader - u0_trace_mtx_in0_2"]
+pub type U0_TRACE_MTX_IN0_2_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in0_2` writer - u0_trace_mtx_in0_2"]
+pub type U0_TRACE_MTX_IN0_2_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_trace_mtx_in1_2` reader - u0_trace_mtx_in1_2"]
+pub type U0_TRACE_MTX_IN1_2_R = crate::FieldReader;
+#[doc = "Field `u0_trace_mtx_in1_2` writer - u0_trace_mtx_in1_2"]
+pub type U0_TRACE_MTX_IN1_2_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
 impl R {
-    #[doc = "Bit 0 - u0_tdm16slot_clkpol"]
+    #[doc = "Bit 0 - tdm16slot_clkpol"]
     #[inline(always)]
-    pub fn u0_tdm16slot_clkpol(&self) -> U0_TDM16SLOT_CLKPOL_R {
-        U0_TDM16SLOT_CLKPOL_R::new((self.bits & 1) != 0)
+    pub fn tdm16slot_clkpol(&self) -> TDM16SLOT_CLKPOL_R {
+        TDM16SLOT_CLKPOL_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_tdm16slot_pcm_ms"]
+    #[doc = "Bit 1 - tdm16slot_pcm_ms"]
     #[inline(always)]
-    pub fn u0_tdm16slot_pcm_ms(&self) -> U0_TDM16SLOT_PCM_MS_R {
-        U0_TDM16SLOT_PCM_MS_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn tdm16slot_pcm_ms(&self) -> TDM16SLOT_PCM_MS_R {
+        TDM16SLOT_PCM_MS_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:6 - u0_trace_mtx_scfg_c0_in0_ctl"]
+    #[doc = "Bits 2:6 - u0_trace_mtx_in0_0"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c0_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C0_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C0_IN0_CTL_R::new(((self.bits >> 2) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_0(&self) -> U0_TRACE_MTX_IN0_0_R {
+        U0_TRACE_MTX_IN0_0_R::new(((self.bits >> 2) & 0x1f) as u8)
     }
-    #[doc = "Bits 7:11 - u0_trace_mtx_scfg_c0_in1_ctl"]
+    #[doc = "Bits 7:11 - u0_trace_mtx_in1_0"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c0_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C0_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C0_IN1_CTL_R::new(((self.bits >> 7) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_0(&self) -> U0_TRACE_MTX_IN1_0_R {
+        U0_TRACE_MTX_IN1_0_R::new(((self.bits >> 7) & 0x1f) as u8)
     }
-    #[doc = "Bits 12:16 - u0_trace_mtx_scfg_c1_in0_ctl"]
+    #[doc = "Bits 12:16 - u0_trace_mtx_in0_1"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c1_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C1_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C1_IN0_CTL_R::new(((self.bits >> 12) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_1(&self) -> U0_TRACE_MTX_IN0_1_R {
+        U0_TRACE_MTX_IN0_1_R::new(((self.bits >> 12) & 0x1f) as u8)
     }
-    #[doc = "Bits 17:21 - u0_trace_mtx_scfg_c1_in1_ctl"]
+    #[doc = "Bits 17:21 - u0_trace_mtx_in1_1"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c1_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C1_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C1_IN1_CTL_R::new(((self.bits >> 17) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_1(&self) -> U0_TRACE_MTX_IN1_1_R {
+        U0_TRACE_MTX_IN1_1_R::new(((self.bits >> 17) & 0x1f) as u8)
     }
-    #[doc = "Bits 22:26 - u0_trace_mtx_scfg_c2_in0_ctl"]
+    #[doc = "Bits 22:26 - u0_trace_mtx_in0_2"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c2_in0_ctl(&self) -> U0_TRACE_MTX_SCFG_C2_IN0_CTL_R {
-        U0_TRACE_MTX_SCFG_C2_IN0_CTL_R::new(((self.bits >> 22) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in0_2(&self) -> U0_TRACE_MTX_IN0_2_R {
+        U0_TRACE_MTX_IN0_2_R::new(((self.bits >> 22) & 0x1f) as u8)
     }
-    #[doc = "Bits 27:31 - u0_trace_mtx_scfg_c2_in1_ctl"]
+    #[doc = "Bits 27:31 - u0_trace_mtx_in1_2"]
     #[inline(always)]
-    pub fn u0_trace_mtx_scfg_c2_in1_ctl(&self) -> U0_TRACE_MTX_SCFG_C2_IN1_CTL_R {
-        U0_TRACE_MTX_SCFG_C2_IN1_CTL_R::new(((self.bits >> 27) & 0x1f) as u8)
+    pub fn u0_trace_mtx_in1_2(&self) -> U0_TRACE_MTX_IN1_2_R {
+        U0_TRACE_MTX_IN1_2_R::new(((self.bits >> 27) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 2:6 - u0_trace_mtx_scfg_c0_in0_ctl"]
+    #[doc = "Bits 2:6 - u0_trace_mtx_in0_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c0_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C0_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C0_IN0_CTL_W::new(self, 2)
+    pub fn u0_trace_mtx_in0_0(&mut self) -> U0_TRACE_MTX_IN0_0_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_0_W::new(self, 2)
     }
-    #[doc = "Bits 7:11 - u0_trace_mtx_scfg_c0_in1_ctl"]
+    #[doc = "Bits 7:11 - u0_trace_mtx_in1_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c0_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C0_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C0_IN1_CTL_W::new(self, 7)
+    pub fn u0_trace_mtx_in1_0(&mut self) -> U0_TRACE_MTX_IN1_0_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_0_W::new(self, 7)
     }
-    #[doc = "Bits 12:16 - u0_trace_mtx_scfg_c1_in0_ctl"]
+    #[doc = "Bits 12:16 - u0_trace_mtx_in0_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c1_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C1_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C1_IN0_CTL_W::new(self, 12)
+    pub fn u0_trace_mtx_in0_1(&mut self) -> U0_TRACE_MTX_IN0_1_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_1_W::new(self, 12)
     }
-    #[doc = "Bits 17:21 - u0_trace_mtx_scfg_c1_in1_ctl"]
+    #[doc = "Bits 17:21 - u0_trace_mtx_in1_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c1_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C1_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C1_IN1_CTL_W::new(self, 17)
+    pub fn u0_trace_mtx_in1_1(&mut self) -> U0_TRACE_MTX_IN1_1_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_1_W::new(self, 17)
     }
-    #[doc = "Bits 22:26 - u0_trace_mtx_scfg_c2_in0_ctl"]
+    #[doc = "Bits 22:26 - u0_trace_mtx_in0_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c2_in0_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C2_IN0_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C2_IN0_CTL_W::new(self, 22)
+    pub fn u0_trace_mtx_in0_2(&mut self) -> U0_TRACE_MTX_IN0_2_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN0_2_W::new(self, 22)
     }
-    #[doc = "Bits 27:31 - u0_trace_mtx_scfg_c2_in1_ctl"]
+    #[doc = "Bits 27:31 - u0_trace_mtx_in1_2"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_trace_mtx_scfg_c2_in1_ctl(
-        &mut self,
-    ) -> U0_TRACE_MTX_SCFG_C2_IN1_CTL_W<SYS_SYSCFG_24_SPEC> {
-        U0_TRACE_MTX_SCFG_C2_IN1_CTL_W::new(self, 27)
+    pub fn u0_trace_mtx_in1_2(&mut self) -> U0_TRACE_MTX_IN1_2_W<SYS_SYSCFG_24_SPEC> {
+        U0_TRACE_MTX_IN1_2_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_3.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_3.rs
@@ -2,76 +2,68 @@
 pub type R = crate::R<SYS_SYSCFG_3_SPEC>;
 #[doc = "Register `sys_syscfg_3` writer"]
 pub type W = crate::W<SYS_SYSCFG_3_SPEC>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio0` reader - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO0_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio0` writer - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio1` reader - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO1_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio1` writer - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio2` reader - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO2_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio2` writer - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio3` reader - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO3_R = crate::BitReader;
-#[doc = "Field `scfg_vout0_remap_awaddr_gpio3` writer - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
-pub type SCFG_VOUT0_REMAP_AWADDR_GPIO3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio0` reader - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO0_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio0` writer - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio1` reader - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO1_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio1` writer - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio2` reader - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO2_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio2` writer - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `vout0_remap_awaddr_gpio3` reader - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO3_R = crate::BitReader;
+#[doc = "Field `vout0_remap_awaddr_gpio3` writer - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
+pub type VOUT0_REMAP_AWADDR_GPIO3_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio0(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO0_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO0_R::new((self.bits & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio0(&self) -> VOUT0_REMAP_AWADDR_GPIO0_R {
+        VOUT0_REMAP_AWADDR_GPIO0_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio1(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO1_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO1_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio1(&self) -> VOUT0_REMAP_AWADDR_GPIO1_R {
+        VOUT0_REMAP_AWADDR_GPIO1_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio2(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO2_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO2_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio2(&self) -> VOUT0_REMAP_AWADDR_GPIO2_R {
+        VOUT0_REMAP_AWADDR_GPIO2_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
     #[inline(always)]
-    pub fn scfg_vout0_remap_awaddr_gpio3(&self) -> SCFG_VOUT0_REMAP_AWADDR_GPIO3_R {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO3_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn vout0_remap_awaddr_gpio3(&self) -> VOUT0_REMAP_AWADDR_GPIO3_R {
+        VOUT0_REMAP_AWADDR_GPIO3_R::new(((self.bits >> 3) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 0: GPIO Group 0 (GPIO21-35) voltage select 3.3V, 1: GPIO Group 0 (GPIO21-35) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio0(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO0_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO0_W::new(self, 0)
+    pub fn vout0_remap_awaddr_gpio0(&mut self) -> VOUT0_REMAP_AWADDR_GPIO0_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO0_W::new(self, 0)
     }
     #[doc = "Bit 1 - 0: GPIO Group 1 (GPIO36-63) voltage select 3.3V, 1: GPIO Group 1 (GPIO36-63) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio1(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO1_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO1_W::new(self, 1)
+    pub fn vout0_remap_awaddr_gpio1(&mut self) -> VOUT0_REMAP_AWADDR_GPIO1_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO1_W::new(self, 1)
     }
     #[doc = "Bit 2 - 0: GPIO Group 2 (GPIO0-6) voltage select 3.3V, 1: GPIO Group 2 (GPIO0-6) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio2(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO2_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO2_W::new(self, 2)
+    pub fn vout0_remap_awaddr_gpio2(&mut self) -> VOUT0_REMAP_AWADDR_GPIO2_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO2_W::new(self, 2)
     }
     #[doc = "Bit 3 - 0: GPIO Group 3 (GPIO7-20) voltage select 3.3V, 1: GPIO Group 3 (GPIO7-20) voltage select 1.8V"]
     #[inline(always)]
     #[must_use]
-    pub fn scfg_vout0_remap_awaddr_gpio3(
-        &mut self,
-    ) -> SCFG_VOUT0_REMAP_AWADDR_GPIO3_W<SYS_SYSCFG_3_SPEC> {
-        SCFG_VOUT0_REMAP_AWADDR_GPIO3_W::new(self, 3)
+    pub fn vout0_remap_awaddr_gpio3(&mut self) -> VOUT0_REMAP_AWADDR_GPIO3_W<SYS_SYSCFG_3_SPEC> {
+        VOUT0_REMAP_AWADDR_GPIO3_W::new(self, 3)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_34.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_34.rs
@@ -34,28 +34,28 @@ pub type U0_VENC_INTSRAM_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_VENC_INTSRAM_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_venc_intsram_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_VENC_INTSRAM_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_i_ipu_current_buffer` reader - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
-pub type U0_WAVE420L_I_IPU_CURRENT_BUFFER_R = crate::FieldReader;
-#[doc = "Field `u0_wave420l_i_ipu_current_buffer` writer - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
-pub type U0_WAVE420L_I_IPU_CURRENT_BUFFER_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `u0_wave420l_i_ipu_end_of_row` reader - This signal is flipped every time when the IPU completes writing a row."]
-pub type U0_WAVE420L_I_IPU_END_OF_ROW_R = crate::BitReader;
-#[doc = "Field `u0_wave420l_i_ipu_end_of_row` writer - This signal is flipped every time when the IPU completes writing a row."]
-pub type U0_WAVE420L_I_IPU_END_OF_ROW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_i_ipu_new_frame` reader - This signal is flipped every time when the IPU completes writing a new frame."]
-pub type U0_WAVE420L_I_IPU_NEW_FRAME_R = crate::BitReader;
-#[doc = "Field `u0_wave420l_i_ipu_new_frame` writer - This signal is flipped every time when the IPU completes writing a new frame."]
-pub type U0_WAVE420L_I_IPU_NEW_FRAME_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_wave420l_o_vpu_idle` reader - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
-pub type U0_WAVE420L_O_VPU_IDLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_can_fd_enable` reader - u1_can_ctrl_can_fd_enable"]
-pub type U1_CAN_CTRL_CAN_FD_ENABLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_can_fd_enable` writer - u1_can_ctrl_can_fd_enable"]
-pub type U1_CAN_CTRL_CAN_FD_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_can_ctrl_host_ecc_disable` reader - u1_can_ctrl_host_ecc_disable"]
-pub type U1_CAN_CTRL_HOST_ECC_DISABLE_R = crate::BitReader;
-#[doc = "Field `u1_can_ctrl_host_ecc_disable` writer - u1_can_ctrl_host_ecc_disable"]
-pub type U1_CAN_CTRL_HOST_ECC_DISABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_ipu_current_buffer` reader - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
+pub type WAVE420L_IPU_CURRENT_BUFFER_R = crate::FieldReader;
+#[doc = "Field `wave420l_ipu_current_buffer` writer - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
+pub type WAVE420L_IPU_CURRENT_BUFFER_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `wave420l_ipu_end_of_row` reader - This signal is flipped every time when the IPU completes writing a row."]
+pub type WAVE420L_IPU_END_OF_ROW_R = crate::BitReader;
+#[doc = "Field `wave420l_ipu_end_of_row` writer - This signal is flipped every time when the IPU completes writing a row."]
+pub type WAVE420L_IPU_END_OF_ROW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_ipu_new_frame` reader - This signal is flipped every time when the IPU completes writing a new frame."]
+pub type WAVE420L_IPU_NEW_FRAME_R = crate::BitReader;
+#[doc = "Field `wave420l_ipu_new_frame` writer - This signal is flipped every time when the IPU completes writing a new frame."]
+pub type WAVE420L_IPU_NEW_FRAME_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `wave420l_vpu_idle` reader - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
+pub type WAVE420L_VPU_IDLE_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_1` reader - can_ctrl_fd_enable_1"]
+pub type CAN_CTRL_FD_ENABLE_1_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_1` writer - can_ctrl_fd_enable_1"]
+pub type CAN_CTRL_FD_ENABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_ecc_disable_1` reader - can_ctrl_host_ecc_disable_1"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_1_R = crate::BitReader;
+#[doc = "Field `can_ctrl_host_ecc_disable_1` writer - can_ctrl_host_ecc_disable_1"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -99,33 +99,33 @@ impl R {
     }
     #[doc = "Bits 12:14 - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_current_buffer(&self) -> U0_WAVE420L_I_IPU_CURRENT_BUFFER_R {
-        U0_WAVE420L_I_IPU_CURRENT_BUFFER_R::new(((self.bits >> 12) & 7) as u8)
+    pub fn wave420l_ipu_current_buffer(&self) -> WAVE420L_IPU_CURRENT_BUFFER_R {
+        WAVE420L_IPU_CURRENT_BUFFER_R::new(((self.bits >> 12) & 7) as u8)
     }
     #[doc = "Bit 15 - This signal is flipped every time when the IPU completes writing a row."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_end_of_row(&self) -> U0_WAVE420L_I_IPU_END_OF_ROW_R {
-        U0_WAVE420L_I_IPU_END_OF_ROW_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn wave420l_ipu_end_of_row(&self) -> WAVE420L_IPU_END_OF_ROW_R {
+        WAVE420L_IPU_END_OF_ROW_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - This signal is flipped every time when the IPU completes writing a new frame."]
     #[inline(always)]
-    pub fn u0_wave420l_i_ipu_new_frame(&self) -> U0_WAVE420L_I_IPU_NEW_FRAME_R {
-        U0_WAVE420L_I_IPU_NEW_FRAME_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn wave420l_ipu_new_frame(&self) -> WAVE420L_IPU_NEW_FRAME_R {
+        WAVE420L_IPU_NEW_FRAME_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - VPU monitoring signal. This signal gives out an opposite value of VPU_BUSY register."]
     #[inline(always)]
-    pub fn u0_wave420l_o_vpu_idle(&self) -> U0_WAVE420L_O_VPU_IDLE_R {
-        U0_WAVE420L_O_VPU_IDLE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn wave420l_vpu_idle(&self) -> WAVE420L_VPU_IDLE_R {
+        WAVE420L_VPU_IDLE_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u1_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 18 - can_ctrl_fd_enable_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_can_fd_enable(&self) -> U1_CAN_CTRL_CAN_FD_ENABLE_R {
-        U1_CAN_CTRL_CAN_FD_ENABLE_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn can_ctrl_fd_enable_1(&self) -> CAN_CTRL_FD_ENABLE_1_R {
+        CAN_CTRL_FD_ENABLE_1_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u1_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 19 - can_ctrl_host_ecc_disable_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_host_ecc_disable(&self) -> U1_CAN_CTRL_HOST_ECC_DISABLE_R {
-        U1_CAN_CTRL_HOST_ECC_DISABLE_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn can_ctrl_host_ecc_disable_1(&self) -> CAN_CTRL_HOST_ECC_DISABLE_1_R {
+        CAN_CTRL_HOST_ECC_DISABLE_1_R::new(((self.bits >> 19) & 1) != 0)
     }
 }
 impl W {
@@ -196,40 +196,36 @@ impl W {
     #[doc = "Bits 12:14 - This signal indicates which buffer is currently active so that the VPU can correctly use the ipu_end_of_row signal for row counter."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_current_buffer(
+    pub fn wave420l_ipu_current_buffer(
         &mut self,
-    ) -> U0_WAVE420L_I_IPU_CURRENT_BUFFER_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_CURRENT_BUFFER_W::new(self, 12)
+    ) -> WAVE420L_IPU_CURRENT_BUFFER_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_CURRENT_BUFFER_W::new(self, 12)
     }
     #[doc = "Bit 15 - This signal is flipped every time when the IPU completes writing a row."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_end_of_row(
-        &mut self,
-    ) -> U0_WAVE420L_I_IPU_END_OF_ROW_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_END_OF_ROW_W::new(self, 15)
+    pub fn wave420l_ipu_end_of_row(&mut self) -> WAVE420L_IPU_END_OF_ROW_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_END_OF_ROW_W::new(self, 15)
     }
     #[doc = "Bit 16 - This signal is flipped every time when the IPU completes writing a new frame."]
     #[inline(always)]
     #[must_use]
-    pub fn u0_wave420l_i_ipu_new_frame(
-        &mut self,
-    ) -> U0_WAVE420L_I_IPU_NEW_FRAME_W<SYS_SYSCFG_34_SPEC> {
-        U0_WAVE420L_I_IPU_NEW_FRAME_W::new(self, 16)
+    pub fn wave420l_ipu_new_frame(&mut self) -> WAVE420L_IPU_NEW_FRAME_W<SYS_SYSCFG_34_SPEC> {
+        WAVE420L_IPU_NEW_FRAME_W::new(self, 16)
     }
-    #[doc = "Bit 18 - u1_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 18 - can_ctrl_fd_enable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_can_ctrl_can_fd_enable(&mut self) -> U1_CAN_CTRL_CAN_FD_ENABLE_W<SYS_SYSCFG_34_SPEC> {
-        U1_CAN_CTRL_CAN_FD_ENABLE_W::new(self, 18)
+    pub fn can_ctrl_fd_enable_1(&mut self) -> CAN_CTRL_FD_ENABLE_1_W<SYS_SYSCFG_34_SPEC> {
+        CAN_CTRL_FD_ENABLE_1_W::new(self, 18)
     }
-    #[doc = "Bit 19 - u1_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 19 - can_ctrl_host_ecc_disable_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_can_ctrl_host_ecc_disable(
+    pub fn can_ctrl_host_ecc_disable_1(
         &mut self,
-    ) -> U1_CAN_CTRL_HOST_ECC_DISABLE_W<SYS_SYSCFG_34_SPEC> {
-        U1_CAN_CTRL_HOST_ECC_DISABLE_W::new(self, 19)
+    ) -> CAN_CTRL_HOST_ECC_DISABLE_1_W<SYS_SYSCFG_34_SPEC> {
+        CAN_CTRL_HOST_ECC_DISABLE_1_W::new(self, 19)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_35.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_35.rs
@@ -2,8 +2,8 @@
 pub type R = crate::R<SYS_SYSCFG_35_SPEC>;
 #[doc = "Register `sys_syscfg_35` writer"]
 pub type W = crate::W<SYS_SYSCFG_35_SPEC>;
-#[doc = "Field `u1_can_ctrl_host_if` reader - u1_can_ctrl_host_if"]
-pub type U1_CAN_CTRL_HOST_IF_R = crate::FieldReader<u32>;
+#[doc = "Field `can_ctrl_host_if_1` reader - can_ctrl_host_if_1"]
+pub type CAN_CTRL_HOST_IF_1_R = crate::FieldReader<u32>;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_SLP_R = crate::BitReader;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -37,10 +37,10 @@ pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_VG_R = crate::BitReader;
 #[doc = "Field `u1_gmac5_axi64_scfg_ram_cfg_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U1_GMAC5_AXI64_SCFG_RAM_CFG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:18 - u1_can_ctrl_host_if"]
+    #[doc = "Bits 0:18 - can_ctrl_host_if_1"]
     #[inline(always)]
-    pub fn u1_can_ctrl_host_if(&self) -> U1_CAN_CTRL_HOST_IF_R {
-        U1_CAN_CTRL_HOST_IF_R::new(self.bits & 0x0007_ffff)
+    pub fn can_ctrl_host_if_1(&self) -> CAN_CTRL_HOST_IF_1_R {
+        CAN_CTRL_HOST_IF_1_R::new(self.bits & 0x0007_ffff)
     }
     #[doc = "Bit 19 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_36.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_36.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<SYS_SYSCFG_36_SPEC>;
 #[doc = "Register `sys_syscfg_36` writer"]
 pub type W = crate::W<SYS_SYSCFG_36_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_mac_speed_0` reader - u1_gmac5_axi64_mac_speed_0"]
-pub type U1_GMAC5_AXI64_MAC_SPEED_0_R = crate::FieldReader;
-#[doc = "Field `u1_gmac5_axi64_phy_intf_sel_i` reader - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
-pub type U1_GMAC5_AXI64_PHY_INTF_SEL_I_R = crate::FieldReader;
-#[doc = "Field `u1_gmac5_axi64_phy_intf_sel_i` writer - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
-pub type U1_GMAC5_AXI64_PHY_INTF_SEL_I_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `gmac5_axi64_mac_speed` reader - gmac5_axi64_mac_speed"]
+pub type GMAC5_AXI64_MAC_SPEED_R = crate::FieldReader;
+#[doc = "Field `gmac5_axi64_phy_intf_sel` reader - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
+pub type GMAC5_AXI64_PHY_INTF_SEL_R = crate::FieldReader;
+#[doc = "Field `gmac5_axi64_phy_intf_sel` writer - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
+pub type GMAC5_AXI64_PHY_INTF_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
 impl R {
-    #[doc = "Bits 0:1 - u1_gmac5_axi64_mac_speed_0"]
+    #[doc = "Bits 0:1 - gmac5_axi64_mac_speed"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_mac_speed_0(&self) -> U1_GMAC5_AXI64_MAC_SPEED_0_R {
-        U1_GMAC5_AXI64_MAC_SPEED_0_R::new((self.bits & 3) as u8)
+    pub fn gmac5_axi64_mac_speed(&self) -> GMAC5_AXI64_MAC_SPEED_R {
+        GMAC5_AXI64_MAC_SPEED_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bits 2:4 - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_phy_intf_sel_i(&self) -> U1_GMAC5_AXI64_PHY_INTF_SEL_I_R {
-        U1_GMAC5_AXI64_PHY_INTF_SEL_I_R::new(((self.bits >> 2) & 7) as u8)
+    pub fn gmac5_axi64_phy_intf_sel(&self) -> GMAC5_AXI64_PHY_INTF_SEL_R {
+        GMAC5_AXI64_PHY_INTF_SEL_R::new(((self.bits >> 2) & 7) as u8)
     }
 }
 impl W {
     #[doc = "Bits 2:4 - Active PHY Selected | When you have multiple GMAC PHY interfaces in your configuration, this field indicates the sampled value of the PHY selector during reset de-assertion. | Values: 0x0:(GMII or MII), 0x01:RGMII, 0x2:SGMII, 0x3:TBI, 0x4:RMII, 0x5:RTBI, 0x6:SMII, 0x7:REVMII"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_gmac5_axi64_phy_intf_sel_i(
-        &mut self,
-    ) -> U1_GMAC5_AXI64_PHY_INTF_SEL_I_W<SYS_SYSCFG_36_SPEC> {
-        U1_GMAC5_AXI64_PHY_INTF_SEL_I_W::new(self, 2)
+    pub fn gmac5_axi64_phy_intf_sel(&mut self) -> GMAC5_AXI64_PHY_INTF_SEL_W<SYS_SYSCFG_36_SPEC> {
+        GMAC5_AXI64_PHY_INTF_SEL_W::new(self, 2)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_37.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_37.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<SYS_SYSCFG_37_SPEC>;
 #[doc = "Register `sys_syscfg_37` writer"]
 pub type W = crate::W<SYS_SYSCFG_37_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_ptp_timestamp_o_31_0` reader - u1_gmac5_axi64_ptp_timestamp_o_31_0"]
-pub type U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `gmac5_axi64_ptp_timestamp_0_31` reader - gmac5_axi64_ptp_timestamp_0_31"]
+pub type GMAC5_AXI64_PTP_TIMESTAMP_0_31_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_gmac5_axi64_ptp_timestamp_o_31_0"]
+    #[doc = "Bits 0:31 - gmac5_axi64_ptp_timestamp_0_31"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_ptp_timestamp_o_31_0(&self) -> U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R {
-        U1_GMAC5_AXI64_PTP_TIMESTAMP_O_31_0_R::new(self.bits)
+    pub fn gmac5_axi64_ptp_timestamp_0_31(&self) -> GMAC5_AXI64_PTP_TIMESTAMP_0_31_R {
+        GMAC5_AXI64_PTP_TIMESTAMP_0_31_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_38.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_38.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<SYS_SYSCFG_38_SPEC>;
 #[doc = "Register `sys_syscfg_38` writer"]
 pub type W = crate::W<SYS_SYSCFG_38_SPEC>;
-#[doc = "Field `u1_gmac5_axi64_ptp_timestamp_o_63_32` reader - u1_gmac5_axi64_ptp_timestamp_o_63_32"]
-pub type U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `gmac5_axi64_ptp_timestamp_32_63` reader - gmac5_axi64_ptp_timestamp_32_63"]
+pub type GMAC5_AXI64_PTP_TIMESTAMP_32_63_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_gmac5_axi64_ptp_timestamp_o_63_32"]
+    #[doc = "Bits 0:31 - gmac5_axi64_ptp_timestamp_32_63"]
     #[inline(always)]
-    pub fn u1_gmac5_axi64_ptp_timestamp_o_63_32(&self) -> U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R {
-        U1_GMAC5_AXI64_PTP_TIMESTAMP_O_63_32_R::new(self.bits)
+    pub fn gmac5_axi64_ptp_timestamp_32_63(&self) -> GMAC5_AXI64_PTP_TIMESTAMP_32_63_R {
+        GMAC5_AXI64_PTP_TIMESTAMP_32_63_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_39.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_39.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<SYS_SYSCFG_39_SPEC>;
 #[doc = "Register `sys_syscfg_39` writer"]
 pub type W = crate::W<SYS_SYSCFG_39_SPEC>;
-#[doc = "Field `u1_i2c_ic_en` reader - I2C interface enable."]
-pub type U1_I2C_IC_EN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select."]
-pub type U1_SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
-#[doc = "Field `u1_sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select."]
-pub type U1_SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u1_sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_sdio_m_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u1_sdio_m_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U1_SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_clr_reset_status` reader - u1_reset_ctrl_clr_reset_status"]
-pub type U1_RESET_CTRL_CLR_RESET_STATUS_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_clr_reset_status` writer - u1_reset_ctrl_clr_reset_status"]
-pub type U1_RESET_CTRL_CLR_RESET_STATUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_pll_timecnt_finish` reader - u1_reset_ctrl_pll_timecnt_finish"]
-pub type U1_RESET_CTRL_PLL_TIMECNT_FINISH_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_rstn_sw` reader - u1_reset_ctrl_rstn_sw"]
-pub type U1_RESET_CTRL_RSTN_SW_R = crate::BitReader;
-#[doc = "Field `u1_reset_ctrl_rstn_sw` writer - u1_reset_ctrl_rstn_sw"]
-pub type U1_RESET_CTRL_RSTN_SW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_reset_ctrl_sys_reset_status` reader - u1_reset_ctrl_sys_reset_status"]
-pub type U1_RESET_CTRL_SYS_RESET_STATUS_R = crate::FieldReader;
+#[doc = "Field `i2c_ic_en_1` reader - I2C interface enable."]
+pub type I2C_IC_EN_1_R = crate::BitReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl_1` reader - Data strobe delay chain select."]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_1_R = crate::FieldReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl_1` writer - Data strobe delay chain select."]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_1_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `sdio_hbig_endian_1` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_1_R = crate::BitReader;
+#[doc = "Field `sdio_hbig_endian_1` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `sdio_m_hbig_endian_1` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_1_R = crate::BitReader;
+#[doc = "Field `sdio_m_hbig_endian_1` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_clr_reset_status_1` reader - reset_ctrl_clr_reset_status_1"]
+pub type RESET_CTRL_CLR_RESET_STATUS_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_clr_reset_status_1` writer - reset_ctrl_clr_reset_status_1"]
+pub type RESET_CTRL_CLR_RESET_STATUS_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_pll_timecnt_finish_1` reader - reset_ctrl_pll_timecnt_finish_1"]
+pub type RESET_CTRL_PLL_TIMECNT_FINISH_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_rstn_sw_1` reader - reset_ctrl_rstn_sw_1"]
+pub type RESET_CTRL_RSTN_SW_1_R = crate::BitReader;
+#[doc = "Field `reset_ctrl_rstn_sw_1` writer - reset_ctrl_rstn_sw_1"]
+pub type RESET_CTRL_RSTN_SW_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `reset_ctrl_sys_reset_status_1` reader - reset_ctrl_sys_reset_status_1"]
+pub type RESET_CTRL_SYS_RESET_STATUS_1_R = crate::FieldReader;
 #[doc = "Field `i2c_ic_en_2` reader - I2C interface enable."]
 pub type I2C_IC_EN_2_R = crate::BitReader;
 #[doc = "Field `i2c_ic_en_3` reader - I2C interface enable."]
@@ -41,43 +41,43 @@ pub type I2C_IC_EN_6_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - I2C interface enable."]
     #[inline(always)]
-    pub fn u1_i2c_ic_en(&self) -> U1_I2C_IC_EN_R {
-        U1_I2C_IC_EN_R::new((self.bits & 1) != 0)
+    pub fn i2c_ic_en_1(&self) -> I2C_IC_EN_1_R {
+        I2C_IC_EN_1_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bits 1:5 - Data strobe delay chain select."]
     #[inline(always)]
-    pub fn u1_sdio_data_strobe_phase_ctrl(&self) -> U1_SDIO_DATA_STROBE_PHASE_CTRL_R {
-        U1_SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 1) & 0x1f) as u8)
+    pub fn sdio_data_strobe_phase_ctrl_1(&self) -> SDIO_DATA_STROBE_PHASE_CTRL_1_R {
+        SDIO_DATA_STROBE_PHASE_CTRL_1_R::new(((self.bits >> 1) & 0x1f) as u8)
     }
     #[doc = "Bit 6 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u1_sdio_hbig_endian(&self) -> U1_SDIO_HBIG_ENDIAN_R {
-        U1_SDIO_HBIG_ENDIAN_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn sdio_hbig_endian_1(&self) -> SDIO_HBIG_ENDIAN_1_R {
+        SDIO_HBIG_ENDIAN_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u1_sdio_m_hbig_endian(&self) -> U1_SDIO_M_HBIG_ENDIAN_R {
-        U1_SDIO_M_HBIG_ENDIAN_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn sdio_m_hbig_endian_1(&self) -> SDIO_M_HBIG_ENDIAN_1_R {
+        SDIO_M_HBIG_ENDIAN_1_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u1_reset_ctrl_clr_reset_status"]
+    #[doc = "Bit 8 - reset_ctrl_clr_reset_status_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_clr_reset_status(&self) -> U1_RESET_CTRL_CLR_RESET_STATUS_R {
-        U1_RESET_CTRL_CLR_RESET_STATUS_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn reset_ctrl_clr_reset_status_1(&self) -> RESET_CTRL_CLR_RESET_STATUS_1_R {
+        RESET_CTRL_CLR_RESET_STATUS_1_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_reset_ctrl_pll_timecnt_finish"]
+    #[doc = "Bit 9 - reset_ctrl_pll_timecnt_finish_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_pll_timecnt_finish(&self) -> U1_RESET_CTRL_PLL_TIMECNT_FINISH_R {
-        U1_RESET_CTRL_PLL_TIMECNT_FINISH_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn reset_ctrl_pll_timecnt_finish_1(&self) -> RESET_CTRL_PLL_TIMECNT_FINISH_1_R {
+        RESET_CTRL_PLL_TIMECNT_FINISH_1_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_reset_ctrl_rstn_sw"]
+    #[doc = "Bit 10 - reset_ctrl_rstn_sw_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_rstn_sw(&self) -> U1_RESET_CTRL_RSTN_SW_R {
-        U1_RESET_CTRL_RSTN_SW_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn reset_ctrl_rstn_sw_1(&self) -> RESET_CTRL_RSTN_SW_1_R {
+        RESET_CTRL_RSTN_SW_1_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bits 11:14 - u1_reset_ctrl_sys_reset_status"]
+    #[doc = "Bits 11:14 - reset_ctrl_sys_reset_status_1"]
     #[inline(always)]
-    pub fn u1_reset_ctrl_sys_reset_status(&self) -> U1_RESET_CTRL_SYS_RESET_STATUS_R {
-        U1_RESET_CTRL_SYS_RESET_STATUS_R::new(((self.bits >> 11) & 0x0f) as u8)
+    pub fn reset_ctrl_sys_reset_status_1(&self) -> RESET_CTRL_SYS_RESET_STATUS_1_R {
+        RESET_CTRL_SYS_RESET_STATUS_1_R::new(((self.bits >> 11) & 0x0f) as u8)
     }
     #[doc = "Bit 15 - I2C interface enable."]
     #[inline(always)]
@@ -109,36 +109,36 @@ impl W {
     #[doc = "Bits 1:5 - Data strobe delay chain select."]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_data_strobe_phase_ctrl(
+    pub fn sdio_data_strobe_phase_ctrl_1(
         &mut self,
-    ) -> U1_SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 1)
+    ) -> SDIO_DATA_STROBE_PHASE_CTRL_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_DATA_STROBE_PHASE_CTRL_1_W::new(self, 1)
     }
     #[doc = "Bit 6 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_hbig_endian(&mut self) -> U1_SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_HBIG_ENDIAN_W::new(self, 6)
+    pub fn sdio_hbig_endian_1(&mut self) -> SDIO_HBIG_ENDIAN_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_HBIG_ENDIAN_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_sdio_m_hbig_endian(&mut self) -> U1_SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_39_SPEC> {
-        U1_SDIO_M_HBIG_ENDIAN_W::new(self, 7)
+    pub fn sdio_m_hbig_endian_1(&mut self) -> SDIO_M_HBIG_ENDIAN_1_W<SYS_SYSCFG_39_SPEC> {
+        SDIO_M_HBIG_ENDIAN_1_W::new(self, 7)
     }
-    #[doc = "Bit 8 - u1_reset_ctrl_clr_reset_status"]
+    #[doc = "Bit 8 - reset_ctrl_clr_reset_status_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_reset_ctrl_clr_reset_status(
+    pub fn reset_ctrl_clr_reset_status_1(
         &mut self,
-    ) -> U1_RESET_CTRL_CLR_RESET_STATUS_W<SYS_SYSCFG_39_SPEC> {
-        U1_RESET_CTRL_CLR_RESET_STATUS_W::new(self, 8)
+    ) -> RESET_CTRL_CLR_RESET_STATUS_1_W<SYS_SYSCFG_39_SPEC> {
+        RESET_CTRL_CLR_RESET_STATUS_1_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u1_reset_ctrl_rstn_sw"]
+    #[doc = "Bit 10 - reset_ctrl_rstn_sw_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_reset_ctrl_rstn_sw(&mut self) -> U1_RESET_CTRL_RSTN_SW_W<SYS_SYSCFG_39_SPEC> {
-        U1_RESET_CTRL_RSTN_SW_W::new(self, 10)
+    pub fn reset_ctrl_rstn_sw_1(&mut self) -> RESET_CTRL_RSTN_SW_1_W<SYS_SYSCFG_39_SPEC> {
+        RESET_CTRL_RSTN_SW_1_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_4.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_4.rs
@@ -2,70 +2,68 @@
 pub type R = crate::R<SYS_SYSCFG_4_SPEC>;
 #[doc = "Register `sys_syscfg_4` writer"]
 pub type W = crate::W<SYS_SYSCFG_4_SPEC>;
-#[doc = "Field `u0_coda12_o_cur_inst_a` reader - Tie 0 in JPU internal, do not care"]
-pub type U0_CODA12_O_CUR_INST_A_R = crate::FieldReader;
-#[doc = "Field `u0_wave511_o_vpu_idle` reader - VPU monitoring signal"]
-pub type U0_WAVE511_O_VPU_IDLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_can_fd_enable` reader - u0_can_ctrl_can_fd_enable"]
-pub type U0_CAN_CTRL_CAN_FD_ENABLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_can_fd_enable` writer - u0_can_ctrl_can_fd_enable"]
-pub type U0_CAN_CTRL_CAN_FD_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_can_ctrl_host_ecc_disable` reader - u0_can_ctrl_host_ecc_disable"]
-pub type U0_CAN_CTRL_HOST_ECC_DISABLE_R = crate::BitReader;
-#[doc = "Field `u0_can_ctrl_host_ecc_disable` writer - u0_can_ctrl_host_ecc_disable"]
-pub type U0_CAN_CTRL_HOST_ECC_DISABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_can_ctrl_host_if` reader - u0_can_ctrl_host_if"]
-pub type U0_CAN_CTRL_HOST_IF_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel` reader - des_qspi_sclk_dla: clock delay"]
-pub type U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R = crate::FieldReader;
+#[doc = "Field `coda12_cur_inst` reader - Tie 0 in JPU internal, do not care"]
+pub type CODA12_CUR_INST_R = crate::FieldReader;
+#[doc = "Field `wave511_vpu_idle` reader - VPU monitoring signal"]
+pub type WAVE511_VPU_IDLE_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_0` reader - can_ctrl_fd_enable_0"]
+pub type CAN_CTRL_FD_ENABLE_0_R = crate::BitReader;
+#[doc = "Field `can_ctrl_fd_enable_0` writer - can_ctrl_fd_enable_0"]
+pub type CAN_CTRL_FD_ENABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_ecc_disable_0` reader - can_ctrl_host_ecc_disable_0"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_0_R = crate::BitReader;
+#[doc = "Field `can_ctrl_host_ecc_disable_0` writer - can_ctrl_host_ecc_disable_0"]
+pub type CAN_CTRL_HOST_ECC_DISABLE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `can_ctrl_host_if_0` reader - can_ctrl_host_if_0"]
+pub type CAN_CTRL_HOST_IF_0_R = crate::FieldReader<u32>;
+#[doc = "Field `qspi_sclk_dlychain_sel` reader - des_qspi_sclk_dla: clock delay"]
+pub type QSPI_SCLK_DLYCHAIN_SEL_R = crate::FieldReader;
 impl R {
     #[doc = "Bits 0:1 - Tie 0 in JPU internal, do not care"]
     #[inline(always)]
-    pub fn u0_coda12_o_cur_inst_a(&self) -> U0_CODA12_O_CUR_INST_A_R {
-        U0_CODA12_O_CUR_INST_A_R::new((self.bits & 3) as u8)
+    pub fn coda12_cur_inst(&self) -> CODA12_CUR_INST_R {
+        CODA12_CUR_INST_R::new((self.bits & 3) as u8)
     }
     #[doc = "Bit 2 - VPU monitoring signal"]
     #[inline(always)]
-    pub fn u0_wave511_o_vpu_idle(&self) -> U0_WAVE511_O_VPU_IDLE_R {
-        U0_WAVE511_O_VPU_IDLE_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn wave511_vpu_idle(&self) -> WAVE511_VPU_IDLE_R {
+        WAVE511_VPU_IDLE_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 3 - can_ctrl_fd_enable_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_can_fd_enable(&self) -> U0_CAN_CTRL_CAN_FD_ENABLE_R {
-        U0_CAN_CTRL_CAN_FD_ENABLE_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn can_ctrl_fd_enable_0(&self) -> CAN_CTRL_FD_ENABLE_0_R {
+        CAN_CTRL_FD_ENABLE_0_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 4 - can_ctrl_host_ecc_disable_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_host_ecc_disable(&self) -> U0_CAN_CTRL_HOST_ECC_DISABLE_R {
-        U0_CAN_CTRL_HOST_ECC_DISABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn can_ctrl_host_ecc_disable_0(&self) -> CAN_CTRL_HOST_ECC_DISABLE_0_R {
+        CAN_CTRL_HOST_ECC_DISABLE_0_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:23 - u0_can_ctrl_host_if"]
+    #[doc = "Bits 5:23 - can_ctrl_host_if_0"]
     #[inline(always)]
-    pub fn u0_can_ctrl_host_if(&self) -> U0_CAN_CTRL_HOST_IF_R {
-        U0_CAN_CTRL_HOST_IF_R::new((self.bits >> 5) & 0x0007_ffff)
+    pub fn can_ctrl_host_if_0(&self) -> CAN_CTRL_HOST_IF_0_R {
+        CAN_CTRL_HOST_IF_0_R::new((self.bits >> 5) & 0x0007_ffff)
     }
     #[doc = "Bits 24:28 - des_qspi_sclk_dla: clock delay"]
     #[inline(always)]
-    pub fn u0_cdns_qspi_scfg_qspi_sclk_dlychain_sel(
-        &self,
-    ) -> U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R {
-        U0_CDNS_QSPI_SCFG_QSPI_SCLK_DLYCHAIN_SEL_R::new(((self.bits >> 24) & 0x1f) as u8)
+    pub fn qspi_sclk_dlychain_sel(&self) -> QSPI_SCLK_DLYCHAIN_SEL_R {
+        QSPI_SCLK_DLYCHAIN_SEL_R::new(((self.bits >> 24) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bit 3 - u0_can_ctrl_can_fd_enable"]
+    #[doc = "Bit 3 - can_ctrl_fd_enable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_can_ctrl_can_fd_enable(&mut self) -> U0_CAN_CTRL_CAN_FD_ENABLE_W<SYS_SYSCFG_4_SPEC> {
-        U0_CAN_CTRL_CAN_FD_ENABLE_W::new(self, 3)
+    pub fn can_ctrl_fd_enable_0(&mut self) -> CAN_CTRL_FD_ENABLE_0_W<SYS_SYSCFG_4_SPEC> {
+        CAN_CTRL_FD_ENABLE_0_W::new(self, 3)
     }
-    #[doc = "Bit 4 - u0_can_ctrl_host_ecc_disable"]
+    #[doc = "Bit 4 - can_ctrl_host_ecc_disable_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_can_ctrl_host_ecc_disable(
+    pub fn can_ctrl_host_ecc_disable_0(
         &mut self,
-    ) -> U0_CAN_CTRL_HOST_ECC_DISABLE_W<SYS_SYSCFG_4_SPEC> {
-        U0_CAN_CTRL_HOST_ECC_DISABLE_W::new(self, 4)
+    ) -> CAN_CTRL_HOST_ECC_DISABLE_0_W<SYS_SYSCFG_4_SPEC> {
+        CAN_CTRL_HOST_ECC_DISABLE_0_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_5.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_5.rs
@@ -66,18 +66,18 @@ pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG
 pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_cdns_spdif_scfg_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_CDNS_SPDIF_SCFG_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdns_spdif_trmodeo` reader - 1 for transmitter 0 for receiver"]
-pub type U0_CDNS_SPDIF_TRMODEO_R = crate::BitReader;
-#[doc = "Field `u0_i2c_ic_en` reader - I2C interface enable"]
-pub type U0_I2C_IC_EN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select"]
-pub type U0_SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
-#[doc = "Field `u0_sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select"]
-pub type U0_SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `spdif_trmodeo` reader - 1 for transmitter 0 for receiver"]
+pub type SPDIF_TRMODEO_R = crate::BitReader;
+#[doc = "Field `i2c_ic_en` reader - I2C interface enable"]
+pub type I2C_IC_EN_R = crate::BitReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl` reader - Data strobe delay chain select"]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_R = crate::FieldReader;
+#[doc = "Field `sdio_data_strobe_phase_ctrl` writer - Data strobe delay chain select"]
+pub type SDIO_DATA_STROBE_PHASE_CTRL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `sdio_hbig_endian` reader - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_R = crate::BitReader;
+#[doc = "Field `sdio_hbig_endian` writer - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -161,23 +161,23 @@ impl R {
     }
     #[doc = "Bit 24 - 1 for transmitter 0 for receiver"]
     #[inline(always)]
-    pub fn u0_cdns_spdif_trmodeo(&self) -> U0_CDNS_SPDIF_TRMODEO_R {
-        U0_CDNS_SPDIF_TRMODEO_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn spdif_trmodeo(&self) -> SPDIF_TRMODEO_R {
+        SPDIF_TRMODEO_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - I2C interface enable"]
     #[inline(always)]
-    pub fn u0_i2c_ic_en(&self) -> U0_I2C_IC_EN_R {
-        U0_I2C_IC_EN_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn i2c_ic_en(&self) -> I2C_IC_EN_R {
+        I2C_IC_EN_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bits 26:30 - Data strobe delay chain select"]
     #[inline(always)]
-    pub fn u0_sdio_data_strobe_phase_ctrl(&self) -> U0_SDIO_DATA_STROBE_PHASE_CTRL_R {
-        U0_SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn sdio_data_strobe_phase_ctrl(&self) -> SDIO_DATA_STROBE_PHASE_CTRL_R {
+        SDIO_DATA_STROBE_PHASE_CTRL_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
     #[doc = "Bit 31 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u0_sdio_hbig_endian(&self) -> U0_SDIO_HBIG_ENDIAN_R {
-        U0_SDIO_HBIG_ENDIAN_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn sdio_hbig_endian(&self) -> SDIO_HBIG_ENDIAN_R {
+        SDIO_HBIG_ENDIAN_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
@@ -312,16 +312,16 @@ impl W {
     #[doc = "Bits 26:30 - Data strobe delay chain select"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_data_strobe_phase_ctrl(
+    pub fn sdio_data_strobe_phase_ctrl(
         &mut self,
-    ) -> U0_SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_5_SPEC> {
-        U0_SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 26)
+    ) -> SDIO_DATA_STROBE_PHASE_CTRL_W<SYS_SYSCFG_5_SPEC> {
+        SDIO_DATA_STROBE_PHASE_CTRL_W::new(self, 26)
     }
     #[doc = "Bit 31 - AHB bus interface endianness: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_hbig_endian(&mut self) -> U0_SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_5_SPEC> {
-        U0_SDIO_HBIG_ENDIAN_W::new(self, 31)
+    pub fn sdio_hbig_endian(&mut self) -> SDIO_HBIG_ENDIAN_W<SYS_SYSCFG_5_SPEC> {
+        SDIO_HBIG_ENDIAN_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_6.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_6.rs
@@ -2,18 +2,18 @@
 pub type R = crate::R<SYS_SYSCFG_6_SPEC>;
 #[doc = "Register `sys_syscfg_6` writer"]
 pub type W = crate::W<SYS_SYSCFG_6_SPEC>;
-#[doc = "Field `u0_sdio_m_hbig_endian` reader - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
-#[doc = "Field `u0_sdio_m_hbig_endian` writer - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
-pub type U0_SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_i2srx_3ch_adc_ena` reader - u0_i2srx_3ch_adc_ena"]
-pub type U0_I2SRX_3CH_ADC_ENA_R = crate::BitReader;
-#[doc = "Field `u0_i2srx_3ch_adc_ena` writer - u0_i2srx_3ch_adc_ena"]
-pub type U0_I2SRX_3CH_ADC_ENA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_intmem_rom_sram_scfg_disable_rom` reader - u0_intmem_rom_sram_scfg_disable_rom"]
-pub type U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R = crate::BitReader;
-#[doc = "Field `u0_intmem_rom_sram_scfg_disable_rom` writer - u0_intmem_rom_sram_scfg_disable_rom"]
-pub type U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `sdio_m_hbig_endian` reader - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_R = crate::BitReader;
+#[doc = "Field `sdio_m_hbig_endian` writer - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
+pub type SDIO_M_HBIG_ENDIAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `i2srx_adc_en` reader - i2srx_adc_en"]
+pub type I2SRX_ADC_EN_R = crate::BitReader;
+#[doc = "Field `i2srx_adc_en` writer - i2srx_adc_en"]
+pub type I2SRX_ADC_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `intmem_rom_sram_scfg_disable_rom` reader - intmem_rom_sram_scfg_disable_rom"]
+pub type INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R = crate::BitReader;
+#[doc = "Field `intmem_rom_sram_scfg_disable_rom` writer - intmem_rom_sram_scfg_disable_rom"]
+pub type INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_SLP_R = crate::BitReader;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -46,18 +46,18 @@ pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VS_W<'a, REG> = crate::BitWriter<'a, REG
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R = crate::BitReader;
 #[doc = "Field `u0_intmem_rom_sram_sram_config_vg` writer - SRAM/ROM configuration. VG: timing setting for debug purpose, default is 1'b1."]
 pub type U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_0` reader - u0_jtag_daisy_chain_jtag_en_0"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R = crate::BitReader;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_0` writer - u0_jtag_daisy_chain_jtag_en_0"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_1` reader - u0_jtag_daisy_chain_jtag_en_1"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R = crate::BitReader;
-#[doc = "Field `u0_jtag_daisy_chain_jtag_en_1` writer - u0_jtag_daisy_chain_jtag_en_1"]
-pub type U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_pdrstn_split_sw_usbpipe_plugen` reader - u0_pdrstn_split_sw_usbpipe_plugen"]
-pub type U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R = crate::BitReader;
-#[doc = "Field `u0_pdrstn_split_sw_usbpipe_plugen` writer - u0_pdrstn_split_sw_usbpipe_plugen"]
-pub type U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `jtag_daisy_chain_en_0` reader - jtag_daisy_chain_en_0"]
+pub type JTAG_DAISY_CHAIN_EN_0_R = crate::BitReader;
+#[doc = "Field `jtag_daisy_chain_en_0` writer - jtag_daisy_chain_en_0"]
+pub type JTAG_DAISY_CHAIN_EN_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `jtag_daisy_chain_en_1` reader - jtag_daisy_chain_en_1"]
+pub type JTAG_DAISY_CHAIN_EN_1_R = crate::BitReader;
+#[doc = "Field `jtag_daisy_chain_en_1` writer - jtag_daisy_chain_en_1"]
+pub type JTAG_DAISY_CHAIN_EN_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pdrstn_usbpipe_plugen` reader - pdrstn_usbpipe_plugen"]
+pub type PDRSTN_USBPIPE_PLUGEN_R = crate::BitReader;
+#[doc = "Field `pdrstn_usbpipe_plugen` writer - pdrstn_usbpipe_plugen"]
+pub type PDRSTN_USBPIPE_PLUGEN_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `pll0_cpi_bias` reader - pll0_cpi_bias"]
 pub type PLL0_CPI_BIAS_R = crate::FieldReader;
 #[doc = "Field `pll0_cpi_bias` writer - pll0_cpi_bias"]
@@ -77,18 +77,18 @@ pub type PLL0_DSMPD_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
-    pub fn u0_sdio_m_hbig_endian(&self) -> U0_SDIO_M_HBIG_ENDIAN_R {
-        U0_SDIO_M_HBIG_ENDIAN_R::new((self.bits & 1) != 0)
+    pub fn sdio_m_hbig_endian(&self) -> SDIO_M_HBIG_ENDIAN_R {
+        SDIO_M_HBIG_ENDIAN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_i2srx_3ch_adc_ena"]
+    #[doc = "Bit 1 - i2srx_adc_en"]
     #[inline(always)]
-    pub fn u0_i2srx_3ch_adc_ena(&self) -> U0_I2SRX_3CH_ADC_ENA_R {
-        U0_I2SRX_3CH_ADC_ENA_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn i2srx_adc_en(&self) -> I2SRX_ADC_EN_R {
+        I2SRX_ADC_EN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_intmem_rom_sram_scfg_disable_rom"]
+    #[doc = "Bit 2 - intmem_rom_sram_scfg_disable_rom"]
     #[inline(always)]
-    pub fn u0_intmem_rom_sram_scfg_disable_rom(&self) -> U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R {
-        U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn intmem_rom_sram_scfg_disable_rom(&self) -> INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R {
+        INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -130,20 +130,20 @@ impl R {
     pub fn u0_intmem_rom_sram_sram_config_vg(&self) -> U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R {
         U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_jtag_daisy_chain_jtag_en_0"]
+    #[doc = "Bit 15 - jtag_daisy_chain_en_0"]
     #[inline(always)]
-    pub fn u0_jtag_daisy_chain_jtag_en_0(&self) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn jtag_daisy_chain_en_0(&self) -> JTAG_DAISY_CHAIN_EN_0_R {
+        JTAG_DAISY_CHAIN_EN_0_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_jtag_daisy_chain_jtag_en_1"]
+    #[doc = "Bit 16 - jtag_daisy_chain_en_1"]
     #[inline(always)]
-    pub fn u0_jtag_daisy_chain_jtag_en_1(&self) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn jtag_daisy_chain_en_1(&self) -> JTAG_DAISY_CHAIN_EN_1_R {
+        JTAG_DAISY_CHAIN_EN_1_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_pdrstn_split_sw_usbpipe_plugen"]
+    #[doc = "Bit 17 - pdrstn_usbpipe_plugen"]
     #[inline(always)]
-    pub fn u0_pdrstn_split_sw_usbpipe_plugen(&self) -> U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R {
-        U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn pdrstn_usbpipe_plugen(&self) -> PDRSTN_USBPIPE_PLUGEN_R {
+        PDRSTN_USBPIPE_PLUGEN_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bits 18:20 - pll0_cpi_bias"]
     #[inline(always)]
@@ -170,22 +170,22 @@ impl W {
     #[doc = "Bit 0 - AHB master bus interface endianess: 1: Big-endian AHB bus interface, 0: Little-endian AHB bus interface"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_sdio_m_hbig_endian(&mut self) -> U0_SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_6_SPEC> {
-        U0_SDIO_M_HBIG_ENDIAN_W::new(self, 0)
+    pub fn sdio_m_hbig_endian(&mut self) -> SDIO_M_HBIG_ENDIAN_W<SYS_SYSCFG_6_SPEC> {
+        SDIO_M_HBIG_ENDIAN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u0_i2srx_3ch_adc_ena"]
+    #[doc = "Bit 1 - i2srx_adc_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_i2srx_3ch_adc_ena(&mut self) -> U0_I2SRX_3CH_ADC_ENA_W<SYS_SYSCFG_6_SPEC> {
-        U0_I2SRX_3CH_ADC_ENA_W::new(self, 1)
+    pub fn i2srx_adc_en(&mut self) -> I2SRX_ADC_EN_W<SYS_SYSCFG_6_SPEC> {
+        I2SRX_ADC_EN_W::new(self, 1)
     }
-    #[doc = "Bit 2 - u0_intmem_rom_sram_scfg_disable_rom"]
+    #[doc = "Bit 2 - intmem_rom_sram_scfg_disable_rom"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_intmem_rom_sram_scfg_disable_rom(
+    pub fn intmem_rom_sram_scfg_disable_rom(
         &mut self,
-    ) -> U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<SYS_SYSCFG_6_SPEC> {
-        U0_INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W::new(self, 2)
+    ) -> INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W<SYS_SYSCFG_6_SPEC> {
+        INTMEM_ROM_SRAM_SCFG_DISABLE_ROM_W::new(self, 2)
     }
     #[doc = "Bit 3 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -251,29 +251,23 @@ impl W {
     ) -> U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W<SYS_SYSCFG_6_SPEC> {
         U0_INTMEM_ROM_SRAM_SRAM_CONFIG_VG_W::new(self, 14)
     }
-    #[doc = "Bit 15 - u0_jtag_daisy_chain_jtag_en_0"]
+    #[doc = "Bit 15 - jtag_daisy_chain_en_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_jtag_daisy_chain_jtag_en_0(
-        &mut self,
-    ) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W<SYS_SYSCFG_6_SPEC> {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_0_W::new(self, 15)
+    pub fn jtag_daisy_chain_en_0(&mut self) -> JTAG_DAISY_CHAIN_EN_0_W<SYS_SYSCFG_6_SPEC> {
+        JTAG_DAISY_CHAIN_EN_0_W::new(self, 15)
     }
-    #[doc = "Bit 16 - u0_jtag_daisy_chain_jtag_en_1"]
+    #[doc = "Bit 16 - jtag_daisy_chain_en_1"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_jtag_daisy_chain_jtag_en_1(
-        &mut self,
-    ) -> U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W<SYS_SYSCFG_6_SPEC> {
-        U0_JTAG_DAISY_CHAIN_JTAG_EN_1_W::new(self, 16)
+    pub fn jtag_daisy_chain_en_1(&mut self) -> JTAG_DAISY_CHAIN_EN_1_W<SYS_SYSCFG_6_SPEC> {
+        JTAG_DAISY_CHAIN_EN_1_W::new(self, 16)
     }
-    #[doc = "Bit 17 - u0_pdrstn_split_sw_usbpipe_plugen"]
+    #[doc = "Bit 17 - pdrstn_usbpipe_plugen"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_pdrstn_split_sw_usbpipe_plugen(
-        &mut self,
-    ) -> U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W<SYS_SYSCFG_6_SPEC> {
-        U0_PDRSTN_SPLIT_SW_USBPIPE_PLUGEN_W::new(self, 17)
+    pub fn pdrstn_usbpipe_plugen(&mut self) -> PDRSTN_USBPIPE_PLUGEN_W<SYS_SYSCFG_6_SPEC> {
+        PDRSTN_USBPIPE_PLUGEN_W::new(self, 17)
     }
     #[doc = "Bits 18:20 - pll0_cpi_bias"]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_7.rs
+++ b/jh7110-vf2-13b-pac/src/sys_syscon/sys_syscfg_7.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<SYS_SYSCFG_7_SPEC>;
 #[doc = "Register `sys_syscfg_7` writer"]
 pub type W = crate::W<SYS_SYSCFG_7_SPEC>;
-#[doc = "Field `u0_pll_wrap_pll0_fbdiv` reader - u0_pll_wrap_pll0_fbdiv"]
-pub type U0_PLL_WRAP_PLL0_FBDIV_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_pll_wrap_pll0_fbdiv` writer - u0_pll_wrap_pll0_fbdiv"]
-pub type U0_PLL_WRAP_PLL0_FBDIV_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
+#[doc = "Field `pll0_fbdiv` reader - pll0_fbdiv"]
+pub type PLL0_FBDIV_R = crate::FieldReader<u16>;
+#[doc = "Field `pll0_fbdiv` writer - pll0_fbdiv"]
+pub type PLL0_FBDIV_W<'a, REG> = crate::FieldWriter<'a, REG, 12, u16>;
 impl R {
-    #[doc = "Bits 0:11 - u0_pll_wrap_pll0_fbdiv"]
+    #[doc = "Bits 0:11 - pll0_fbdiv"]
     #[inline(always)]
-    pub fn u0_pll_wrap_pll0_fbdiv(&self) -> U0_PLL_WRAP_PLL0_FBDIV_R {
-        U0_PLL_WRAP_PLL0_FBDIV_R::new((self.bits & 0x0fff) as u16)
+    pub fn pll0_fbdiv(&self) -> PLL0_FBDIV_R {
+        PLL0_FBDIV_R::new((self.bits & 0x0fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:11 - u0_pll_wrap_pll0_fbdiv"]
+    #[doc = "Bits 0:11 - pll0_fbdiv"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_pll_wrap_pll0_fbdiv(&mut self) -> U0_PLL_WRAP_PLL0_FBDIV_W<SYS_SYSCFG_7_SPEC> {
-        U0_PLL_WRAP_PLL0_FBDIV_W::new(self, 0)
+    pub fn pll0_fbdiv(&mut self) -> PLL0_FBDIV_W<SYS_SYSCFG_7_SPEC> {
+        PLL0_FBDIV_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]


### PR DESCRIPTION
Simplifies the naming of `sys_syscon` register fields from the ones supplied in the JH7110 Technical Reference Manual.