### PR TITLE
fixup: clint: add register fields

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -24,6 +24,14 @@
           <addressOffset>0x0</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_1</name>
@@ -31,6 +39,14 @@
           <addressOffset>0x4</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_2</name>
@@ -38,6 +54,14 @@
           <addressOffset>0x8</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_3</name>
@@ -45,6 +69,14 @@
           <addressOffset>0xC</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_4</name>
@@ -52,6 +84,14 @@
           <addressOffset>0x10</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_0</name>
@@ -59,6 +99,14 @@
           <addressOffset>0x4000</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_1</name>
@@ -66,6 +114,14 @@
           <addressOffset>0x4008</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_2</name>
@@ -73,6 +129,14 @@
           <addressOffset>0x4010</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_3</name>
@@ -80,6 +144,14 @@
           <addressOffset>0x4018</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_4</name>
@@ -87,6 +159,14 @@
           <addressOffset>0x4020</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtime</name>
@@ -94,6 +174,14 @@
           <addressOffset>0xBFF8</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
       </registers>
     </peripheral>

--- a/jh7110-vf2-12a-pac/src/clint/msip_0.rs
+++ b/jh7110-vf2-12a-pac/src/clint/msip_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_0_SPEC>;
 #[doc = "Register `msip_0` writer"]
 pub type W = crate::W<MSIP_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_0_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/msip_1.rs
+++ b/jh7110-vf2-12a-pac/src/clint/msip_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_1_SPEC>;
 #[doc = "Register `msip_1` writer"]
 pub type W = crate::W<MSIP_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_1_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/msip_2.rs
+++ b/jh7110-vf2-12a-pac/src/clint/msip_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_2_SPEC>;
 #[doc = "Register `msip_2` writer"]
 pub type W = crate::W<MSIP_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_2_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/msip_3.rs
+++ b/jh7110-vf2-12a-pac/src/clint/msip_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_3_SPEC>;
 #[doc = "Register `msip_3` writer"]
 pub type W = crate::W<MSIP_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_3_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/msip_4.rs
+++ b/jh7110-vf2-12a-pac/src/clint/msip_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_4_SPEC>;
 #[doc = "Register `msip_4` writer"]
 pub type W = crate::W<MSIP_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_4_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtime.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtime.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIME_SPEC>;
 #[doc = "Register `mtime` writer"]
 pub type W = crate::W<MTIME_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIME_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIME_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtimecmp_0.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtimecmp_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_0_SPEC>;
 #[doc = "Register `mtimecmp_0` writer"]
 pub type W = crate::W<MTIMECMP_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_0_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtimecmp_1.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtimecmp_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_1_SPEC>;
 #[doc = "Register `mtimecmp_1` writer"]
 pub type W = crate::W<MTIMECMP_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_1_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtimecmp_2.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtimecmp_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_2_SPEC>;
 #[doc = "Register `mtimecmp_2` writer"]
 pub type W = crate::W<MTIMECMP_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_2_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtimecmp_3.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtimecmp_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_3_SPEC>;
 #[doc = "Register `mtimecmp_3` writer"]
 pub type W = crate::W<MTIMECMP_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_3_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-12a-pac/src/clint/mtimecmp_4.rs
+++ b/jh7110-vf2-12a-pac/src/clint/mtimecmp_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_4_SPEC>;
 #[doc = "Register `mtimecmp_4` writer"]
 pub type W = crate::W<MTIMECMP_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_4_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -24,6 +24,14 @@
           <addressOffset>0x0</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_1</name>
@@ -31,6 +39,14 @@
           <addressOffset>0x4</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_2</name>
@@ -38,6 +54,14 @@
           <addressOffset>0x8</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_3</name>
@@ -45,6 +69,14 @@
           <addressOffset>0xC</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>msip_4</name>
@@ -52,6 +84,14 @@
           <addressOffset>0x10</addressOffset>
           <size>32</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>control</name>
+              <description></description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_0</name>
@@ -59,6 +99,14 @@
           <addressOffset>0x4000</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_1</name>
@@ -66,6 +114,14 @@
           <addressOffset>0x4008</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_2</name>
@@ -73,6 +129,14 @@
           <addressOffset>0x4010</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_3</name>
@@ -80,6 +144,14 @@
           <addressOffset>0x4018</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtimecmp_4</name>
@@ -87,6 +159,14 @@
           <addressOffset>0x4020</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
         <register>
           <name>mtime</name>
@@ -94,6 +174,14 @@
           <addressOffset>0xBFF8</addressOffset>
           <size>64</size>
           <resetValue>0</resetValue>
+          <fields>
+            <field>
+              <name>cycles</name>
+              <description></description>
+              <bitRange>[63:0]</bitRange>
+              <access>read-write</access>
+            </field>
+          </fields>
         </register>
       </registers>
     </peripheral>

--- a/jh7110-vf2-13b-pac/src/clint/msip_0.rs
+++ b/jh7110-vf2-13b-pac/src/clint/msip_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_0_SPEC>;
 #[doc = "Register `msip_0` writer"]
 pub type W = crate::W<MSIP_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_0_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/msip_1.rs
+++ b/jh7110-vf2-13b-pac/src/clint/msip_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_1_SPEC>;
 #[doc = "Register `msip_1` writer"]
 pub type W = crate::W<MSIP_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_1_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/msip_2.rs
+++ b/jh7110-vf2-13b-pac/src/clint/msip_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_2_SPEC>;
 #[doc = "Register `msip_2` writer"]
 pub type W = crate::W<MSIP_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_2_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/msip_3.rs
+++ b/jh7110-vf2-13b-pac/src/clint/msip_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_3_SPEC>;
 #[doc = "Register `msip_3` writer"]
 pub type W = crate::W<MSIP_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_3_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/msip_4.rs
+++ b/jh7110-vf2-13b-pac/src/clint/msip_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MSIP_4_SPEC>;
 #[doc = "Register `msip_4` writer"]
 pub type W = crate::W<MSIP_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MSIP_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `control` reader - "]
+pub type CONTROL_R = crate::BitReader;
+#[doc = "Field `control` writer - "]
+pub type CONTROL_W<'a, REG> = crate::BitWriter<'a, REG>;
+impl R {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    pub fn control(&self) -> CONTROL_R {
+        CONTROL_R::new((self.bits & 1) != 0)
     }
 }
 impl W {
+    #[doc = "Bit 0"]
+    #[inline(always)]
+    #[must_use]
+    pub fn control(&mut self) -> CONTROL_W<MSIP_4_SPEC> {
+        CONTROL_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtime.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtime.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIME_SPEC>;
 #[doc = "Register `mtime` writer"]
 pub type W = crate::W<MTIME_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIME_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIME_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtimecmp_0.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtimecmp_0.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_0_SPEC>;
 #[doc = "Register `mtimecmp_0` writer"]
 pub type W = crate::W<MTIMECMP_0_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_0_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_0_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtimecmp_1.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtimecmp_1.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_1_SPEC>;
 #[doc = "Register `mtimecmp_1` writer"]
 pub type W = crate::W<MTIMECMP_1_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_1_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_1_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtimecmp_2.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtimecmp_2.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_2_SPEC>;
 #[doc = "Register `mtimecmp_2` writer"]
 pub type W = crate::W<MTIMECMP_2_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_2_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_2_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtimecmp_3.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtimecmp_3.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_3_SPEC>;
 #[doc = "Register `mtimecmp_3` writer"]
 pub type W = crate::W<MTIMECMP_3_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_3_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_3_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/jh7110-vf2-13b-pac/src/clint/mtimecmp_4.rs
+++ b/jh7110-vf2-13b-pac/src/clint/mtimecmp_4.rs
@@ -2,17 +2,24 @@
 pub type R = crate::R<MTIMECMP_4_SPEC>;
 #[doc = "Register `mtimecmp_4` writer"]
 pub type W = crate::W<MTIMECMP_4_SPEC>;
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "{}", self.bits())
-    }
-}
-impl core::fmt::Debug for crate::generic::Reg<MTIMECMP_4_SPEC> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Debug::fmt(&self.read(), f)
+#[doc = "Field `cycles` reader - "]
+pub type CYCLES_R = crate::FieldReader<u64>;
+#[doc = "Field `cycles` writer - "]
+pub type CYCLES_W<'a, REG> = crate::FieldWriter<'a, REG, 64, u64>;
+impl R {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    pub fn cycles(&self) -> CYCLES_R {
+        CYCLES_R::new(self.bits)
     }
 }
 impl W {
+    #[doc = "Bits 0:63"]
+    #[inline(always)]
+    #[must_use]
+    pub fn cycles(&mut self) -> CYCLES_W<MTIMECMP_4_SPEC> {
+        CYCLES_W::new(self, 0)
+    }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]
     #[doc = r" # Safety"]


### PR DESCRIPTION
Adds register fields to the `clint` peripheral registers based on the `U74` Core Complex Manual.