### PR TITLE
fixup: stg_syscon: more naming changes

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -12216,134 +12216,134 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_en</name>
-              <description>u0_cdn_usb_adp_en</description>
+              <name>u0_usb_adp_en</name>
+              <description>u0_usb_adp_en</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_probe_ana</name>
-              <description>u0_cdn_usb_adp_probe_ana</description>
+              <name>u0_usb_adp_probe_ana</name>
+              <description>u0_usb_adp_probe_ana</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_probe_en</name>
-              <description>u0_cdn_usb_adp_probe_en</description>
+              <name>u0_usb_adp_probe_en</name>
+              <description>u0_usb_adp_probe_en</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sense_ana</name>
-              <description>u0_cdn_usb_adp_sense_ana</description>
+              <name>u0_usb_adp_sense_ana</name>
+              <description>u0_usb_adp_sense_ana</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sense_en</name>
-              <description>u0_cdn_usb_adp_sense_en</description>
+              <name>u0_usb_adp_sense_en</name>
+              <description>u0_usb_adp_sense_en</description>
               <bitRange>[12:12]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sink_current_en</name>
-              <description>u0_cdn_usb_adp_sink_current_en</description>
+              <name>u0_usb_adp_sink_current_en</name>
+              <description>u0_usb_adp_sink_current_en</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_source_current_en</name>
-              <description>u0_cdn_usb_adp_source_current_en</description>
+              <name>u0_usb_adp_source_current_en</name>
+              <description>u0_usb_adp_source_current_en</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_bc_en</name>
-              <description>u0_cdn_usb_bc_en</description>
+              <name>u0_usb_bc_en</name>
+              <description>u0_usb_bc_en</description>
               <bitRange>[15:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_chrg_vbus</name>
-              <description>u0_cdn_usb_chrg_vbus</description>
+              <name>u0_usb_chrg_vbus</name>
+              <description>u0_usb_chrg_vbus</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dcd_comp_sts</name>
-              <description>u0_cdn_usb_dcd_comp_sts</description>
+              <name>u0_usb_dcd_comp_sts</name>
+              <description>u0_usb_dcd_comp_sts</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dischrg_vbus</name>
-              <description>u0_cdn_usb_dischrg_vbus</description>
+              <name>u0_usb_dischrg_vbus</name>
+              <description>u0_usb_dischrg_vbus</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vdat_ref_comp_en</name>
-              <description>u0_cdn_usb_dm_vdat_ref_comp_en</description>
+              <name>u0_usb_dm_vdat_ref_comp_en</name>
+              <description>u0_usb_dm_vdat_ref_comp_en</description>
               <bitRange>[19:19]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vdat_ref_comp_sts</name>
-              <description>u0_cdn_usb_dm_vdat_ref_comp_sts</description>
+              <name>u0_usb_dm_vdat_ref_comp_sts</name>
+              <description>u0_usb_dm_vdat_ref_comp_sts</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vlgc_comp_en</name>
-              <description>u0_cdn_usb_dm_vlgc_comp_en</description>
+              <name>u0_usb_dm_vlgc_comp_en</name>
+              <description>u0_usb_dm_vlgc_comp_en</description>
               <bitRange>[21:21]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vlgc_comp_sts</name>
-              <description>u0_cdn_usb_dm_vlgc_comp_sts</description>
+              <name>u0_usb_dm_vlgc_comp_sts</name>
+              <description>u0_usb_dm_vlgc_comp_sts</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dp_vdat_ref_comp_en</name>
-              <description>u0_cdn_usb_dp_vdat_ref_comp_en</description>
+              <name>u0_usb_dp_vdat_ref_comp_en</name>
+              <description>u0_usb_dp_vdat_ref_comp_en</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dp_vdat_ref_comp_sts</name>
-              <description>u0_cdn_usb_dp_vdat_ref_comp_sts</description>
+              <name>u0_usb_dp_vdat_ref_comp_sts</name>
+              <description>u0_usb_dp_vdat_ref_comp_sts</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_host_system_err</name>
-              <description>u0_cdn_usb_host_system_err</description>
+              <name>u0_usb_host_system_err</name>
+              <description>u0_usb_host_system_err</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_hsystem_err_ext</name>
-              <description>u0_cdn_usb_hsystem_err_ext</description>
+              <name>u0_usb_hsystem_err_ext</name>
+              <description>u0_usb_hsystem_err_ext</description>
               <bitRange>[26:26]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idm_sink_en</name>
-              <description>u0_cdn_usb_idm_sink_en</description>
+              <name>u0_usb_idm_sink_en</name>
+              <description>u0_usb_idm_sink_en</description>
               <bitRange>[27:27]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idp_sink_en</name>
-              <description>u0_cdn_usb_idp_sink_en</description>
+              <name>u0_usb_idp_sink_en</name>
+              <description>u0_usb_idp_sink_en</description>
               <bitRange>[28:28]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idp_src_en</name>
-              <description>u0_cdn_usb_idp_src_en</description>
+              <name>u0_usb_idp_src_en</name>
+              <description>u0_usb_idp_src_en</description>
               <bitRange>[29:29]</bitRange>
               <access>read-only</access>
             </field>
@@ -12357,68 +12357,68 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_lowest_belt</name>
+              <name>u0_usb_lowest_belt</name>
               <description>LTM interface to software</description>
               <bitRange>[11:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_ltm_host_req</name>
+              <name>u0_usb_ltm_host_req</name>
               <description>LTM interface to software</description>
               <bitRange>[12:12]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_ltm_host_req_halt</name>
+              <name>u0_usb_ltm_host_req_halt</name>
               <description>LTM interface to software</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mdctrl_clk_sel</name>
-              <description>u0_cdn_usb_mdctrl_clk_sel</description>
+              <name>u0_usb_mdctrl_clk_sel</name>
+              <description>u0_usb_mdctrl_clk_sel</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mdctrl_clk_status</name>
-              <description>u0_cdn_usb_mdctrl_clk_status</description>
+              <name>u0_usb_mdctrl_clk_status</name>
+              <description>u0_usb_mdctrl_clk_status</description>
               <bitRange>[15:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mode_strap</name>
+              <name>u0_usb_mode_strap</name>
               <description>Can onlly be changed when pwrup_rst_n is low</description>
               <bitRange>[18:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_otg_suspendm</name>
-              <description>u0_cdn_usb_otg_suspendm</description>
+              <name>u0_usb_otg_suspendm</name>
+              <description>u0_usb_otg_suspendm</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_otg_suspendm_byps</name>
-              <description>u0_cdn_usb_otg_suspendm_byps</description>
+              <name>u0_usb_otg_suspendm_byps</name>
+              <description>u0_usb_otg_suspendm_byps</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_phy_bvalid</name>
-              <description>u0_cdn_usb_phy_bvalid</description>
+              <name>u0_usb_phy_bvalid</name>
+              <description>u0_usb_phy_bvalid</description>
               <bitRange>[21:21]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_pll_en</name>
-              <description>u0_cdn_usb_pll_en</description>
+              <name>u0_usb_pll_en</name>
+              <description>u0_usb_pll_en</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_refclk_mode</name>
-              <description>u0_cdn_usb_refclk_mode</description>
+              <name>u0_usb_refclk_mode</name>
+              <description>u0_usb_refclk_mode</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
@@ -12441,32 +12441,32 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_float_comp_en</name>
-              <description>u0_cdn_usb_rid_float_comp_en</description>
+              <name>u0_usb_rid_float_comp_en</name>
+              <description>u0_usb_rid_float_comp_en</description>
               <bitRange>[27:27]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_float_comp_sts</name>
-              <description>u0_cdn_usb_rid_float_comp_sts</description>
+              <name>u0_usb_rid_float_comp_sts</name>
+              <description>u0_usb_rid_float_comp_sts</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_gnd_comp_sts</name>
-              <description>u0_cdn_usb_rid_gnd_comp_sts</description>
+              <name>u0_usb_rid_gnd_comp_sts</name>
+              <description>u0_usb_rid_gnd_comp_sts</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_nonfloat_comp_en</name>
-              <description>u0_cdn_usb_rid_nonfloat_comp_en</description>
+              <name>u0_usb_rid_nonfloat_comp_en</name>
+              <description>u0_usb_rid_nonfloat_comp_en</description>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rx_dm</name>
-              <description>u0_cdn_usb_rx_dm</description>
+              <name>u0_usb_rx_dm</name>
+              <description>u0_usb_rx_dm</description>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
             </field>
@@ -12480,182 +12480,182 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_rx_dp</name>
-              <description>u0_cdn_usb_rx_dp</description>
+              <name>u0_usb_rx_dp</name>
+              <description>u0_usb_rx_dp</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rx_rcv</name>
-              <description>u0_cdn_usb_rx_rcv</description>
+              <name>u0_usb_rx_rcv</name>
+              <description>u0_usb_rx_rcv</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_self_test</name>
+              <name>u0_usb_self_test</name>
               <description>For software bist_test</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sessend</name>
-              <description>u0_cdn_usb_sessend</description>
+              <name>u0_usb_sessend</name>
+              <description>u0_usb_sessend</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sessvalid</name>
-              <description>u0_cdn_usb_sessvalid</description>
+              <name>u0_usb_sessvalid</name>
+              <description>u0_usb_sessvalid</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sof</name>
-              <description>u0_cdn_usb_sof</description>
+              <name>u0_usb_sof</name>
+              <description>u0_usb_sof</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_test_bist</name>
+              <name>u0_usb_test_bist</name>
               <description>For software bist_test</description>
               <bitRange>[6:6]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_ack</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_ack</description>
+              <name>u0_usb_usbdev_main_power_off_ack</name>
+              <description>u0_usb_usbdev_main_power_off_ack</description>
               <bitRange>[7:7]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_ready</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_ready</description>
+              <name>u0_usb_usbdev_main_power_off_ready</name>
+              <description>u0_usb_usbdev_main_power_off_ready</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_req</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_req</description>
+              <name>u0_usb_usbdev_main_power_off_req</name>
+              <description>u0_usb_usbdev_main_power_off_req</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_ready</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_ready</description>
+              <name>u0_usb_usbdev_main_power_on_ready</name>
+              <description>u0_usb_usbdev_main_power_on_ready</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_req</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_req</description>
+              <name>u0_usb_usbdev_main_power_on_req</name>
+              <description>u0_usb_usbdev_main_power_on_req</description>
               <bitRange>[11:11]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_valid</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_valid</description>
+              <name>u0_usb_usbdev_main_power_on_valid</name>
+              <description>u0_usb_usbdev_main_power_on_valid</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_ack</name>
-              <description>u0_cdn_usb_usbdev_power_off_ack</description>
+              <name>u0_usb_usbdev_power_off_ack</name>
+              <description>u0_usb_usbdev_power_off_ack</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_ready</name>
-              <description>u0_cdn_usb_usbdev_power_off_ready</description>
+              <name>u0_usb_usbdev_power_off_ready</name>
+              <description>u0_usb_usbdev_power_off_ready</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_req</name>
-              <description>u0_cdn_usb_usbdev_power_off_req</description>
+              <name>u0_usb_usbdev_power_off_req</name>
+              <description>u0_usb_usbdev_power_off_req</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_ready</name>
-              <description>u0_cdn_usb_usbdev_power_on_ready</description>
+              <name>u0_usb_usbdev_power_on_ready</name>
+              <description>u0_usb_usbdev_power_on_ready</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_req</name>
-              <description>u0_cdn_usb_usbdev_power_on_req</description>
+              <name>u0_usb_usbdev_power_on_req</name>
+              <description>u0_usb_usbdev_power_on_req</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_valid</name>
-              <description>u0_cdn_usb_usbdev_power_on_valid</description>
+              <name>u0_usb_usbdev_power_on_valid</name>
+              <description>u0_usb_usbdev_power_on_valid</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_dmpulldown_sit</name>
-              <description>u0_cdn_usb_utmi_dmpulldown_sit</description>
+              <name>u0_usb_utmi_dmpulldown_sit</name>
+              <description>u0_usb_utmi_dmpulldown_sit</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_dppulldown_sit</name>
-              <description>u0_cdn_usb_utmi_dppulldown_sit</description>
+              <name>u0_usb_utmi_dppulldown_sit</name>
+              <description>u0_usb_utmi_dppulldown_sit</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_fslsserialmode_sit</name>
-              <description>u0_cdn_usb_utmi_fslsserialmode_sit</description>
+              <name>u0_usb_utmi_fslsserialmode_sit</name>
+              <description>u0_usb_utmi_fslsserialmode_sit</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_hostdisconnect_sit</name>
-              <description>u0_cdn_usb_utmi_hostdisconnect_sit</description>
+              <name>u0_usb_utmi_hostdisconnect_sit</name>
+              <description>u0_usb_utmi_hostdisconnect_sit</description>
               <bitRange>[22:22]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_iddig_sit</name>
-              <description>u0_cdn_usb_utmi_iddig_sit</description>
+              <name>u0_usb_utmi_iddig_sit</name>
+              <description>u0_usb_utmi_iddig_sit</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_idpullup_sit</name>
-              <description>u0_cdn_usb_utmi_idpullup_sit</description>
+              <name>u0_usb_utmi_idpullup_sit</name>
+              <description>u0_usb_utmi_idpullup_sit</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_linestate_sit</name>
-              <description>u0_cdn_usb_utmi_linestate_sit</description>
+              <name>u0_usb_utmi_linestate_sit</name>
+              <description>u0_usb_utmi_linestate_sit</description>
               <bitRange>[26:25]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_opmode_sit</name>
-              <description>u0_cdn_usb_utmi_opmode_sit</description>
+              <name>u0_usb_utmi_opmode_sit</name>
+              <description>u0_usb_utmi_opmode_sit</description>
               <bitRange>[28:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxactive_sit</name>
-              <description>u0_cdn_usb_utmi_rxactive_sit</description>
+              <name>u0_usb_utmi_rxactive_sit</name>
+              <description>u0_usb_utmi_rxactive_sit</description>
               <bitRange>[29:29]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxerror_sit</name>
-              <description>u0_cdn_usb_utmi_rxerror_sit</description>
+              <name>u0_usb_utmi_rxerror_sit</name>
+              <description>u0_usb_utmi_rxerror_sit</description>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxvalid_sit</name>
-              <description>u0_cdn_usb_utmi_rxvalid_sit</description>
+              <name>u0_usb_utmi_rxvalid_sit</name>
+              <description>u0_usb_utmi_rxvalid_sit</description>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
             </field>
@@ -12669,104 +12669,104 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_utmi_rxvalidh_sit</name>
-              <description>u0_cdn_usb_utmi_rxvalidh_sit</description>
+              <name>u0_usb_utmi_rxvalidh_sit</name>
+              <description>u0_usb_utmi_rxvalidh_sit</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_sessvld</name>
-              <description>u0_cdn_usb_utmi_sessvld</description>
+              <name>u0_usb_utmi_sessvld</name>
+              <description>u0_usb_utmi_sessvld</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_termselect_sit</name>
-              <description>u0_cdn_usb_utmi_termselect_sit</description>
+              <name>u0_usb_utmi_termselect_sit</name>
+              <description>u0_usb_utmi_termselect_sit</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_dat_sit</name>
-              <description>u0_cdn_usb_utmi_tx_dat_sit</description>
+              <name>u0_usb_utmi_tx_dat_sit</name>
+              <description>u0_usb_utmi_tx_dat_sit</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_enable_n_sit</name>
-              <description>u0_cdn_usb_utmi_tx_enable_n_sit</description>
+              <name>u0_usb_utmi_tx_enable_n_sit</name>
+              <description>u0_usb_utmi_tx_enable_n_sit</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_se0_sit</name>
-              <description>u0_cdn_usb_utmi_tx_se0_sit</description>
+              <name>u0_usb_utmi_tx_se0_sit</name>
+              <description>u0_usb_utmi_tx_se0_sit</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txbitstuffenable_sit</name>
-              <description>u0_cdn_usb_utmi_txbitstuffenable_sit</description>
+              <name>u0_usb_utmi_txbitstuffenable_sit</name>
+              <description>u0_usb_utmi_txbitstuffenable_sit</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txready_sit</name>
-              <description>u0_cdn_usb_utmi_txready_sit</description>
+              <name>u0_usb_utmi_txready_sit</name>
+              <description>u0_usb_utmi_txready_sit</description>
               <bitRange>[7:7]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txvalid_sit</name>
-              <description>u0_cdn_usb_utmi_txvalid_sit</description>
+              <name>u0_usb_utmi_txvalid_sit</name>
+              <description>u0_usb_utmi_txvalid_sit</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txvalidh_sit</name>
-              <description>u0_cdn_usb_utmi_txvalidh_sit</description>
+              <name>u0_usb_utmi_txvalidh_sit</name>
+              <description>u0_usb_utmi_txvalidh_sit</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vbusvalid_sit</name>
-              <description>u0_cdn_usb_utmi_vbusvalid_sit</description>
+              <name>u0_usb_utmi_vbusvalid_sit</name>
+              <description>u0_usb_utmi_vbusvalid_sit</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_xcvrselect_sit</name>
-              <description>u0_cdn_usb_utmi_xcvrselect_sit</description>
+              <name>u0_usb_utmi_xcvrselect_sit</name>
+              <description>u0_usb_utmi_xcvrselect_sit</description>
               <bitRange>[12:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vdm_src_en</name>
-              <description>u0_cdn_usb_utmi_vdm_src_en</description>
+              <name>u0_usb_utmi_vdm_src_en</name>
+              <description>u0_usb_utmi_vdm_src_en</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vdp_src_en</name>
-              <description>u0_cdn_usb_utmi_vdp_src_en</description>
+              <name>u0_usb_utmi_vdp_src_en</name>
+              <description>u0_usb_utmi_vdp_src_en</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_wakeup</name>
-              <description>u0_cdn_usb_wakeup</description>
+              <name>u0_usb_wakeup</name>
+              <description>u0_usb_wakeup</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhc_d0_ack</name>
-              <description>u0_cdn_usb_xhc_d0_ack</description>
+              <name>u0_usb_xhc_d0_ack</name>
+              <description>u0_usb_xhc_d0_ack</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhc_d0_req</name>
-              <description>u0_cdn_usb_xhc_d0_req</description>
+              <name>u0_usb_xhc_d0_req</name>
+              <description>u0_usb_xhc_d0_req</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -12780,8 +12780,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_bus</name>
-              <description>u0_cdn_usb_xhci_debug_bus</description>
+              <name>u0_usb_xhci_debug_bus</name>
+              <description>u0_usb_xhci_debug_bus</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -12795,8 +12795,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_link_state</name>
-              <description>u0_cdn_usb_xhci_debug_link_state</description>
+              <name>u0_usb_xhci_debug_link_state</name>
+              <description>u0_usb_xhci_debug_link_state</description>
               <bitRange>[30:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -12810,92 +12810,92 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_sel</name>
-              <description>u0_cdn_usb_xhci_debug_sel</description>
+              <name>u0_usb_xhci_debug_sel</name>
+              <description>u0_usb_xhci_debug_sel</description>
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_off_ack</name>
-              <description>u0_cdn_usb_xhci_main_power_off_ack</description>
+              <name>u0_usb_xhci_main_power_off_ack</name>
+              <description>u0_usb_xhci_main_power_off_ack</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_off_req</name>
-              <description>u0_cdn_usb_xhci_main_power_off_req</description>
+              <name>u0_usb_xhci_main_power_off_req</name>
+              <description>u0_usb_xhci_main_power_off_req</description>
               <bitRange>[6:6]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_ready</name>
-              <description>u0_cdn_usb_xhci_main_power_on_ready</description>
+              <name>u0_usb_xhci_main_power_on_ready</name>
+              <description>u0_usb_xhci_main_power_on_ready</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_req</name>
-              <description>u0_cdn_usb_xhci_main_power_on_req</description>
+              <name>u0_usb_xhci_main_power_on_req</name>
+              <description>u0_usb_xhci_main_power_on_req</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_valid</name>
-              <description>u0_cdn_usb_xhci_main_power_on_valid</description>
+              <name>u0_usb_xhci_main_power_on_valid</name>
+              <description>u0_usb_xhci_main_power_on_valid</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_ack</name>
-              <description>u0_cdn_usb_xhci_power_off_ack</description>
+              <name>u0_usb_xhci_power_off_ack</name>
+              <description>u0_usb_xhci_power_off_ack</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_ready</name>
-              <description>u0_cdn_usb_xhci_power_off_ready</description>
+              <name>u0_usb_xhci_power_off_ready</name>
+              <description>u0_usb_xhci_power_off_ready</description>
               <bitRange>[11:11]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_req</name>
-              <description>u0_cdn_usb_xhci_power_off_req</description>
+              <name>u0_usb_xhci_power_off_req</name>
+              <description>u0_usb_xhci_power_off_req</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_ready</name>
-              <description>u0_cdn_usb_xhci_power_on_ready</description>
+              <name>u0_usb_xhci_power_on_ready</name>
+              <description>u0_usb_xhci_power_on_ready</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_req</name>
-              <description>u0_cdn_usb_xhci_power_on_req</description>
+              <name>u0_usb_xhci_power_on_req</name>
+              <description>u0_usb_xhci_power_on_req</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_valid</name>
-              <description>u0_cdn_usb_xhci_power_on_valid</description>
+              <name>u0_usb_xhci_power_on_valid</name>
+              <description>u0_usb_xhci_power_on_valid</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_cease_from_tile_0</name>
-              <description>u0_e2_sft7110_cease_from_tile_0</description>
+              <name>u0_e2_cease_from_tile_0</name>
+              <description>u0_e2_cease_from_tile_0</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_debug_from_tile_0</name>
-              <description>u0_e2_sft7110_debug_from_tile_0</description>
+              <name>u0_e2_debug_from_tile_0</name>
+              <description>u0_e2_debug_from_tile_0</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_halt_from_tile_0</name>
-              <description>u0_e2_sft7110_halt_from_tile_0</description>
+              <name>u0_e2_halt_from_tile_0</name>
+              <description>u0_e2_halt_from_tile_0</description>
               <bitRange>[18:18]</bitRange>
               <access>read-only</access>
             </field>
@@ -12909,8 +12909,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_nmi_0_rnmi_exception_vector</name>
-              <description>u0_e2_sft7110_nmi_0_rnmi_exception_vector</description>
+              <name>u0_e2_nmi_exception_vector</name>
+              <description>u0_e2_nmi_exception_vector</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12924,8 +12924,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_nmi_0_rnmi_interrupt_vector</name>
-              <description>u0_e2_sft7110_nmi_0_rnmi_interrupt_vector</description>
+              <name>u0_e2_nmi_interrupt_vector</name>
+              <description>u0_e2_nmi_interrupt_vector</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12939,8 +12939,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_reset_vector_0</name>
-              <description>u0_e2_sft7110_reset_vector_0</description>
+              <name>u0_e2_reset_vector_0</name>
+              <description>u0_e2_reset_vector_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12954,8 +12954,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_wfi_from_tile_0</name>
-              <description>u0_e2_sft7110_wfi_from_tile_0</description>
+              <name>u0_e2_wfi_from_tile_0</name>
+              <description>u0_e2_wfi_from_tile_0</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13209,8 +13209,8 @@
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_align_detect</name>
-              <description>u0_plda_pcie_align_detect</description>
+              <name>u0_pcie_align_detect</name>
+              <description>u0_pcie_align_detect</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
@@ -13224,8 +13224,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_mst0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_mst0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13239,8 +13239,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_mst0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_mst0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13254,8 +13254,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_mst0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_mst0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13269,8 +13269,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_mst0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_mst0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13284,8 +13284,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_mst0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_mst0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13299,8 +13299,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_mst0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_mst0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13314,8 +13314,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_mst0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_mst0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13329,8 +13329,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_mst0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_mst0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13344,20 +13344,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_arfunc</description>
+              <name>u0_pcie_axi4_mst0_arfunc</name>
+              <description>u0_pcie_axi4_mst0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arregion</name>
-              <description>u0_plda_pcie_axi4_mst0_arregion</description>
+              <name>u0_pcie_axi4_mst0_arregion</name>
+              <description>u0_pcie_axi4_mst0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-only</access>
             </field>
@@ -13371,8 +13371,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aruser_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aruser_31_0</description>
+              <name>u0_pcie_axi4_mst0_aruser_31_0</name>
+              <description>u0_pcie_axi4_mst0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13386,8 +13386,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aruser_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aruser_63_32</description>
+              <name>u0_pcie_axi4_mst0_aruser_63_32</name>
+              <description>u0_pcie_axi4_mst0_aruser_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13401,14 +13401,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_awfunc</description>
+              <name>u0_pcie_axi4_mst0_awfunc</name>
+              <description>u0_pcie_axi4_mst0_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awregion</name>
-              <description>u0_plda_pcie_axi4_mst0_awregion</description>
+              <name>u0_pcie_axi4_mst0_awregion</name>
+              <description>u0_pcie_axi4_mst0_awregion</description>
               <bitRange>[18:15]</bitRange>
               <access>read-only</access>
             </field>
@@ -13422,8 +13422,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_a2user_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_a2user_31_0</description>
+              <name>u0_pcie_axi4_mst0_a2user_31_0</name>
+              <description>u0_pcie_axi4_mst0_a2user_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13437,14 +13437,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awuser_42_32</name>
-              <description>u0_plda_pcie_axi4_mst0_awuser_42_32</description>
+              <name>u0_pcie_axi4_mst0_awuser_42_32</name>
+              <description>u0_pcie_axi4_mst0_awuser_42_32</description>
               <bitRange>[10:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_rderr</name>
-              <description>u0_plda_pcie_axi4_mst0_rderr</description>
+              <name>u0_pcie_axi4_mst0_rderr</name>
+              <description>u0_pcie_axi4_mst0_rderr</description>
               <bitRange>[18:11]</bitRange>
               <access>read-write</access>
             </field>
@@ -13458,8 +13458,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_ruser</name>
-              <description>u0_plda_pcie_axi4_mst0_ruser</description>
+              <name>u0_pcie_axi4_mst0_ruser</name>
+              <description>u0_pcie_axi4_mst0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13473,8 +13473,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_wderr</name>
-              <description>u0_plda_pcie_axi4_mst0_wderr</description>
+              <name>u0_pcie_axi4_mst0_wderr</name>
+              <description>u0_pcie_axi4_mst0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13488,8 +13488,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_slv0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_slv0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13503,8 +13503,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_slv0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_slv0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13518,8 +13518,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_slv0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_slv0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13533,8 +13533,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_slv0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_slv0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13548,8 +13548,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_slv0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_slv0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13563,8 +13563,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_slv0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_slv0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13578,8 +13578,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_slv0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_slv0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13593,8 +13593,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_slv0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_slv0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13608,20 +13608,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_slv0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_slv0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_arfunc</name>
-              <description>u0_plda_pcie_axi4_slv0_arfunc</description>
+              <name>u0_pcie_axi4_slv0_arfunc</name>
+              <description>u0_pcie_axi4_slv0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_arregion</name>
-              <description>u0_plda_pcie_axi4_slv0_arregion</description>
+              <name>u0_pcie_axi4_slv0_arregion</name>
+              <description>u0_pcie_axi4_slv0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -13635,8 +13635,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aruser_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_aruser_31_0</description>
+              <name>u0_pcie_axi4_slv0_aruser_31_0</name>
+              <description>u0_pcie_axi4_slv0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13650,20 +13650,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aruser_40_32</name>
-              <description>u0_plda_pcie_axi4_slv0_aruser_40_32</description>
+              <name>u0_pcie_axi4_slv0_aruser_40_32</name>
+              <description>u0_pcie_axi4_slv0_aruser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awfunc</name>
-              <description>u0_plda_pcie_axi4_slv0_awfunc</description>
+              <name>u0_pcie_axi4_slv0_awfunc</name>
+              <description>u0_pcie_axi4_slv0_awfunc</description>
               <bitRange>[23:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awregion</name>
-              <description>u0_plda_pcie_axi4_slv0_awregion</description>
+              <name>u0_pcie_axi4_slv0_awregion</name>
+              <description>u0_pcie_axi4_slv0_awregion</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
@@ -13677,8 +13677,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awuser_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_awuser_31_0</description>
+              <name>u0_pcie_axi4_slv0_awuser_31_0</name>
+              <description>u0_pcie_axi4_slv0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13692,14 +13692,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awuser_40_32</name>
-              <description>u0_plda_pcie_axi4_slv0_awuser_40_32</description>
+              <name>u0_pcie_axi4_slv0_awuser_40_32</name>
+              <description>u0_pcie_axi4_slv0_awuser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_rderr</name>
-              <description>u0_plda_pcie_axi4_slv0_rderr</description>
+              <name>u0_pcie_axi4_slv0_rderr</name>
+              <description>u0_pcie_axi4_slv0_rderr</description>
               <bitRange>[16:9]</bitRange>
               <access>read-only</access>
             </field>
@@ -13713,8 +13713,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_ruser</name>
-              <description>u0_plda_pcie_axi4_slv0_ruser</description>
+              <name>u0_pcie_axi4_slv0_ruser</name>
+              <description>u0_pcie_axi4_slv0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13728,14 +13728,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_wderr</name>
-              <description>u0_plda_pcie_axi4_slv0_wderr</description>
+              <name>u0_pcie_axi4_slv0_wderr</name>
+              <description>u0_pcie_axi4_slv0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slvl_arfunc</name>
-              <description>u0_plda_pcie_axi4_slvl_arfunc</description>
+              <name>u0_pcie_axi4_slvl_arfunc</name>
+              <description>u0_pcie_axi4_slvl_arfunc</description>
               <bitRange>[22:8]</bitRange>
               <access>read-only</access>
             </field>
@@ -13749,38 +13749,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slvl_awfunc</name>
-              <description>u0_plda_pcie_axi4_slvl_awfunc</description>
+              <name>u0_pcie_axi4_slvl_awfunc</name>
+              <description>u0_pcie_axi4_slvl_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_bus_width_o</name>
-              <description>u0_plda_pcie_bus_width_o</description>
+              <name>u0_pcie_bus_width_o</name>
+              <description>u0_pcie_bus_width_o</description>
               <bitRange>[16:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_bypass_codec</name>
-              <description>u0_plda_pcie_bypass_codec</description>
+              <name>u0_pcie_bypass_codec</name>
+              <description>u0_pcie_bypass_codec</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_ckref_src</name>
-              <description>u0_plda_pcie_ckref_src</description>
+              <name>u0_pcie_ckref_src</name>
+              <description>u0_pcie_ckref_src</description>
               <bitRange>[19:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_clk_sel</name>
-              <description>u0_plda_pcie_clk_sel</description>
+              <name>u0_pcie_clk_sel</name>
+              <description>u0_pcie_clk_sel</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_clkreq</name>
-              <description>u0_plda_pcie_clkreq</description>
+              <name>u0_pcie_clkreq</name>
+              <description>u0_pcie_clkreq</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
@@ -13794,8 +13794,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_31_0</name>
-              <description>u0_plda_pcie_k_phyparam_31_0</description>
+              <name>u0_pcie_k_phyparam_31_0</name>
+              <description>u0_pcie_k_phyparam_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13809,8 +13809,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_63_32</name>
-              <description>u0_plda_pcie_k_phyparam_63_32</description>
+              <name>u0_pcie_k_phyparam_63_32</name>
+              <description>u0_pcie_k_phyparam_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13824,8 +13824,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_95_64</name>
-              <description>u0_plda_pcie_k_phyparam_95_64</description>
+              <name>u0_pcie_k_phyparam_95_64</name>
+              <description>u0_pcie_k_phyparam_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13839,8 +13839,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_127_96</name>
-              <description>u0_plda_pcie_k_phyparam_127_96</description>
+              <name>u0_pcie_k_phyparam_127_96</name>
+              <description>u0_pcie_k_phyparam_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13854,8 +13854,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_159_128</name>
-              <description>u0_plda_pcie_k_phyparam_159_128</description>
+              <name>u0_pcie_k_phyparam_159_128</name>
+              <description>u0_pcie_k_phyparam_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13869,8 +13869,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_191_160</name>
-              <description>u0_plda_pcie_k_phyparam_191_160</description>
+              <name>u0_pcie_k_phyparam_191_160</name>
+              <description>u0_pcie_k_phyparam_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13884,8 +13884,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_223_192</name>
-              <description>u0_plda_pcie_k_phyparam_223_192</description>
+              <name>u0_pcie_k_phyparam_223_192</name>
+              <description>u0_pcie_k_phyparam_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13899,8 +13899,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_255_224</name>
-              <description>u0_plda_pcie_k_phyparam_255_224</description>
+              <name>u0_pcie_k_phyparam_255_224</name>
+              <description>u0_pcie_k_phyparam_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13914,8 +13914,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_287_256</name>
-              <description>u0_plda_pcie_k_phyparam_287_256</description>
+              <name>u0_pcie_k_phyparam_287_256</name>
+              <description>u0_pcie_k_phyparam_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13929,8 +13929,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_319_288</name>
-              <description>u0_plda_pcie_k_phyparam_319_288</description>
+              <name>u0_pcie_k_phyparam_319_288</name>
+              <description>u0_pcie_k_phyparam_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13944,8 +13944,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_351_320</name>
-              <description>u0_plda_pcie_k_phyparam_351_320</description>
+              <name>u0_pcie_k_phyparam_351_320</name>
+              <description>u0_pcie_k_phyparam_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13959,8 +13959,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_383_352</name>
-              <description>u0_plda_pcie_k_phyparam_383_352</description>
+              <name>u0_pcie_k_phyparam_383_352</name>
+              <description>u0_pcie_k_phyparam_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13974,8 +13974,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_415_384</name>
-              <description>u0_plda_pcie_k_phyparam_415_384</description>
+              <name>u0_pcie_k_phyparam_415_384</name>
+              <description>u0_pcie_k_phyparam_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13989,8 +13989,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_447_416</name>
-              <description>u0_plda_pcie_k_phyparam_447_416</description>
+              <name>u0_pcie_k_phyparam_447_416</name>
+              <description>u0_pcie_k_phyparam_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14004,8 +14004,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_479_448</name>
-              <description>u0_plda_pcie_k_phyparam_479_448</description>
+              <name>u0_pcie_k_phyparam_479_448</name>
+              <description>u0_pcie_k_phyparam_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14019,8 +14019,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_511_480</name>
-              <description>u0_plda_pcie_k_phyparam_511_480</description>
+              <name>u0_pcie_k_phyparam_511_480</name>
+              <description>u0_pcie_k_phyparam_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14034,8 +14034,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_543_512</name>
-              <description>u0_plda_pcie_k_phyparam_543_512</description>
+              <name>u0_pcie_k_phyparam_543_512</name>
+              <description>u0_pcie_k_phyparam_543_512</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14049,8 +14049,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_575_544</name>
-              <description>u0_plda_pcie_k_phyparam_575_544</description>
+              <name>u0_pcie_k_phyparam_575_544</name>
+              <description>u0_pcie_k_phyparam_575_544</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14064,8 +14064,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_607_576</name>
-              <description>u0_plda_pcie_k_phyparam_607_576</description>
+              <name>u0_pcie_k_phyparam_607_576</name>
+              <description>u0_pcie_k_phyparam_607_576</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14079,8 +14079,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_639_608</name>
-              <description>u0_plda_pcie_k_phyparam_639_608</description>
+              <name>u0_pcie_k_phyparam_639_608</name>
+              <description>u0_pcie_k_phyparam_639_608</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14094,8 +14094,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_671_640</name>
-              <description>u0_plda_pcie_k_phyparam_671_640</description>
+              <name>u0_pcie_k_phyparam_671_640</name>
+              <description>u0_pcie_k_phyparam_671_640</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14109,8 +14109,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_703_672</name>
-              <description>u0_plda_pcie_k_phyparam_703_672</description>
+              <name>u0_pcie_k_phyparam_703_672</name>
+              <description>u0_pcie_k_phyparam_703_672</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14124,8 +14124,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_735_704</name>
-              <description>u0_plda_pcie_k_phyparam_735_704</description>
+              <name>u0_pcie_k_phyparam_735_704</name>
+              <description>u0_pcie_k_phyparam_735_704</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14139,8 +14139,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_767_736</name>
-              <description>u0_plda_pcie_k_phyparam_767_736</description>
+              <name>u0_pcie_k_phyparam_767_736</name>
+              <description>u0_pcie_k_phyparam_767_736</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14154,8 +14154,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_799_768</name>
-              <description>u0_plda_pcie_k_phyparam_799_768</description>
+              <name>u0_pcie_k_phyparam_799_768</name>
+              <description>u0_pcie_k_phyparam_799_768</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14169,8 +14169,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_831_800</name>
-              <description>u0_plda_pcie_k_phyparam_831_800</description>
+              <name>u0_pcie_k_phyparam_831_800</name>
+              <description>u0_pcie_k_phyparam_831_800</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14184,26 +14184,26 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_839_832</name>
-              <description>u0_plda_pcie_k_phyparam_839_832</description>
+              <name>u0_pcie_k_phyparam_839_832</name>
+              <description>u0_pcie_k_phyparam_839_832</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_k_rp_nep</name>
-              <description>u0_plda_pcie_k_rp_nep</description>
+              <name>u0_pcie_k_rp_nep</name>
+              <description>u0_pcie_k_rp_nep</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_l1sub_entack</name>
-              <description>u0_plda_pcie_l1sub_entack</description>
+              <name>u0_pcie_l1sub_entack</name>
+              <description>u0_pcie_l1sub_entack</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_l1sub_entreq</name>
-              <description>u0_plda_pcie_l1sub_entreq</description>
+              <name>u0_pcie_l1sub_entreq</name>
+              <description>u0_pcie_l1sub_entreq</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
@@ -14217,8 +14217,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_local_interrupt_in</name>
-              <description>u0_plda_pcie_local_interrupt_in</description>
+              <name>u0_pcie_local_interrupt_in</name>
+              <description>u0_pcie_local_interrupt_in</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14232,38 +14232,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_mperstn</name>
-              <description>u0_plda_pcie_mperstn</description>
+              <name>u0_pcie_mperstn</name>
+              <description>u0_pcie_mperstn</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_ebuf_mode</name>
-              <description>u0_plda_pcie_pcie_ebuf_mode</description>
+              <name>u0_pcie_pcie_ebuf_mode</name>
+              <description>u0_pcie_pcie_ebuf_mode</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_phy_test_cfg</name>
-              <description>u0_plda_pcie_pcie_phy_test_cfg</description>
+              <name>u0_pcie_pcie_phy_test_cfg</name>
+              <description>u0_pcie_pcie_phy_test_cfg</description>
               <bitRange>[24:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_rx_eq_training</name>
-              <description>u0_plda_pcie_pcie_rx_eq_training</description>
+              <name>u0_pcie_pcie_rx_eq_training</name>
+              <description>u0_pcie_pcie_rx_eq_training</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_rxterm_en</name>
-              <description>u0_plda_pcie_pcie_rxterm_en</description>
+              <name>u0_pcie_pcie_rxterm_en</name>
+              <description>u0_pcie_pcie_rxterm_en</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_tx_onezeros</name>
-              <description>u0_plda_pcie_pcie_tx_onezeros</description>
+              <name>u0_pcie_pcie_tx_onezeros</name>
+              <description>u0_pcie_pcie_tx_onezeros</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -14277,8 +14277,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf0_offset</name>
-              <description>u0_plda_pcie_pf0_offset</description>
+              <name>u0_pcie_pf0_offset</name>
+              <description>u0_pcie_pf0_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14292,8 +14292,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf1_offset</name>
-              <description>u0_plda_pcie_pf1_offset</description>
+              <name>u0_pcie_pf1_offset</name>
+              <description>u0_pcie_pf1_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14307,8 +14307,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf2_offset</name>
-              <description>u0_plda_pcie_pf2_offset</description>
+              <name>u0_pcie_pf2_offset</name>
+              <description>u0_pcie_pf2_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14322,38 +14322,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf3_offset</name>
-              <description>u0_plda_pcie_pf3_offset</description>
+              <name>u0_pcie_pf3_offset</name>
+              <description>u0_pcie_pf3_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_phy_mode</name>
-              <description>u0_plda_pcie_phy_mode</description>
+              <name>u0_pcie_phy_mode</name>
+              <description>u0_pcie_phy_mode</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_clkrem_allow</name>
-              <description>u0_plda_pcie_pl_clkrem_allow</description>
+              <name>u0_pcie_pl_clkrem_allow</name>
+              <description>u0_pcie_pl_clkrem_allow</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_clkreq_oen</name>
-              <description>u0_plda_pcie_pl_clkreq_oen</description>
+              <name>u0_pcie_pl_clkreq_oen</name>
+              <description>u0_pcie_pl_clkreq_oen</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_equ_phase</name>
-              <description>u0_plda_pcie_pl_equ_phase</description>
+              <name>u0_pcie_pl_equ_phase</name>
+              <description>u0_pcie_pl_equ_phase</description>
               <bitRange>[25:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_ltssm</name>
-              <description>u0_plda_pcie_pl_ltssm</description>
+              <name>u0_pcie_pl_ltssm</name>
+              <description>u0_pcie_pl_ltssm</description>
               <bitRange>[30:26]</bitRange>
               <access>read-only</access>
             </field>
@@ -14367,8 +14367,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_pclk_rate</name>
-              <description>u0_plda_pcie_pl_pclk_rate</description>
+              <name>u0_pcie_pl_pclk_rate</name>
+              <description>u0_pcie_pl_pclk_rate</description>
               <bitRange>[4:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14382,8 +14382,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_in_31_0</name>
-              <description>u0_plda_pcie_pl_sideband_in_31_0</description>
+              <name>u0_pcie_pl_sideband_in_31_0</name>
+              <description>u0_pcie_pl_sideband_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14397,8 +14397,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_in_63_32</name>
-              <description>u0_plda_pcie_pl_sideband_in_63_32</description>
+              <name>u0_pcie_pl_sideband_in_63_32</name>
+              <description>u0_pcie_pl_sideband_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14412,8 +14412,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_out_31_0</name>
-              <description>u0_plda_pcie_pl_sideband_out_31_0</description>
+              <name>u0_pcie_pl_sideband_out_31_0</name>
+              <description>u0_pcie_pl_sideband_out_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14427,8 +14427,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_out_63_32</name>
-              <description>u0_plda_pcie_pl_sideband_out_63_32</description>
+              <name>u0_pcie_pl_sideband_out_63_32</name>
+              <description>u0_pcie_pl_sideband_out_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14442,20 +14442,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_wake_in</name>
-              <description>u0_plda_pcie_pl_wake_in</description>
+              <name>u0_pcie_pl_wake_in</name>
+              <description>u0_pcie_pl_wake_in</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_wake_oen</name>
-              <description>u0_plda_pcie_pl_wake_oen</description>
+              <name>u0_pcie_pl_wake_oen</name>
+              <description>u0_pcie_pl_wake_oen</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_rx_standby_0</name>
-              <description>u0_plda_pcie_rx_standby_0</description>
+              <name>u0_pcie_rx_standby_0</name>
+              <description>u0_pcie_rx_standby_0</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
@@ -14469,8 +14469,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_in_31_0</name>
-              <description>u0_plda_pcie_test_in_31_0</description>
+              <name>u0_pcie_test_in_31_0</name>
+              <description>u0_pcie_test_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14484,8 +14484,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_in_63_32</name>
-              <description>u0_plda_pcie_test_in_63_32</description>
+              <name>u0_pcie_test_in_63_32</name>
+              <description>u0_pcie_test_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14499,8 +14499,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_31_0</name>
-              <description>u0_plda_pcie_test_out_bridge_31_0</description>
+              <name>u0_pcie_test_out_bridge_31_0</name>
+              <description>u0_pcie_test_out_bridge_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14514,8 +14514,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_63_32</name>
-              <description>u0_plda_pcie_test_out_bridge_63_32</description>
+              <name>u0_pcie_test_out_bridge_63_32</name>
+              <description>u0_pcie_test_out_bridge_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14529,8 +14529,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_95_64</name>
-              <description>u0_plda_pcie_test_out_bridge_95_64</description>
+              <name>u0_pcie_test_out_bridge_95_64</name>
+              <description>u0_pcie_test_out_bridge_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14544,8 +14544,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_127_96</name>
-              <description>u0_plda_pcie_test_out_bridge_127_96</description>
+              <name>u0_pcie_test_out_bridge_127_96</name>
+              <description>u0_pcie_test_out_bridge_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14559,8 +14559,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_159_128</name>
-              <description>u0_plda_pcie_test_out_bridge_159_128</description>
+              <name>u0_pcie_test_out_bridge_159_128</name>
+              <description>u0_pcie_test_out_bridge_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14574,8 +14574,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_191_160</name>
-              <description>u0_plda_pcie_test_out_bridge_191_160</description>
+              <name>u0_pcie_test_out_bridge_191_160</name>
+              <description>u0_pcie_test_out_bridge_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14589,8 +14589,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_223_192</name>
-              <description>u0_plda_pcie_test_out_bridge_223_192</description>
+              <name>u0_pcie_test_out_bridge_223_192</name>
+              <description>u0_pcie_test_out_bridge_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14604,8 +14604,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_255_224</name>
-              <description>u0_plda_pcie_test_out_bridge_255_224</description>
+              <name>u0_pcie_test_out_bridge_255_224</name>
+              <description>u0_pcie_test_out_bridge_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14619,8 +14619,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_287_256</name>
-              <description>u0_plda_pcie_test_out_bridge_287_256</description>
+              <name>u0_pcie_test_out_bridge_287_256</name>
+              <description>u0_pcie_test_out_bridge_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14634,8 +14634,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_319_288</name>
-              <description>u0_plda_pcie_test_out_bridge_319_288</description>
+              <name>u0_pcie_test_out_bridge_319_288</name>
+              <description>u0_pcie_test_out_bridge_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14649,8 +14649,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_351_320</name>
-              <description>u0_plda_pcie_test_out_bridge_351_320</description>
+              <name>u0_pcie_test_out_bridge_351_320</name>
+              <description>u0_pcie_test_out_bridge_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14664,8 +14664,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_383_352</name>
-              <description>u0_plda_pcie_test_out_bridge_383_352</description>
+              <name>u0_pcie_test_out_bridge_383_352</name>
+              <description>u0_pcie_test_out_bridge_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14679,8 +14679,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_415_384</name>
-              <description>u0_plda_pcie_test_out_bridge_415_384</description>
+              <name>u0_pcie_test_out_bridge_415_384</name>
+              <description>u0_pcie_test_out_bridge_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14694,8 +14694,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_447_416</name>
-              <description>u0_plda_pcie_test_out_bridge_447_416</description>
+              <name>u0_pcie_test_out_bridge_447_416</name>
+              <description>u0_pcie_test_out_bridge_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14709,8 +14709,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_479_448</name>
-              <description>u0_plda_pcie_test_out_bridge_479_448</description>
+              <name>u0_pcie_test_out_bridge_479_448</name>
+              <description>u0_pcie_test_out_bridge_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14724,8 +14724,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_511_480</name>
-              <description>u0_plda_pcie_test_out_bridge_511_480</description>
+              <name>u0_pcie_test_out_bridge_511_480</name>
+              <description>u0_pcie_test_out_bridge_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14739,8 +14739,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_31_0</name>
-              <description>u0_plda_pcie_test_out_pcie_31_0</description>
+              <name>u0_pcie_test_out_pcie_31_0</name>
+              <description>u0_pcie_test_out_pcie_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14754,8 +14754,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_63_32</name>
-              <description>u0_plda_pcie_test_out_pcie_63_32</description>
+              <name>u0_pcie_test_out_pcie_63_32</name>
+              <description>u0_pcie_test_out_pcie_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14769,8 +14769,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_95_64</name>
-              <description>u0_plda_pcie_test_out_pcie_95_64</description>
+              <name>u0_pcie_test_out_pcie_95_64</name>
+              <description>u0_pcie_test_out_pcie_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14784,8 +14784,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_127_96</name>
-              <description>u0_plda_pcie_test_out_pcie_127_96</description>
+              <name>u0_pcie_test_out_pcie_127_96</name>
+              <description>u0_pcie_test_out_pcie_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14799,8 +14799,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_159_128</name>
-              <description>u0_plda_pcie_test_out_pcie_159_128</description>
+              <name>u0_pcie_test_out_pcie_159_128</name>
+              <description>u0_pcie_test_out_pcie_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14814,8 +14814,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_191_160</name>
-              <description>u0_plda_pcie_test_out_pcie_191_160</description>
+              <name>u0_pcie_test_out_pcie_191_160</name>
+              <description>u0_pcie_test_out_pcie_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14829,8 +14829,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_223_192</name>
-              <description>u0_plda_pcie_test_out_pcie_223_192</description>
+              <name>u0_pcie_test_out_pcie_223_192</name>
+              <description>u0_pcie_test_out_pcie_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14844,8 +14844,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_255_224</name>
-              <description>u0_plda_pcie_test_out_pcie_255_224</description>
+              <name>u0_pcie_test_out_pcie_255_224</name>
+              <description>u0_pcie_test_out_pcie_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14859,8 +14859,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_287_256</name>
-              <description>u0_plda_pcie_test_out_pcie_287_256</description>
+              <name>u0_pcie_test_out_pcie_287_256</name>
+              <description>u0_pcie_test_out_pcie_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14874,8 +14874,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_319_288</name>
-              <description>u0_plda_pcie_test_out_pcie_319_288</description>
+              <name>u0_pcie_test_out_pcie_319_288</name>
+              <description>u0_pcie_test_out_pcie_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14889,8 +14889,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_351_320</name>
-              <description>u0_plda_pcie_test_out_pcie_351_320</description>
+              <name>u0_pcie_test_out_pcie_351_320</name>
+              <description>u0_pcie_test_out_pcie_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14904,8 +14904,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_383_352</name>
-              <description>u0_plda_pcie_test_out_pcie_383_352</description>
+              <name>u0_pcie_test_out_pcie_383_352</name>
+              <description>u0_pcie_test_out_pcie_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14919,8 +14919,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_415_384</name>
-              <description>u0_plda_pcie_test_out_pcie_415_384</description>
+              <name>u0_pcie_test_out_pcie_415_384</name>
+              <description>u0_pcie_test_out_pcie_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14934,8 +14934,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_447_416</name>
-              <description>u0_plda_pcie_test_out_pcie_447_416</description>
+              <name>u0_pcie_test_out_pcie_447_416</name>
+              <description>u0_pcie_test_out_pcie_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14949,8 +14949,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_479_448</name>
-              <description>u0_plda_pcie_test_out_pcie_479_448</description>
+              <name>u0_pcie_test_out_pcie_479_448</name>
+              <description>u0_pcie_test_out_pcie_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14964,8 +14964,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_511_480</name>
-              <description>u0_plda_pcie_test_out_pcie_511_480</description>
+              <name>u0_pcie_test_out_pcie_511_480</name>
+              <description>u0_pcie_test_out_pcie_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14979,14 +14979,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_sel</name>
-              <description>u0_plda_pcie_test_sel</description>
+              <name>u0_pcie_test_sel</name>
+              <description>u0_pcie_test_sel</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_tl_clock_freq</name>
-              <description>u0_plda_pcie_tl_clock_freq</description>
+              <name>u0_pcie_tl_clock_freq</name>
+              <description>u0_pcie_tl_clock_freq</description>
               <bitRange>[25:4]</bitRange>
               <access>read-write</access>
             </field>
@@ -15000,14 +15000,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_tl_ctrl_hotplug</name>
-              <description>u0_plda_pcie_tl_ctrl_hotplug</description>
+              <name>u0_pcie_tl_ctrl_hotplug</name>
+              <description>u0_pcie_tl_ctrl_hotplug</description>
               <bitRange>[15:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_tl_report_hotplug</name>
-              <description>u0_plda_pcie_tl_report_hotplug</description>
+              <name>u0_pcie_tl_report_hotplug</name>
+              <description>u0_pcie_tl_report_hotplug</description>
               <bitRange>[31:16]</bitRange>
               <access>read-write</access>
             </field>
@@ -15021,50 +15021,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_tx_pattern</name>
-              <description>u0_plda_pcie_tx_pattern</description>
+              <name>u0_pcie_tx_pattern</name>
+              <description>u0_pcie_tx_pattern</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_bus_width</name>
-              <description>u0_plda_pcie_usb3_bus_width</description>
+              <name>u0_pcie_usb3_bus_width</name>
+              <description>u0_pcie_usb3_bus_width</description>
               <bitRange>[3:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_phy_enable</name>
-              <description>u0_plda_pcie_usb3_phy_enable</description>
+              <name>u0_pcie_usb3_phy_enable</name>
+              <description>u0_pcie_usb3_phy_enable</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_rate</name>
-              <description>u0_plda_pcie_usb3_rate</description>
+              <name>u0_pcie_usb3_rate</name>
+              <description>u0_pcie_usb3_rate</description>
               <bitRange>[6:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_rx_standby</name>
-              <description>u0_plda_pcie_usb3_rx_standby</description>
+              <name>u0_pcie_usb3_rx_standby</name>
+              <description>u0_pcie_usb3_rx_standby</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwdecerr</name>
-              <description>u0_plda_pcie_xwdecerr</description>
+              <name>u0_pcie_xwdecerr</name>
+              <description>u0_pcie_xwdecerr</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwerrclr</name>
-              <description>u0_plda_pcie_xwerrclr</description>
+              <name>u0_pcie_xwerrclr</name>
+              <description>u0_pcie_xwerrclr</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwslverr</name>
-              <description>u0_plda_pcie_xwslverr</description>
+              <name>u0_pcie_xwslverr</name>
+              <description>u0_pcie_xwslverr</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
@@ -15132,8 +15132,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_mst0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_mst0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15147,8 +15147,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_mst0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_mst0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15162,8 +15162,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_mst0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_mst0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15177,8 +15177,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_mst0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_mst0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15192,8 +15192,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_mst0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_mst0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15207,8 +15207,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_mst0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_mst0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15222,8 +15222,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_mst0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_mst0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15237,8 +15237,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_mst0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_mst0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15252,20 +15252,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_arfunc</description>
+              <name>u0_pcie_axi4_mst0_arfunc</name>
+              <description>u0_pcie_axi4_mst0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arregion</name>
-              <description>u0_plda_pcie_axi4_mst0_arregion</description>
+              <name>u0_pcie_axi4_mst0_arregion</name>
+              <description>u0_pcie_axi4_mst0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-only</access>
             </field>
@@ -15279,8 +15279,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aruser_31_0</name>
-              <description>u1_plda_pcie_axi4_mst0_aruser_31_0</description>
+              <name>u1_pcie_axi4_mst0_aruser_31_0</name>
+              <description>u1_pcie_axi4_mst0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15294,8 +15294,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aruser_52_32</name>
-              <description>u1_plda_pcie_axi4_mst0_aruser_52_32</description>
+              <name>u1_pcie_axi4_mst0_aruser_52_32</name>
+              <description>u1_pcie_axi4_mst0_aruser_52_32</description>
               <bitRange>[20:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15309,14 +15309,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awfunc</name>
-              <description>u1_plda_pcie_axi4_mst0_awfunc</description>
+              <name>u1_pcie_axi4_mst0_awfunc</name>
+              <description>u1_pcie_axi4_mst0_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awregion</name>
-              <description>u1_plda_pcie_axi4_mst0_awregion</description>
+              <name>u1_pcie_axi4_mst0_awregion</name>
+              <description>u1_pcie_axi4_mst0_awregion</description>
               <bitRange>[18:15]</bitRange>
               <access>read-only</access>
             </field>
@@ -15330,8 +15330,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awuser_31_0</name>
-              <description>u1_plda_pcie_axi4_mst0_awuser_31_0</description>
+              <name>u1_pcie_axi4_mst0_awuser_31_0</name>
+              <description>u1_pcie_axi4_mst0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15345,14 +15345,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awuser_42_32</name>
-              <description>u1_plda_pcie_axi4_mst0_awuser_42_32</description>
+              <name>u1_pcie_axi4_mst0_awuser_42_32</name>
+              <description>u1_pcie_axi4_mst0_awuser_42_32</description>
               <bitRange>[10:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_rderr</name>
-              <description>u1_plda_pcie_axi4_mst0_rderr</description>
+              <name>u1_pcie_axi4_mst0_rderr</name>
+              <description>u1_pcie_axi4_mst0_rderr</description>
               <bitRange>[18:11]</bitRange>
               <access>read-write</access>
             </field>
@@ -15366,8 +15366,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_ruser</name>
-              <description>u1_plda_pcie_axi4_mst0_ruser</description>
+              <name>u1_pcie_axi4_mst0_ruser</name>
+              <description>u1_pcie_axi4_mst0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15381,8 +15381,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_wderr</name>
-              <description>u1_plda_pcie_axi4_mst0_wderr</description>
+              <name>u1_pcie_axi4_mst0_wderr</name>
+              <description>u1_pcie_axi4_mst0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15396,8 +15396,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_31_0</description>
+              <name>u1_pcie_axi4_slv0_aratomop_31_0</name>
+              <description>u1_pcie_axi4_slv0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15411,8 +15411,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_63_32</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_63_32</description>
+              <name>u1_pcie_axi4_slv0_aratomop_63_32</name>
+              <description>u1_pcie_axi4_slv0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15426,8 +15426,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_95_64</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_95_64</description>
+              <name>u1_pcie_axi4_slv0_aratomop_95_64</name>
+              <description>u1_pcie_axi4_slv0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15441,8 +15441,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_127_96</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_127_96</description>
+              <name>u1_pcie_axi4_slv0_aratomop_127_96</name>
+              <description>u1_pcie_axi4_slv0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15456,8 +15456,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_159_128</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_159_128</description>
+              <name>u1_pcie_axi4_slv0_aratomop_159_128</name>
+              <description>u1_pcie_axi4_slv0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15471,8 +15471,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_191_160</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_191_160</description>
+              <name>u1_pcie_axi4_slv0_aratomop_191_160</name>
+              <description>u1_pcie_axi4_slv0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15486,8 +15486,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_223_192</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_223_192</description>
+              <name>u1_pcie_axi4_slv0_aratomop_223_192</name>
+              <description>u1_pcie_axi4_slv0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15501,8 +15501,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_255_224</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_255_224</description>
+              <name>u1_pcie_axi4_slv0_aratomop_255_224</name>
+              <description>u1_pcie_axi4_slv0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15516,20 +15516,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u1_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u1_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u1_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_arfunc</name>
-              <description>u1_plda_pcie_axi4_slv0_arfunc</description>
+              <name>u1_pcie_axi4_slv0_arfunc</name>
+              <description>u1_pcie_axi4_slv0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_arregion</name>
-              <description>u1_plda_pcie_axi4_slv0_arregion</description>
+              <name>u1_pcie_axi4_slv0_arregion</name>
+              <description>u1_pcie_axi4_slv0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -15543,8 +15543,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aruser_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_aruser_31_0</description>
+              <name>u1_pcie_axi4_slv0_aruser_31_0</name>
+              <description>u1_pcie_axi4_slv0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15558,20 +15558,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aruser_40_32</name>
-              <description>u1_plda_pcie_axi4_slv0_aruser_40_32</description>
+              <name>u1_pcie_axi4_slv0_aruser_40_32</name>
+              <description>u1_pcie_axi4_slv0_aruser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awfunc</name>
-              <description>u1_plda_pcie_axi4_slv0_awfunc</description>
+              <name>u1_pcie_axi4_slv0_awfunc</name>
+              <description>u1_pcie_axi4_slv0_awfunc</description>
               <bitRange>[23:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awregion</name>
-              <description>u1_plda_pcie_axi4_slv0_awregion</description>
+              <name>u1_pcie_axi4_slv0_awregion</name>
+              <description>u1_pcie_axi4_slv0_awregion</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
@@ -15585,8 +15585,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awuser_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_awuser_31_0</description>
+              <name>u1_pcie_axi4_slv0_awuser_31_0</name>
+              <description>u1_pcie_axi4_slv0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15600,14 +15600,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awuser_40_32</name>
-              <description>u1_plda_pcie_axi4_slv0_awuser_40_32</description>
+              <name>u1_pcie_axi4_slv0_awuser_40_32</name>
+              <description>u1_pcie_axi4_slv0_awuser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_rderr</name>
-              <description>u1_plda_pcie_axi4_slv0_rderr</description>
+              <name>u1_pcie_axi4_slv0_rderr</name>
+              <description>u1_pcie_axi4_slv0_rderr</description>
               <bitRange>[16:9]</bitRange>
               <access>read-only</access>
             </field>
@@ -15621,8 +15621,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_ruser</name>
-              <description>u1_plda_pcie_axi4_slv0_ruser</description>
+              <name>u1_pcie_axi4_slv0_ruser</name>
+              <description>u1_pcie_axi4_slv0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15636,14 +15636,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_wderr</name>
-              <description>u1_plda_pcie_axi4_slv0_wderr</description>
+              <name>u1_pcie_axi4_slv0_wderr</name>
+              <description>u1_pcie_axi4_slv0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slvl_arfunc</name>
-              <description>u1_plda_pcie_axi4_slvl_arfunc</description>
+              <name>u1_pcie_axi4_slvl_arfunc</name>
+              <description>u1_pcie_axi4_slvl_arfunc</description>
               <bitRange>[22:8]</bitRange>
               <access>read-write</access>
             </field>
@@ -15657,38 +15657,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slvl_awfunc</name>
-              <description>u1_plda_pcie_axi4_slvl_awfunc</description>
+              <name>u1_pcie_axi4_slvl_awfunc</name>
+              <description>u1_pcie_axi4_slvl_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_bus_width_o</name>
-              <description>u1_plda_pcie_bus_width_o</description>
+              <name>u1_pcie_bus_width_o</name>
+              <description>u1_pcie_bus_width_o</description>
               <bitRange>[16:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_bypass_codec</name>
-              <description>u1_plda_pcie_bypass_codec</description>
+              <name>u1_pcie_bypass_codec</name>
+              <description>u1_pcie_bypass_codec</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_ckref_src</name>
-              <description>u1_plda_pcie_ckref_src</description>
+              <name>u1_pcie_ckref_src</name>
+              <description>u1_pcie_ckref_src</description>
               <bitRange>[19:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_clk_sel</name>
-              <description>u1_plda_pcie_clk_sel</description>
+              <name>u1_pcie_clk_sel</name>
+              <description>u1_pcie_clk_sel</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_clkreq</name>
-              <description>u1_plda_pcie_clkreq</description>
+              <name>u1_pcie_clkreq</name>
+              <description>u1_pcie_clkreq</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
@@ -16092,26 +16092,26 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_k_phyparam_839_832</name>
-              <description>u1_plda_pcie_k_phyparam_839_832</description>
+              <name>u1_pcie_k_phyparam_839_832</name>
+              <description>u1_pcie_k_phyparam_839_832</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_k_rp_nep</name>
-              <description>u1_plda_pcie_k_rp_nep</description>
+              <name>u1_pcie_k_rp_nep</name>
+              <description>u1_pcie_k_rp_nep</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_l1sub_entack</name>
-              <description>u1_plda_pcie_l1sub_entack</description>
+              <name>u1_pcie_l1sub_entack</name>
+              <description>u1_pcie_l1sub_entack</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_l1sub_entreq</name>
-              <description>u1_plda_pcie_l1sub_entreq</description>
+              <name>u1_pcie_l1sub_entreq</name>
+              <description>u1_pcie_l1sub_entreq</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
@@ -16125,8 +16125,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_local_interrupt_in</name>
-              <description>u1_plda_pcie_local_interrupt_in</description>
+              <name>u1_pcie_local_interrupt_in</name>
+              <description>u1_pcie_local_interrupt_in</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16140,38 +16140,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_mperstn</name>
-              <description>u1_plda_pcie_mperstn</description>
+              <name>u1_pcie_mperstn</name>
+              <description>u1_pcie_mperstn</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_ebuf_mode</name>
-              <description>u1_plda_pcie_pcie_ebuf_mode</description>
+              <name>u1_pcie_pcie_ebuf_mode</name>
+              <description>u1_pcie_pcie_ebuf_mode</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_phy_test_cfg</name>
-              <description>u1_plda_pcie_pcie_phy_test_cfg</description>
+              <name>u1_pcie_pcie_phy_test_cfg</name>
+              <description>u1_pcie_pcie_phy_test_cfg</description>
               <bitRange>[24:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_rx_eq_training</name>
-              <description>u1_plda_pcie_pcie_rx_eq_training</description>
+              <name>u1_pcie_pcie_rx_eq_training</name>
+              <description>u1_pcie_pcie_rx_eq_training</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_rxterm_en</name>
-              <description>u1_plda_pcie_pcie_rxterm_en</description>
+              <name>u1_pcie_pcie_rxterm_en</name>
+              <description>u1_pcie_pcie_rxterm_en</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_tx_oneszeros</name>
-              <description>u1_plda_pcie_pcie_tx_oneszeros</description>
+              <name>u1_pcie_pcie_tx_oneszeros</name>
+              <description>u1_pcie_pcie_tx_oneszeros</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -16185,8 +16185,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf0_offset</name>
-              <description>u1_plda_pcie_pf0_offset</description>
+              <name>u1_pcie_pf0_offset</name>
+              <description>u1_pcie_pf0_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16200,8 +16200,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf1_offset</name>
-              <description>u1_plda_pcie_pf1_offset</description>
+              <name>u1_pcie_pf1_offset</name>
+              <description>u1_pcie_pf1_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16215,8 +16215,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf2_offset</name>
-              <description>u1_plda_pcie_pf2_offset</description>
+              <name>u1_pcie_pf2_offset</name>
+              <description>u1_pcie_pf2_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16230,38 +16230,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf3_offset</name>
-              <description>u1_plda_pcie_pf3_offset</description>
+              <name>u1_pcie_pf3_offset</name>
+              <description>u1_pcie_pf3_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_phy_mode</name>
-              <description>u1_plda_pcie_phy_mode</description>
+              <name>u1_pcie_phy_mode</name>
+              <description>u1_pcie_phy_mode</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_clkrem_allow</name>
-              <description>u1_plda_pcie_pl_clkrem_allow</description>
+              <name>u1_pcie_pl_clkrem_allow</name>
+              <description>u1_pcie_pl_clkrem_allow</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_clkreq_oen</name>
-              <description>u1_plda_pcie_pl_clkreq_oen</description>
+              <name>u1_pcie_pl_clkreq_oen</name>
+              <description>u1_pcie_pl_clkreq_oen</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_equ_phase</name>
-              <description>u1_plda_pcie_pl_equ_phase</description>
+              <name>u1_pcie_pl_equ_phase</name>
+              <description>u1_pcie_pl_equ_phase</description>
               <bitRange>[25:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_ltssm</name>
-              <description>u1_plda_pcie_pl_ltssm</description>
+              <name>u1_pcie_pl_ltssm</name>
+              <description>u1_pcie_pl_ltssm</description>
               <bitRange>[30:26]</bitRange>
               <access>read-only</access>
             </field>
@@ -16275,8 +16275,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_pclk_rate</name>
-              <description>u1_plda_pcie_pl_pclk_rate</description>
+              <name>u1_pcie_pl_pclk_rate</name>
+              <description>u1_pcie_pl_pclk_rate</description>
               <bitRange>[4:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16290,8 +16290,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_in_31_0</name>
-              <description>u1_plda_pcie_pl_sideband_in_31_0</description>
+              <name>u1_pcie_pl_sideband_in_31_0</name>
+              <description>u1_pcie_pl_sideband_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16305,8 +16305,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_in_63_32</name>
-              <description>u1_plda_pcie_pl_sideband_in_63_32</description>
+              <name>u1_pcie_pl_sideband_in_63_32</name>
+              <description>u1_pcie_pl_sideband_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16320,8 +16320,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_out_31_0</name>
-              <description>u1_plda_pcie_pl_sideband_out_31_0</description>
+              <name>u1_pcie_pl_sideband_out_31_0</name>
+              <description>u1_pcie_pl_sideband_out_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16335,8 +16335,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_out_63_32</name>
-              <description>u1_plda_pcie_pl_sideband_out_63_32</description>
+              <name>u1_pcie_pl_sideband_out_63_32</name>
+              <description>u1_pcie_pl_sideband_out_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16350,20 +16350,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_wake_in</name>
-              <description>u1_plda_pcie_pl_wake_in</description>
+              <name>u1_pcie_pl_wake_in</name>
+              <description>u1_pcie_pl_wake_in</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_wake_oen</name>
-              <description>u1_plda_pcie_pl_wake_oen</description>
+              <name>u1_pcie_pl_wake_oen</name>
+              <description>u1_pcie_pl_wake_oen</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_rx_standby_o</name>
-              <description>u1_plda_pcie_rx_standby_o</description>
+              <name>u1_pcie_rx_standby_o</name>
+              <description>u1_pcie_rx_standby_o</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
@@ -16377,8 +16377,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_in_31_0</name>
-              <description>u1_plda_pcie_test_in_31_0</description>
+              <name>u1_pcie_test_in_31_0</name>
+              <description>u1_pcie_test_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16392,8 +16392,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_in_63_32</name>
-              <description>u1_plda_pcie_test_in_63_32</description>
+              <name>u1_pcie_test_in_63_32</name>
+              <description>u1_pcie_test_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16407,8 +16407,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_31_0</name>
-              <description>u1_plda_pcie_test_out_bridge_31_0</description>
+              <name>u1_pcie_test_out_bridge_31_0</name>
+              <description>u1_pcie_test_out_bridge_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16422,8 +16422,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_63_32</name>
-              <description>u1_plda_pcie_test_out_bridge_63_32</description>
+              <name>u1_pcie_test_out_bridge_63_32</name>
+              <description>u1_pcie_test_out_bridge_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16437,8 +16437,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_95_64</name>
-              <description>u1_plda_pcie_test_out_bridge_95_64</description>
+              <name>u1_pcie_test_out_bridge_95_64</name>
+              <description>u1_pcie_test_out_bridge_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16452,8 +16452,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_127_96</name>
-              <description>u1_plda_pcie_test_out_bridge_127_96</description>
+              <name>u1_pcie_test_out_bridge_127_96</name>
+              <description>u1_pcie_test_out_bridge_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16467,8 +16467,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_159_128</name>
-              <description>u1_plda_pcie_test_out_bridge_159_128</description>
+              <name>u1_pcie_test_out_bridge_159_128</name>
+              <description>u1_pcie_test_out_bridge_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16482,8 +16482,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_191_160</name>
-              <description>u1_plda_pcie_test_out_bridge_191_160</description>
+              <name>u1_pcie_test_out_bridge_191_160</name>
+              <description>u1_pcie_test_out_bridge_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16497,8 +16497,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_223_192</name>
-              <description>u1_plda_pcie_test_out_bridge_223_192</description>
+              <name>u1_pcie_test_out_bridge_223_192</name>
+              <description>u1_pcie_test_out_bridge_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16512,8 +16512,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_255_224</name>
-              <description>u1_plda_pcie_test_out_bridge_255_224</description>
+              <name>u1_pcie_test_out_bridge_255_224</name>
+              <description>u1_pcie_test_out_bridge_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16527,8 +16527,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_287_256</name>
-              <description>u1_plda_pcie_test_out_bridge_287_256</description>
+              <name>u1_pcie_test_out_bridge_287_256</name>
+              <description>u1_pcie_test_out_bridge_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16542,8 +16542,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_319_288</name>
-              <description>u1_plda_pcie_test_out_bridge_319_288</description>
+              <name>u1_pcie_test_out_bridge_319_288</name>
+              <description>u1_pcie_test_out_bridge_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16557,8 +16557,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_351_320</name>
-              <description>u1_plda_pcie_test_out_bridge_351_320</description>
+              <name>u1_pcie_test_out_bridge_351_320</name>
+              <description>u1_pcie_test_out_bridge_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16572,8 +16572,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_383_352</name>
-              <description>u1_plda_pcie_test_out_bridge_383_352</description>
+              <name>u1_pcie_test_out_bridge_383_352</name>
+              <description>u1_pcie_test_out_bridge_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16587,8 +16587,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_415_384</name>
-              <description>u1_plda_pcie_test_out_bridge_415_384</description>
+              <name>u1_pcie_test_out_bridge_415_384</name>
+              <description>u1_pcie_test_out_bridge_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16602,8 +16602,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_447_416</name>
-              <description>u1_plda_pcie_test_out_bridge_447_416</description>
+              <name>u1_pcie_test_out_bridge_447_416</name>
+              <description>u1_pcie_test_out_bridge_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16617,8 +16617,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_479_448</name>
-              <description>u1_plda_pcie_test_out_bridge_479_448</description>
+              <name>u1_pcie_test_out_bridge_479_448</name>
+              <description>u1_pcie_test_out_bridge_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16632,8 +16632,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_511_480</name>
-              <description>u1_plda_pcie_test_out_bridge_511_480</description>
+              <name>u1_pcie_test_out_bridge_511_480</name>
+              <description>u1_pcie_test_out_bridge_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16647,8 +16647,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_31_0</name>
-              <description>u1_plda_pcie_test_out_pcie_31_0</description>
+              <name>u1_pcie_test_out_pcie_31_0</name>
+              <description>u1_pcie_test_out_pcie_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16662,8 +16662,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_63_32</name>
-              <description>u1_plda_pcie_test_out_pcie_63_32</description>
+              <name>u1_pcie_test_out_pcie_63_32</name>
+              <description>u1_pcie_test_out_pcie_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16677,8 +16677,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_95_64</name>
-              <description>u1_plda_pcie_test_out_pcie_95_64</description>
+              <name>u1_pcie_test_out_pcie_95_64</name>
+              <description>u1_pcie_test_out_pcie_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16692,8 +16692,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_127_96</name>
-              <description>u1_plda_pcie_test_out_pcie_127_96</description>
+              <name>u1_pcie_test_out_pcie_127_96</name>
+              <description>u1_pcie_test_out_pcie_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16707,8 +16707,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_159_128</name>
-              <description>u1_plda_pcie_test_out_pcie_159_128</description>
+              <name>u1_pcie_test_out_pcie_159_128</name>
+              <description>u1_pcie_test_out_pcie_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16722,8 +16722,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_191_160</name>
-              <description>u1_plda_pcie_test_out_pcie_191_160</description>
+              <name>u1_pcie_test_out_pcie_191_160</name>
+              <description>u1_pcie_test_out_pcie_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16737,8 +16737,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_223_192</name>
-              <description>u1_plda_pcie_test_out_pcie_223_192</description>
+              <name>u1_pcie_test_out_pcie_223_192</name>
+              <description>u1_pcie_test_out_pcie_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16752,8 +16752,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_255_224</name>
-              <description>u1_plda_pcie_test_out_pcie_255_224</description>
+              <name>u1_pcie_test_out_pcie_255_224</name>
+              <description>u1_pcie_test_out_pcie_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16767,8 +16767,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_287_256</name>
-              <description>u1_plda_pcie_test_out_pcie_287_256</description>
+              <name>u1_pcie_test_out_pcie_287_256</name>
+              <description>u1_pcie_test_out_pcie_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16782,8 +16782,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_319_288</name>
-              <description>u1_plda_pcie_test_out_pcie_319_288</description>
+              <name>u1_pcie_test_out_pcie_319_288</name>
+              <description>u1_pcie_test_out_pcie_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16797,8 +16797,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_351_320</name>
-              <description>u1_plda_pcie_test_out_pcie_351_320</description>
+              <name>u1_pcie_test_out_pcie_351_320</name>
+              <description>u1_pcie_test_out_pcie_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16812,8 +16812,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_383_352</name>
-              <description>u1_plda_pcie_test_out_pcie_383_352</description>
+              <name>u1_pcie_test_out_pcie_383_352</name>
+              <description>u1_pcie_test_out_pcie_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16827,8 +16827,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_415_384</name>
-              <description>u1_plda_pcie_test_out_pcie_415_384</description>
+              <name>u1_pcie_test_out_pcie_415_384</name>
+              <description>u1_pcie_test_out_pcie_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16842,8 +16842,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_447_416</name>
-              <description>u1_plda_pcie_test_out_pcie_447_416</description>
+              <name>u1_pcie_test_out_pcie_447_416</name>
+              <description>u1_pcie_test_out_pcie_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16857,8 +16857,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_479_448</name>
-              <description>u1_plda_pcie_test_out_pcie_479_448</description>
+              <name>u1_pcie_test_out_pcie_479_448</name>
+              <description>u1_pcie_test_out_pcie_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16872,8 +16872,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_511_480</name>
-              <description>u1_plda_pcie_test_out_pcie_511_480</description>
+              <name>u1_pcie_test_out_pcie_511_480</name>
+              <description>u1_pcie_test_out_pcie_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16887,14 +16887,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_sel</name>
-              <description>u1_plda_pcie_test_sel</description>
+              <name>u1_pcie_test_sel</name>
+              <description>u1_pcie_test_sel</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_tl_clock_freq</name>
-              <description>u1_plda_pcie_tl_clock_freq</description>
+              <name>u1_pcie_tl_clock_freq</name>
+              <description>u1_pcie_tl_clock_freq</description>
               <bitRange>[25:4]</bitRange>
               <access>read-write</access>
             </field>
@@ -16908,14 +16908,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_tl_ctrl_hotplug</name>
-              <description>u1_plda_pcie_tl_ctrl_hotplug</description>
+              <name>u1_pcie_tl_ctrl_hotplug</name>
+              <description>u1_pcie_tl_ctrl_hotplug</description>
               <bitRange>[15:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_tl_report_hotplug</name>
-              <description>u1_plda_pcie_tl_report_hotplug</description>
+              <name>u1_pcie_tl_report_hotplug</name>
+              <description>u1_pcie_tl_report_hotplug</description>
               <bitRange>[31:16]</bitRange>
               <access>read-write</access>
             </field>
@@ -16929,50 +16929,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_tx_pattern</name>
-              <description>u1_plda_pcie_tx_pattern</description>
+              <name>u1_pcie_tx_pattern</name>
+              <description>u1_pcie_tx_pattern</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_bus_width</name>
-              <description>u1_plda_pcie_usb3_bus_width</description>
+              <name>u1_pcie_usb3_bus_width</name>
+              <description>u1_pcie_usb3_bus_width</description>
               <bitRange>[3:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_phy_enable</name>
-              <description>u1_plda_pcie_usb3_phy_enable</description>
+              <name>u1_pcie_usb3_phy_enable</name>
+              <description>u1_pcie_usb3_phy_enable</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_rate</name>
-              <description>u1_plda_pcie_usb3_rate</description>
+              <name>u1_pcie_usb3_rate</name>
+              <description>u1_pcie_usb3_rate</description>
               <bitRange>[6:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_rx_standby</name>
-              <description>u1_plda_pcie_usb3_rx_standby</description>
+              <name>u1_pcie_usb3_rx_standby</name>
+              <description>u1_pcie_usb3_rx_standby</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwdecerr</name>
-              <description>u1_plda_pcie_xwdecerr</description>
+              <name>u1_pcie_xwdecerr</name>
+              <description>u1_pcie_xwdecerr</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwerrclr</name>
-              <description>u1_plda_pcie_xwerrclr</description>
+              <name>u1_pcie_xwerrclr</name>
+              <description>u1_pcie_xwerrclr</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwslverr</name>
-              <description>u1_plda_pcie_xwslverr</description>
+              <name>u1_pcie_xwslverr</name>
+              <description>u1_pcie_xwslverr</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_0.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_0.rs
@@ -10,68 +10,68 @@ pub type SCFG_HPROT_SD_0_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 pub type SCFG_HPROT_SD_1_R = crate::FieldReader;
 #[doc = "Field `scfg_hprot_sd_1` writer - scfg_hprot_sd_1"]
 pub type SCFG_HPROT_SD_1_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u0_cdn_usb_adp_en` reader - u0_cdn_usb_adp_en"]
-pub type U0_CDN_USB_ADP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_probe_ana` reader - u0_cdn_usb_adp_probe_ana"]
-pub type U0_CDN_USB_ADP_PROBE_ANA_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_probe_ana` writer - u0_cdn_usb_adp_probe_ana"]
-pub type U0_CDN_USB_ADP_PROBE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_adp_probe_en` reader - u0_cdn_usb_adp_probe_en"]
-pub type U0_CDN_USB_ADP_PROBE_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sense_ana` reader - u0_cdn_usb_adp_sense_ana"]
-pub type U0_CDN_USB_ADP_SENSE_ANA_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sense_ana` writer - u0_cdn_usb_adp_sense_ana"]
-pub type U0_CDN_USB_ADP_SENSE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_adp_sense_en` reader - u0_cdn_usb_adp_sense_en"]
-pub type U0_CDN_USB_ADP_SENSE_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sink_current_en` reader - u0_cdn_usb_adp_sink_current_en"]
-pub type U0_CDN_USB_ADP_SINK_CURRENT_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_source_current_en` reader - u0_cdn_usb_adp_source_current_en"]
-pub type U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_bc_en` reader - u0_cdn_usb_bc_en"]
-pub type U0_CDN_USB_BC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_chrg_vbus` reader - u0_cdn_usb_chrg_vbus"]
-pub type U0_CDN_USB_CHRG_VBUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_chrg_vbus` writer - u0_cdn_usb_chrg_vbus"]
-pub type U0_CDN_USB_CHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dcd_comp_sts` reader - u0_cdn_usb_dcd_comp_sts"]
-pub type U0_CDN_USB_DCD_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dcd_comp_sts` writer - u0_cdn_usb_dcd_comp_sts"]
-pub type U0_CDN_USB_DCD_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dischrg_vbus` reader - u0_cdn_usb_dischrg_vbus"]
-pub type U0_CDN_USB_DISCHRG_VBUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dischrg_vbus` writer - u0_cdn_usb_dischrg_vbus"]
-pub type U0_CDN_USB_DISCHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_en` reader - u0_cdn_usb_dm_vdat_ref_comp_en"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_sts` reader - u0_cdn_usb_dm_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_sts` writer - u0_cdn_usb_dm_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_en` reader - u0_cdn_usb_dm_vlgc_comp_en"]
-pub type U0_CDN_USB_DM_VLGC_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_sts` reader - u0_cdn_usb_dm_vlgc_comp_sts"]
-pub type U0_CDN_USB_DM_VLGC_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_sts` writer - u0_cdn_usb_dm_vlgc_comp_sts"]
-pub type U0_CDN_USB_DM_VLGC_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_en` reader - u0_cdn_usb_dp_vdat_ref_comp_en"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_sts` reader - u0_cdn_usb_dp_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_sts` writer - u0_cdn_usb_dp_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_host_system_err` reader - u0_cdn_usb_host_system_err"]
-pub type U0_CDN_USB_HOST_SYSTEM_ERR_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_host_system_err` writer - u0_cdn_usb_host_system_err"]
-pub type U0_CDN_USB_HOST_SYSTEM_ERR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_hsystem_err_ext` reader - u0_cdn_usb_hsystem_err_ext"]
-pub type U0_CDN_USB_HSYSTEM_ERR_EXT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idm_sink_en` reader - u0_cdn_usb_idm_sink_en"]
-pub type U0_CDN_USB_IDM_SINK_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idp_sink_en` reader - u0_cdn_usb_idp_sink_en"]
-pub type U0_CDN_USB_IDP_SINK_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idp_src_en` reader - u0_cdn_usb_idp_src_en"]
-pub type U0_CDN_USB_IDP_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_en` reader - u0_usb_adp_en"]
+pub type U0_USB_ADP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_probe_ana` reader - u0_usb_adp_probe_ana"]
+pub type U0_USB_ADP_PROBE_ANA_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_probe_ana` writer - u0_usb_adp_probe_ana"]
+pub type U0_USB_ADP_PROBE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_adp_probe_en` reader - u0_usb_adp_probe_en"]
+pub type U0_USB_ADP_PROBE_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sense_ana` reader - u0_usb_adp_sense_ana"]
+pub type U0_USB_ADP_SENSE_ANA_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sense_ana` writer - u0_usb_adp_sense_ana"]
+pub type U0_USB_ADP_SENSE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_adp_sense_en` reader - u0_usb_adp_sense_en"]
+pub type U0_USB_ADP_SENSE_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sink_current_en` reader - u0_usb_adp_sink_current_en"]
+pub type U0_USB_ADP_SINK_CURRENT_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_source_current_en` reader - u0_usb_adp_source_current_en"]
+pub type U0_USB_ADP_SOURCE_CURRENT_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_bc_en` reader - u0_usb_bc_en"]
+pub type U0_USB_BC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_chrg_vbus` reader - u0_usb_chrg_vbus"]
+pub type U0_USB_CHRG_VBUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_chrg_vbus` writer - u0_usb_chrg_vbus"]
+pub type U0_USB_CHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dcd_comp_sts` reader - u0_usb_dcd_comp_sts"]
+pub type U0_USB_DCD_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dcd_comp_sts` writer - u0_usb_dcd_comp_sts"]
+pub type U0_USB_DCD_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dischrg_vbus` reader - u0_usb_dischrg_vbus"]
+pub type U0_USB_DISCHRG_VBUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dischrg_vbus` writer - u0_usb_dischrg_vbus"]
+pub type U0_USB_DISCHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_en` reader - u0_usb_dm_vdat_ref_comp_en"]
+pub type U0_USB_DM_VDAT_REF_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_sts` reader - u0_usb_dm_vdat_ref_comp_sts"]
+pub type U0_USB_DM_VDAT_REF_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_sts` writer - u0_usb_dm_vdat_ref_comp_sts"]
+pub type U0_USB_DM_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dm_vlgc_comp_en` reader - u0_usb_dm_vlgc_comp_en"]
+pub type U0_USB_DM_VLGC_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vlgc_comp_sts` reader - u0_usb_dm_vlgc_comp_sts"]
+pub type U0_USB_DM_VLGC_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vlgc_comp_sts` writer - u0_usb_dm_vlgc_comp_sts"]
+pub type U0_USB_DM_VLGC_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_en` reader - u0_usb_dp_vdat_ref_comp_en"]
+pub type U0_USB_DP_VDAT_REF_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_sts` reader - u0_usb_dp_vdat_ref_comp_sts"]
+pub type U0_USB_DP_VDAT_REF_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_sts` writer - u0_usb_dp_vdat_ref_comp_sts"]
+pub type U0_USB_DP_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_host_system_err` reader - u0_usb_host_system_err"]
+pub type U0_USB_HOST_SYSTEM_ERR_R = crate::BitReader;
+#[doc = "Field `u0_usb_host_system_err` writer - u0_usb_host_system_err"]
+pub type U0_USB_HOST_SYSTEM_ERR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_hsystem_err_ext` reader - u0_usb_hsystem_err_ext"]
+pub type U0_USB_HSYSTEM_ERR_EXT_R = crate::BitReader;
+#[doc = "Field `u0_usb_idm_sink_en` reader - u0_usb_idm_sink_en"]
+pub type U0_USB_IDM_SINK_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_idp_sink_en` reader - u0_usb_idp_sink_en"]
+pub type U0_USB_IDP_SINK_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_idp_src_en` reader - u0_usb_idp_src_en"]
+pub type U0_USB_IDP_SRC_EN_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:3 - scfg_hprot_sd_0"]
     #[inline(always)]
@@ -83,115 +83,115 @@ impl R {
     pub fn scfg_hprot_sd_1(&self) -> SCFG_HPROT_SD_1_R {
         SCFG_HPROT_SD_1_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_adp_en"]
+    #[doc = "Bit 8 - u0_usb_adp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_en(&self) -> U0_CDN_USB_ADP_EN_R {
-        U0_CDN_USB_ADP_EN_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_adp_en(&self) -> U0_USB_ADP_EN_R {
+        U0_USB_ADP_EN_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_adp_probe_ana"]
+    #[doc = "Bit 9 - u0_usb_adp_probe_ana"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_probe_ana(&self) -> U0_CDN_USB_ADP_PROBE_ANA_R {
-        U0_CDN_USB_ADP_PROBE_ANA_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_adp_probe_ana(&self) -> U0_USB_ADP_PROBE_ANA_R {
+        U0_USB_ADP_PROBE_ANA_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_adp_probe_en"]
+    #[doc = "Bit 10 - u0_usb_adp_probe_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_probe_en(&self) -> U0_CDN_USB_ADP_PROBE_EN_R {
-        U0_CDN_USB_ADP_PROBE_EN_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_adp_probe_en(&self) -> U0_USB_ADP_PROBE_EN_R {
+        U0_USB_ADP_PROBE_EN_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_adp_sense_ana"]
+    #[doc = "Bit 11 - u0_usb_adp_sense_ana"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sense_ana(&self) -> U0_CDN_USB_ADP_SENSE_ANA_R {
-        U0_CDN_USB_ADP_SENSE_ANA_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_adp_sense_ana(&self) -> U0_USB_ADP_SENSE_ANA_R {
+        U0_USB_ADP_SENSE_ANA_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_adp_sense_en"]
+    #[doc = "Bit 12 - u0_usb_adp_sense_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sense_en(&self) -> U0_CDN_USB_ADP_SENSE_EN_R {
-        U0_CDN_USB_ADP_SENSE_EN_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_adp_sense_en(&self) -> U0_USB_ADP_SENSE_EN_R {
+        U0_USB_ADP_SENSE_EN_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_adp_sink_current_en"]
+    #[doc = "Bit 13 - u0_usb_adp_sink_current_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sink_current_en(&self) -> U0_CDN_USB_ADP_SINK_CURRENT_EN_R {
-        U0_CDN_USB_ADP_SINK_CURRENT_EN_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_adp_sink_current_en(&self) -> U0_USB_ADP_SINK_CURRENT_EN_R {
+        U0_USB_ADP_SINK_CURRENT_EN_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_adp_source_current_en"]
+    #[doc = "Bit 14 - u0_usb_adp_source_current_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_source_current_en(&self) -> U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R {
-        U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_adp_source_current_en(&self) -> U0_USB_ADP_SOURCE_CURRENT_EN_R {
+        U0_USB_ADP_SOURCE_CURRENT_EN_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_bc_en"]
+    #[doc = "Bit 15 - u0_usb_bc_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_bc_en(&self) -> U0_CDN_USB_BC_EN_R {
-        U0_CDN_USB_BC_EN_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_bc_en(&self) -> U0_USB_BC_EN_R {
+        U0_USB_BC_EN_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_chrg_vbus"]
+    #[doc = "Bit 16 - u0_usb_chrg_vbus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_chrg_vbus(&self) -> U0_CDN_USB_CHRG_VBUS_R {
-        U0_CDN_USB_CHRG_VBUS_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_chrg_vbus(&self) -> U0_USB_CHRG_VBUS_R {
+        U0_USB_CHRG_VBUS_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_dcd_comp_sts"]
+    #[doc = "Bit 17 - u0_usb_dcd_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dcd_comp_sts(&self) -> U0_CDN_USB_DCD_COMP_STS_R {
-        U0_CDN_USB_DCD_COMP_STS_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_dcd_comp_sts(&self) -> U0_USB_DCD_COMP_STS_R {
+        U0_USB_DCD_COMP_STS_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_dischrg_vbus"]
+    #[doc = "Bit 18 - u0_usb_dischrg_vbus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dischrg_vbus(&self) -> U0_CDN_USB_DISCHRG_VBUS_R {
-        U0_CDN_USB_DISCHRG_VBUS_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_usb_dischrg_vbus(&self) -> U0_USB_DISCHRG_VBUS_R {
+        U0_USB_DISCHRG_VBUS_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_dm_vdat_ref_comp_en"]
+    #[doc = "Bit 19 - u0_usb_dm_vdat_ref_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_en(&self) -> U0_CDN_USB_DM_VDAT_REF_COMP_EN_R {
-        U0_CDN_USB_DM_VDAT_REF_COMP_EN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_dm_vdat_ref_comp_en(&self) -> U0_USB_DM_VDAT_REF_COMP_EN_R {
+        U0_USB_DM_VDAT_REF_COMP_EN_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_dm_vdat_ref_comp_sts"]
+    #[doc = "Bit 20 - u0_usb_dm_vdat_ref_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_sts(&self) -> U0_CDN_USB_DM_VDAT_REF_COMP_STS_R {
-        U0_CDN_USB_DM_VDAT_REF_COMP_STS_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_dm_vdat_ref_comp_sts(&self) -> U0_USB_DM_VDAT_REF_COMP_STS_R {
+        U0_USB_DM_VDAT_REF_COMP_STS_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_dm_vlgc_comp_en"]
+    #[doc = "Bit 21 - u0_usb_dm_vlgc_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vlgc_comp_en(&self) -> U0_CDN_USB_DM_VLGC_COMP_EN_R {
-        U0_CDN_USB_DM_VLGC_COMP_EN_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_dm_vlgc_comp_en(&self) -> U0_USB_DM_VLGC_COMP_EN_R {
+        U0_USB_DM_VLGC_COMP_EN_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_dm_vlgc_comp_sts"]
+    #[doc = "Bit 22 - u0_usb_dm_vlgc_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vlgc_comp_sts(&self) -> U0_CDN_USB_DM_VLGC_COMP_STS_R {
-        U0_CDN_USB_DM_VLGC_COMP_STS_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_dm_vlgc_comp_sts(&self) -> U0_USB_DM_VLGC_COMP_STS_R {
+        U0_USB_DM_VLGC_COMP_STS_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_dp_vdat_ref_comp_en"]
+    #[doc = "Bit 23 - u0_usb_dp_vdat_ref_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_en(&self) -> U0_CDN_USB_DP_VDAT_REF_COMP_EN_R {
-        U0_CDN_USB_DP_VDAT_REF_COMP_EN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_dp_vdat_ref_comp_en(&self) -> U0_USB_DP_VDAT_REF_COMP_EN_R {
+        U0_USB_DP_VDAT_REF_COMP_EN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_dp_vdat_ref_comp_sts"]
+    #[doc = "Bit 24 - u0_usb_dp_vdat_ref_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_sts(&self) -> U0_CDN_USB_DP_VDAT_REF_COMP_STS_R {
-        U0_CDN_USB_DP_VDAT_REF_COMP_STS_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_usb_dp_vdat_ref_comp_sts(&self) -> U0_USB_DP_VDAT_REF_COMP_STS_R {
+        U0_USB_DP_VDAT_REF_COMP_STS_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bit 25 - u0_cdn_usb_host_system_err"]
+    #[doc = "Bit 25 - u0_usb_host_system_err"]
     #[inline(always)]
-    pub fn u0_cdn_usb_host_system_err(&self) -> U0_CDN_USB_HOST_SYSTEM_ERR_R {
-        U0_CDN_USB_HOST_SYSTEM_ERR_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_usb_host_system_err(&self) -> U0_USB_HOST_SYSTEM_ERR_R {
+        U0_USB_HOST_SYSTEM_ERR_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u0_cdn_usb_hsystem_err_ext"]
+    #[doc = "Bit 26 - u0_usb_hsystem_err_ext"]
     #[inline(always)]
-    pub fn u0_cdn_usb_hsystem_err_ext(&self) -> U0_CDN_USB_HSYSTEM_ERR_EXT_R {
-        U0_CDN_USB_HSYSTEM_ERR_EXT_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_usb_hsystem_err_ext(&self) -> U0_USB_HSYSTEM_ERR_EXT_R {
+        U0_USB_HSYSTEM_ERR_EXT_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_cdn_usb_idm_sink_en"]
+    #[doc = "Bit 27 - u0_usb_idm_sink_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idm_sink_en(&self) -> U0_CDN_USB_IDM_SINK_EN_R {
-        U0_CDN_USB_IDM_SINK_EN_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_usb_idm_sink_en(&self) -> U0_USB_IDM_SINK_EN_R {
+        U0_USB_IDM_SINK_EN_R::new(((self.bits >> 27) & 1) != 0)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_idp_sink_en"]
+    #[doc = "Bit 28 - u0_usb_idp_sink_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idp_sink_en(&self) -> U0_CDN_USB_IDP_SINK_EN_R {
-        U0_CDN_USB_IDP_SINK_EN_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_usb_idp_sink_en(&self) -> U0_USB_IDP_SINK_EN_R {
+        U0_USB_IDP_SINK_EN_R::new(((self.bits >> 28) & 1) != 0)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_idp_src_en"]
+    #[doc = "Bit 29 - u0_usb_idp_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idp_src_en(&self) -> U0_CDN_USB_IDP_SRC_EN_R {
-        U0_CDN_USB_IDP_SRC_EN_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_idp_src_en(&self) -> U0_USB_IDP_SRC_EN_R {
+        U0_USB_IDP_SRC_EN_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
@@ -207,67 +207,63 @@ impl W {
     pub fn scfg_hprot_sd_1(&mut self) -> SCFG_HPROT_SD_1_W<STG_SYSCFG_0_SPEC> {
         SCFG_HPROT_SD_1_W::new(self, 4)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_adp_probe_ana"]
+    #[doc = "Bit 9 - u0_usb_adp_probe_ana"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_adp_probe_ana(&mut self) -> U0_CDN_USB_ADP_PROBE_ANA_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_ADP_PROBE_ANA_W::new(self, 9)
+    pub fn u0_usb_adp_probe_ana(&mut self) -> U0_USB_ADP_PROBE_ANA_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_ADP_PROBE_ANA_W::new(self, 9)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_adp_sense_ana"]
+    #[doc = "Bit 11 - u0_usb_adp_sense_ana"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_adp_sense_ana(&mut self) -> U0_CDN_USB_ADP_SENSE_ANA_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_ADP_SENSE_ANA_W::new(self, 11)
+    pub fn u0_usb_adp_sense_ana(&mut self) -> U0_USB_ADP_SENSE_ANA_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_ADP_SENSE_ANA_W::new(self, 11)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_chrg_vbus"]
+    #[doc = "Bit 16 - u0_usb_chrg_vbus"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_chrg_vbus(&mut self) -> U0_CDN_USB_CHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_CHRG_VBUS_W::new(self, 16)
+    pub fn u0_usb_chrg_vbus(&mut self) -> U0_USB_CHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_CHRG_VBUS_W::new(self, 16)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_dcd_comp_sts"]
+    #[doc = "Bit 17 - u0_usb_dcd_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dcd_comp_sts(&mut self) -> U0_CDN_USB_DCD_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DCD_COMP_STS_W::new(self, 17)
+    pub fn u0_usb_dcd_comp_sts(&mut self) -> U0_USB_DCD_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DCD_COMP_STS_W::new(self, 17)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_dischrg_vbus"]
+    #[doc = "Bit 18 - u0_usb_dischrg_vbus"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dischrg_vbus(&mut self) -> U0_CDN_USB_DISCHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DISCHRG_VBUS_W::new(self, 18)
+    pub fn u0_usb_dischrg_vbus(&mut self) -> U0_USB_DISCHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DISCHRG_VBUS_W::new(self, 18)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_dm_vdat_ref_comp_sts"]
+    #[doc = "Bit 20 - u0_usb_dm_vdat_ref_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_sts(
+    pub fn u0_usb_dm_vdat_ref_comp_sts(
         &mut self,
-    ) -> U0_CDN_USB_DM_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DM_VDAT_REF_COMP_STS_W::new(self, 20)
+    ) -> U0_USB_DM_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DM_VDAT_REF_COMP_STS_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_dm_vlgc_comp_sts"]
+    #[doc = "Bit 22 - u0_usb_dm_vlgc_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dm_vlgc_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_DM_VLGC_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DM_VLGC_COMP_STS_W::new(self, 22)
+    pub fn u0_usb_dm_vlgc_comp_sts(&mut self) -> U0_USB_DM_VLGC_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DM_VLGC_COMP_STS_W::new(self, 22)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_dp_vdat_ref_comp_sts"]
+    #[doc = "Bit 24 - u0_usb_dp_vdat_ref_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_sts(
+    pub fn u0_usb_dp_vdat_ref_comp_sts(
         &mut self,
-    ) -> U0_CDN_USB_DP_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DP_VDAT_REF_COMP_STS_W::new(self, 24)
+    ) -> U0_USB_DP_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DP_VDAT_REF_COMP_STS_W::new(self, 24)
     }
-    #[doc = "Bit 25 - u0_cdn_usb_host_system_err"]
+    #[doc = "Bit 25 - u0_usb_host_system_err"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_host_system_err(
-        &mut self,
-    ) -> U0_CDN_USB_HOST_SYSTEM_ERR_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_HOST_SYSTEM_ERR_W::new(self, 25)
+    pub fn u0_usb_host_system_err(&mut self) -> U0_USB_HOST_SYSTEM_ERR_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_HOST_SYSTEM_ERR_W::new(self, 25)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_1.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_1.rs
@@ -2,42 +2,42 @@
 pub type R = crate::R<STG_SYSCFG_1_SPEC>;
 #[doc = "Register `stg_syscfg_1` writer"]
 pub type W = crate::W<STG_SYSCFG_1_SPEC>;
-#[doc = "Field `u0_cdn_usb_lowest_belt` reader - LTM interface to software"]
-pub type U0_CDN_USB_LOWEST_BELT_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_cdn_usb_ltm_host_req` reader - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_ltm_host_req_halt` reader - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_HALT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_ltm_host_req_halt` writer - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_HALT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_sel` reader - u0_cdn_usb_mdctrl_clk_sel"]
-pub type U0_CDN_USB_MDCTRL_CLK_SEL_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_sel` writer - u0_cdn_usb_mdctrl_clk_sel"]
-pub type U0_CDN_USB_MDCTRL_CLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_status` reader - u0_cdn_usb_mdctrl_clk_status"]
-pub type U0_CDN_USB_MDCTRL_CLK_STATUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_mode_strap` reader - Can onlly be changed when pwrup_rst_n is low"]
-pub type U0_CDN_USB_MODE_STRAP_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_mode_strap` writer - Can onlly be changed when pwrup_rst_n is low"]
-pub type U0_CDN_USB_MODE_STRAP_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `u0_cdn_usb_otg_suspendm` reader - u0_cdn_usb_otg_suspendm"]
-pub type U0_CDN_USB_OTG_SUSPENDM_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_otg_suspendm` writer - u0_cdn_usb_otg_suspendm"]
-pub type U0_CDN_USB_OTG_SUSPENDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_otg_suspendm_byps` reader - u0_cdn_usb_otg_suspendm_byps"]
-pub type U0_CDN_USB_OTG_SUSPENDM_BYPS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_otg_suspendm_byps` writer - u0_cdn_usb_otg_suspendm_byps"]
-pub type U0_CDN_USB_OTG_SUSPENDM_BYPS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_phy_bvalid` reader - u0_cdn_usb_phy_bvalid"]
-pub type U0_CDN_USB_PHY_BVALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_pll_en` reader - u0_cdn_usb_pll_en"]
-pub type U0_CDN_USB_PLL_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_pll_en` writer - u0_cdn_usb_pll_en"]
-pub type U0_CDN_USB_PLL_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_refclk_mode` reader - u0_cdn_usb_refclk_mode"]
-pub type U0_CDN_USB_REFCLK_MODE_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_refclk_mode` writer - u0_cdn_usb_refclk_mode"]
-pub type U0_CDN_USB_REFCLK_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_lowest_belt` reader - LTM interface to software"]
+pub type U0_USB_LOWEST_BELT_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_usb_ltm_host_req` reader - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_ltm_host_req_halt` reader - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_HALT_R = crate::BitReader;
+#[doc = "Field `u0_usb_ltm_host_req_halt` writer - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_HALT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_mdctrl_clk_sel` reader - u0_usb_mdctrl_clk_sel"]
+pub type U0_USB_MDCTRL_CLK_SEL_R = crate::BitReader;
+#[doc = "Field `u0_usb_mdctrl_clk_sel` writer - u0_usb_mdctrl_clk_sel"]
+pub type U0_USB_MDCTRL_CLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_mdctrl_clk_status` reader - u0_usb_mdctrl_clk_status"]
+pub type U0_USB_MDCTRL_CLK_STATUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_mode_strap` reader - Can onlly be changed when pwrup_rst_n is low"]
+pub type U0_USB_MODE_STRAP_R = crate::FieldReader;
+#[doc = "Field `u0_usb_mode_strap` writer - Can onlly be changed when pwrup_rst_n is low"]
+pub type U0_USB_MODE_STRAP_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `u0_usb_otg_suspendm` reader - u0_usb_otg_suspendm"]
+pub type U0_USB_OTG_SUSPENDM_R = crate::BitReader;
+#[doc = "Field `u0_usb_otg_suspendm` writer - u0_usb_otg_suspendm"]
+pub type U0_USB_OTG_SUSPENDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_otg_suspendm_byps` reader - u0_usb_otg_suspendm_byps"]
+pub type U0_USB_OTG_SUSPENDM_BYPS_R = crate::BitReader;
+#[doc = "Field `u0_usb_otg_suspendm_byps` writer - u0_usb_otg_suspendm_byps"]
+pub type U0_USB_OTG_SUSPENDM_BYPS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_phy_bvalid` reader - u0_usb_phy_bvalid"]
+pub type U0_USB_PHY_BVALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_pll_en` reader - u0_usb_pll_en"]
+pub type U0_USB_PLL_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_pll_en` writer - u0_usb_pll_en"]
+pub type U0_USB_PLL_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_refclk_mode` reader - u0_usb_refclk_mode"]
+pub type U0_USB_REFCLK_MODE_R = crate::BitReader;
+#[doc = "Field `u0_usb_refclk_mode` writer - u0_usb_refclk_mode"]
+pub type U0_USB_REFCLK_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_0` reader - u0_cdn_usb_rid_comp_sts_0"]
 pub type U0_CDN_USB_RID_COMP_STS_0_R = crate::BitReader;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_0` writer - u0_cdn_usb_rid_comp_sts_0"]
@@ -50,75 +50,75 @@ pub type U0_CDN_USB_RID_COMP_STS_1_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_CDN_USB_RID_COMP_STS_2_R = crate::BitReader;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_2` writer - u0_cdn_usb_rid_comp_sts_2"]
 pub type U0_CDN_USB_RID_COMP_STS_2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_en` reader - u0_cdn_usb_rid_float_comp_en"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_sts` reader - u0_cdn_usb_rid_float_comp_sts"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_sts` writer - u0_cdn_usb_rid_float_comp_sts"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_gnd_comp_sts` reader - u0_cdn_usb_rid_gnd_comp_sts"]
-pub type U0_CDN_USB_RID_GND_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_gnd_comp_sts` writer - u0_cdn_usb_rid_gnd_comp_sts"]
-pub type U0_CDN_USB_RID_GND_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_nonfloat_comp_en` reader - u0_cdn_usb_rid_nonfloat_comp_en"]
-pub type U0_CDN_USB_RID_NONFLOAT_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rx_dm` reader - u0_cdn_usb_rx_dm"]
-pub type U0_CDN_USB_RX_DM_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_en` reader - u0_usb_rid_float_comp_en"]
+pub type U0_USB_RID_FLOAT_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_sts` reader - u0_usb_rid_float_comp_sts"]
+pub type U0_USB_RID_FLOAT_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_sts` writer - u0_usb_rid_float_comp_sts"]
+pub type U0_USB_RID_FLOAT_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_rid_gnd_comp_sts` reader - u0_usb_rid_gnd_comp_sts"]
+pub type U0_USB_RID_GND_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_gnd_comp_sts` writer - u0_usb_rid_gnd_comp_sts"]
+pub type U0_USB_RID_GND_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_rid_nonfloat_comp_en` reader - u0_usb_rid_nonfloat_comp_en"]
+pub type U0_USB_RID_NONFLOAT_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_dm` reader - u0_usb_rx_dm"]
+pub type U0_USB_RX_DM_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:11 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_lowest_belt(&self) -> U0_CDN_USB_LOWEST_BELT_R {
-        U0_CDN_USB_LOWEST_BELT_R::new((self.bits & 0x0fff) as u16)
+    pub fn u0_usb_lowest_belt(&self) -> U0_USB_LOWEST_BELT_R {
+        U0_USB_LOWEST_BELT_R::new((self.bits & 0x0fff) as u16)
     }
     #[doc = "Bit 12 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_ltm_host_req(&self) -> U0_CDN_USB_LTM_HOST_REQ_R {
-        U0_CDN_USB_LTM_HOST_REQ_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_ltm_host_req(&self) -> U0_USB_LTM_HOST_REQ_R {
+        U0_USB_LTM_HOST_REQ_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_ltm_host_req_halt(&self) -> U0_CDN_USB_LTM_HOST_REQ_HALT_R {
-        U0_CDN_USB_LTM_HOST_REQ_HALT_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_ltm_host_req_halt(&self) -> U0_USB_LTM_HOST_REQ_HALT_R {
+        U0_USB_LTM_HOST_REQ_HALT_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_mdctrl_clk_sel"]
+    #[doc = "Bit 14 - u0_usb_mdctrl_clk_sel"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mdctrl_clk_sel(&self) -> U0_CDN_USB_MDCTRL_CLK_SEL_R {
-        U0_CDN_USB_MDCTRL_CLK_SEL_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_mdctrl_clk_sel(&self) -> U0_USB_MDCTRL_CLK_SEL_R {
+        U0_USB_MDCTRL_CLK_SEL_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_mdctrl_clk_status"]
+    #[doc = "Bit 15 - u0_usb_mdctrl_clk_status"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mdctrl_clk_status(&self) -> U0_CDN_USB_MDCTRL_CLK_STATUS_R {
-        U0_CDN_USB_MDCTRL_CLK_STATUS_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_mdctrl_clk_status(&self) -> U0_USB_MDCTRL_CLK_STATUS_R {
+        U0_USB_MDCTRL_CLK_STATUS_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bits 16:18 - Can onlly be changed when pwrup_rst_n is low"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mode_strap(&self) -> U0_CDN_USB_MODE_STRAP_R {
-        U0_CDN_USB_MODE_STRAP_R::new(((self.bits >> 16) & 7) as u8)
+    pub fn u0_usb_mode_strap(&self) -> U0_USB_MODE_STRAP_R {
+        U0_USB_MODE_STRAP_R::new(((self.bits >> 16) & 7) as u8)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_otg_suspendm"]
+    #[doc = "Bit 19 - u0_usb_otg_suspendm"]
     #[inline(always)]
-    pub fn u0_cdn_usb_otg_suspendm(&self) -> U0_CDN_USB_OTG_SUSPENDM_R {
-        U0_CDN_USB_OTG_SUSPENDM_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_otg_suspendm(&self) -> U0_USB_OTG_SUSPENDM_R {
+        U0_USB_OTG_SUSPENDM_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_otg_suspendm_byps"]
+    #[doc = "Bit 20 - u0_usb_otg_suspendm_byps"]
     #[inline(always)]
-    pub fn u0_cdn_usb_otg_suspendm_byps(&self) -> U0_CDN_USB_OTG_SUSPENDM_BYPS_R {
-        U0_CDN_USB_OTG_SUSPENDM_BYPS_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_otg_suspendm_byps(&self) -> U0_USB_OTG_SUSPENDM_BYPS_R {
+        U0_USB_OTG_SUSPENDM_BYPS_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_phy_bvalid"]
+    #[doc = "Bit 21 - u0_usb_phy_bvalid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_phy_bvalid(&self) -> U0_CDN_USB_PHY_BVALID_R {
-        U0_CDN_USB_PHY_BVALID_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_phy_bvalid(&self) -> U0_USB_PHY_BVALID_R {
+        U0_USB_PHY_BVALID_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_pll_en"]
+    #[doc = "Bit 22 - u0_usb_pll_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_pll_en(&self) -> U0_CDN_USB_PLL_EN_R {
-        U0_CDN_USB_PLL_EN_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_pll_en(&self) -> U0_USB_PLL_EN_R {
+        U0_USB_PLL_EN_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_refclk_mode"]
+    #[doc = "Bit 23 - u0_usb_refclk_mode"]
     #[inline(always)]
-    pub fn u0_cdn_usb_refclk_mode(&self) -> U0_CDN_USB_REFCLK_MODE_R {
-        U0_CDN_USB_REFCLK_MODE_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_refclk_mode(&self) -> U0_USB_REFCLK_MODE_R {
+        U0_USB_REFCLK_MODE_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - u0_cdn_usb_rid_comp_sts_0"]
     #[inline(always)]
@@ -135,78 +135,74 @@ impl R {
     pub fn u0_cdn_usb_rid_comp_sts_2(&self) -> U0_CDN_USB_RID_COMP_STS_2_R {
         U0_CDN_USB_RID_COMP_STS_2_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_cdn_usb_rid_float_comp_en"]
+    #[doc = "Bit 27 - u0_usb_rid_float_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_float_comp_en(&self) -> U0_CDN_USB_RID_FLOAT_COMP_EN_R {
-        U0_CDN_USB_RID_FLOAT_COMP_EN_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_usb_rid_float_comp_en(&self) -> U0_USB_RID_FLOAT_COMP_EN_R {
+        U0_USB_RID_FLOAT_COMP_EN_R::new(((self.bits >> 27) & 1) != 0)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_rid_float_comp_sts"]
+    #[doc = "Bit 28 - u0_usb_rid_float_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_float_comp_sts(&self) -> U0_CDN_USB_RID_FLOAT_COMP_STS_R {
-        U0_CDN_USB_RID_FLOAT_COMP_STS_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_usb_rid_float_comp_sts(&self) -> U0_USB_RID_FLOAT_COMP_STS_R {
+        U0_USB_RID_FLOAT_COMP_STS_R::new(((self.bits >> 28) & 1) != 0)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_rid_gnd_comp_sts"]
+    #[doc = "Bit 29 - u0_usb_rid_gnd_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_gnd_comp_sts(&self) -> U0_CDN_USB_RID_GND_COMP_STS_R {
-        U0_CDN_USB_RID_GND_COMP_STS_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_rid_gnd_comp_sts(&self) -> U0_USB_RID_GND_COMP_STS_R {
+        U0_USB_RID_GND_COMP_STS_R::new(((self.bits >> 29) & 1) != 0)
     }
-    #[doc = "Bit 30 - u0_cdn_usb_rid_nonfloat_comp_en"]
+    #[doc = "Bit 30 - u0_usb_rid_nonfloat_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_nonfloat_comp_en(&self) -> U0_CDN_USB_RID_NONFLOAT_COMP_EN_R {
-        U0_CDN_USB_RID_NONFLOAT_COMP_EN_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_usb_rid_nonfloat_comp_en(&self) -> U0_USB_RID_NONFLOAT_COMP_EN_R {
+        U0_USB_RID_NONFLOAT_COMP_EN_R::new(((self.bits >> 30) & 1) != 0)
     }
-    #[doc = "Bit 31 - u0_cdn_usb_rx_dm"]
+    #[doc = "Bit 31 - u0_usb_rx_dm"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_dm(&self) -> U0_CDN_USB_RX_DM_R {
-        U0_CDN_USB_RX_DM_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_usb_rx_dm(&self) -> U0_USB_RX_DM_R {
+        U0_USB_RX_DM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 13 - LTM interface to software"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_ltm_host_req_halt(
-        &mut self,
-    ) -> U0_CDN_USB_LTM_HOST_REQ_HALT_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_LTM_HOST_REQ_HALT_W::new(self, 13)
+    pub fn u0_usb_ltm_host_req_halt(&mut self) -> U0_USB_LTM_HOST_REQ_HALT_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_LTM_HOST_REQ_HALT_W::new(self, 13)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_mdctrl_clk_sel"]
+    #[doc = "Bit 14 - u0_usb_mdctrl_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_mdctrl_clk_sel(&mut self) -> U0_CDN_USB_MDCTRL_CLK_SEL_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_MDCTRL_CLK_SEL_W::new(self, 14)
+    pub fn u0_usb_mdctrl_clk_sel(&mut self) -> U0_USB_MDCTRL_CLK_SEL_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_MDCTRL_CLK_SEL_W::new(self, 14)
     }
     #[doc = "Bits 16:18 - Can onlly be changed when pwrup_rst_n is low"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_mode_strap(&mut self) -> U0_CDN_USB_MODE_STRAP_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_MODE_STRAP_W::new(self, 16)
+    pub fn u0_usb_mode_strap(&mut self) -> U0_USB_MODE_STRAP_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_MODE_STRAP_W::new(self, 16)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_otg_suspendm"]
+    #[doc = "Bit 19 - u0_usb_otg_suspendm"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_otg_suspendm(&mut self) -> U0_CDN_USB_OTG_SUSPENDM_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_OTG_SUSPENDM_W::new(self, 19)
+    pub fn u0_usb_otg_suspendm(&mut self) -> U0_USB_OTG_SUSPENDM_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_OTG_SUSPENDM_W::new(self, 19)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_otg_suspendm_byps"]
+    #[doc = "Bit 20 - u0_usb_otg_suspendm_byps"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_otg_suspendm_byps(
-        &mut self,
-    ) -> U0_CDN_USB_OTG_SUSPENDM_BYPS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_OTG_SUSPENDM_BYPS_W::new(self, 20)
+    pub fn u0_usb_otg_suspendm_byps(&mut self) -> U0_USB_OTG_SUSPENDM_BYPS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_OTG_SUSPENDM_BYPS_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_pll_en"]
+    #[doc = "Bit 22 - u0_usb_pll_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_pll_en(&mut self) -> U0_CDN_USB_PLL_EN_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_PLL_EN_W::new(self, 22)
+    pub fn u0_usb_pll_en(&mut self) -> U0_USB_PLL_EN_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_PLL_EN_W::new(self, 22)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_refclk_mode"]
+    #[doc = "Bit 23 - u0_usb_refclk_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_refclk_mode(&mut self) -> U0_CDN_USB_REFCLK_MODE_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_REFCLK_MODE_W::new(self, 23)
+    pub fn u0_usb_refclk_mode(&mut self) -> U0_USB_REFCLK_MODE_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_REFCLK_MODE_W::new(self, 23)
     }
     #[doc = "Bit 24 - u0_cdn_usb_rid_comp_sts_0"]
     #[inline(always)]
@@ -226,21 +222,17 @@ impl W {
     pub fn u0_cdn_usb_rid_comp_sts_2(&mut self) -> U0_CDN_USB_RID_COMP_STS_2_W<STG_SYSCFG_1_SPEC> {
         U0_CDN_USB_RID_COMP_STS_2_W::new(self, 26)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_rid_float_comp_sts"]
+    #[doc = "Bit 28 - u0_usb_rid_float_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_rid_float_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_RID_FLOAT_COMP_STS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_RID_FLOAT_COMP_STS_W::new(self, 28)
+    pub fn u0_usb_rid_float_comp_sts(&mut self) -> U0_USB_RID_FLOAT_COMP_STS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_RID_FLOAT_COMP_STS_W::new(self, 28)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_rid_gnd_comp_sts"]
+    #[doc = "Bit 29 - u0_usb_rid_gnd_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_rid_gnd_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_RID_GND_COMP_STS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_RID_GND_COMP_STS_W::new(self, 29)
+    pub fn u0_usb_rid_gnd_comp_sts(&mut self) -> U0_USB_RID_GND_COMP_STS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_RID_GND_COMP_STS_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_10.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_10.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_10_SPEC>;
 #[doc = "Register `stg_syscfg_10` writer"]
 pub type W = crate::W<STG_SYSCFG_10_SPEC>;
-#[doc = "Field `u0_e2_sft7110_wfi_from_tile_0` reader - u0_e2_sft7110_wfi_from_tile_0"]
-pub type U0_E2_SFT7110_WFI_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_wfi_from_tile_0` reader - u0_e2_wfi_from_tile_0"]
+pub type U0_E2_WFI_FROM_TILE_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_e2_sft7110_wfi_from_tile_0"]
+    #[doc = "Bit 0 - u0_e2_wfi_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_wfi_from_tile_0(&self) -> U0_E2_SFT7110_WFI_FROM_TILE_0_R {
-        U0_E2_SFT7110_WFI_FROM_TILE_0_R::new((self.bits & 1) != 0)
+    pub fn u0_e2_wfi_from_tile_0(&self) -> U0_E2_WFI_FROM_TILE_0_R {
+        U0_E2_WFI_FROM_TILE_0_R::new((self.bits & 1) != 0)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_100.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_100.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_100_SPEC>;
 #[doc = "Register `stg_syscfg_100` writer"]
 pub type W = crate::W<STG_SYSCFG_100_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_319_288` reader - u0_plda_pcie_test_out_bridge_319_288"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_319_288` reader - u0_pcie_test_out_bridge_319_288"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_319_288(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_319_288(&self) -> U0_PCIE_TEST_OUT_BRIDGE_319_288_R {
+        U0_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_101.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_101.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_101_SPEC>;
 #[doc = "Register `stg_syscfg_101` writer"]
 pub type W = crate::W<STG_SYSCFG_101_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_351_320` reader - u0_plda_pcie_test_out_bridge_351_320"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_351_320` reader - u0_pcie_test_out_bridge_351_320"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_351_320(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_351_320(&self) -> U0_PCIE_TEST_OUT_BRIDGE_351_320_R {
+        U0_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_102.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_102.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_102_SPEC>;
 #[doc = "Register `stg_syscfg_102` writer"]
 pub type W = crate::W<STG_SYSCFG_102_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_383_352` reader - u0_plda_pcie_test_out_bridge_383_352"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_383_352` reader - u0_pcie_test_out_bridge_383_352"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_383_352(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_383_352(&self) -> U0_PCIE_TEST_OUT_BRIDGE_383_352_R {
+        U0_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_103.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_103.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_103_SPEC>;
 #[doc = "Register `stg_syscfg_103` writer"]
 pub type W = crate::W<STG_SYSCFG_103_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_415_384` reader - u0_plda_pcie_test_out_bridge_415_384"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_415_384` reader - u0_pcie_test_out_bridge_415_384"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_415_384(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_415_384(&self) -> U0_PCIE_TEST_OUT_BRIDGE_415_384_R {
+        U0_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_104.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_104.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_104_SPEC>;
 #[doc = "Register `stg_syscfg_104` writer"]
 pub type W = crate::W<STG_SYSCFG_104_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_447_416` reader - u0_plda_pcie_test_out_bridge_447_416"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_447_416` reader - u0_pcie_test_out_bridge_447_416"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_447_416(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_447_416(&self) -> U0_PCIE_TEST_OUT_BRIDGE_447_416_R {
+        U0_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_105.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_105.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_105_SPEC>;
 #[doc = "Register `stg_syscfg_105` writer"]
 pub type W = crate::W<STG_SYSCFG_105_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_479_448` reader - u0_plda_pcie_test_out_bridge_479_448"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_479_448` reader - u0_pcie_test_out_bridge_479_448"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_479_448(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_479_448(&self) -> U0_PCIE_TEST_OUT_BRIDGE_479_448_R {
+        U0_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_106.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_106.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_106_SPEC>;
 #[doc = "Register `stg_syscfg_106` writer"]
 pub type W = crate::W<STG_SYSCFG_106_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_511_480` reader - u0_plda_pcie_test_out_bridge_511_480"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_511_480` reader - u0_pcie_test_out_bridge_511_480"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_511_480(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_511_480(&self) -> U0_PCIE_TEST_OUT_BRIDGE_511_480_R {
+        U0_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_107.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_107.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_107_SPEC>;
 #[doc = "Register `stg_syscfg_107` writer"]
 pub type W = crate::W<STG_SYSCFG_107_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_31_0` reader - u0_plda_pcie_test_out_pcie_31_0"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_31_0` reader - u0_pcie_test_out_pcie_31_0"]
+pub type U0_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_31_0(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_31_0(&self) -> U0_PCIE_TEST_OUT_PCIE_31_0_R {
+        U0_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_108.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_108.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_108_SPEC>;
 #[doc = "Register `stg_syscfg_108` writer"]
 pub type W = crate::W<STG_SYSCFG_108_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_63_32` reader - u0_plda_pcie_test_out_pcie_63_32"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_63_32` reader - u0_pcie_test_out_pcie_63_32"]
+pub type U0_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_63_32(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_63_32(&self) -> U0_PCIE_TEST_OUT_PCIE_63_32_R {
+        U0_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_109.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_109.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_109_SPEC>;
 #[doc = "Register `stg_syscfg_109` writer"]
 pub type W = crate::W<STG_SYSCFG_109_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_95_64` reader - u0_plda_pcie_test_out_pcie_95_64"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_95_64` reader - u0_pcie_test_out_pcie_95_64"]
+pub type U0_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_95_64(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_95_64(&self) -> U0_PCIE_TEST_OUT_PCIE_95_64_R {
+        U0_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_110.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_110.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_110_SPEC>;
 #[doc = "Register `stg_syscfg_110` writer"]
 pub type W = crate::W<STG_SYSCFG_110_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_127_96` reader - u0_plda_pcie_test_out_pcie_127_96"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_127_96` reader - u0_pcie_test_out_pcie_127_96"]
+pub type U0_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_127_96(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_127_96(&self) -> U0_PCIE_TEST_OUT_PCIE_127_96_R {
+        U0_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_111.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_111.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_111_SPEC>;
 #[doc = "Register `stg_syscfg_111` writer"]
 pub type W = crate::W<STG_SYSCFG_111_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_159_128` reader - u0_plda_pcie_test_out_pcie_159_128"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_159_128` reader - u0_pcie_test_out_pcie_159_128"]
+pub type U0_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_159_128(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_159_128(&self) -> U0_PCIE_TEST_OUT_PCIE_159_128_R {
+        U0_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_112.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_112.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_112_SPEC>;
 #[doc = "Register `stg_syscfg_112` writer"]
 pub type W = crate::W<STG_SYSCFG_112_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_191_160` reader - u0_plda_pcie_test_out_pcie_191_160"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_191_160` reader - u0_pcie_test_out_pcie_191_160"]
+pub type U0_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_191_160(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_191_160(&self) -> U0_PCIE_TEST_OUT_PCIE_191_160_R {
+        U0_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_113.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_113.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_113_SPEC>;
 #[doc = "Register `stg_syscfg_113` writer"]
 pub type W = crate::W<STG_SYSCFG_113_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_223_192` reader - u0_plda_pcie_test_out_pcie_223_192"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_223_192` reader - u0_pcie_test_out_pcie_223_192"]
+pub type U0_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_223_192(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_223_192(&self) -> U0_PCIE_TEST_OUT_PCIE_223_192_R {
+        U0_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_114.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_114.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_114_SPEC>;
 #[doc = "Register `stg_syscfg_114` writer"]
 pub type W = crate::W<STG_SYSCFG_114_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_255_224` reader - u0_plda_pcie_test_out_pcie_255_224"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_255_224` reader - u0_pcie_test_out_pcie_255_224"]
+pub type U0_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_255_224(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_255_224(&self) -> U0_PCIE_TEST_OUT_PCIE_255_224_R {
+        U0_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_115.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_115.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_115_SPEC>;
 #[doc = "Register `stg_syscfg_115` writer"]
 pub type W = crate::W<STG_SYSCFG_115_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_287_256` reader - u0_plda_pcie_test_out_pcie_287_256"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_287_256` reader - u0_pcie_test_out_pcie_287_256"]
+pub type U0_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_287_256(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_287_256(&self) -> U0_PCIE_TEST_OUT_PCIE_287_256_R {
+        U0_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_116.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_116.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_116_SPEC>;
 #[doc = "Register `stg_syscfg_116` writer"]
 pub type W = crate::W<STG_SYSCFG_116_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_319_288` reader - u0_plda_pcie_test_out_pcie_319_288"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_319_288` reader - u0_pcie_test_out_pcie_319_288"]
+pub type U0_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_319_288(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_319_288(&self) -> U0_PCIE_TEST_OUT_PCIE_319_288_R {
+        U0_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_117.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_117.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_117_SPEC>;
 #[doc = "Register `stg_syscfg_117` writer"]
 pub type W = crate::W<STG_SYSCFG_117_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_351_320` reader - u0_plda_pcie_test_out_pcie_351_320"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_351_320` reader - u0_pcie_test_out_pcie_351_320"]
+pub type U0_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_351_320(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_351_320(&self) -> U0_PCIE_TEST_OUT_PCIE_351_320_R {
+        U0_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_118.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_118.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_118_SPEC>;
 #[doc = "Register `stg_syscfg_118` writer"]
 pub type W = crate::W<STG_SYSCFG_118_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_383_352` reader - u0_plda_pcie_test_out_pcie_383_352"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_383_352` reader - u0_pcie_test_out_pcie_383_352"]
+pub type U0_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_383_352(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_383_352(&self) -> U0_PCIE_TEST_OUT_PCIE_383_352_R {
+        U0_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_119.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_119.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_119_SPEC>;
 #[doc = "Register `stg_syscfg_119` writer"]
 pub type W = crate::W<STG_SYSCFG_119_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_415_384` reader - u0_plda_pcie_test_out_pcie_415_384"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_415_384` reader - u0_pcie_test_out_pcie_415_384"]
+pub type U0_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_415_384(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_415_384(&self) -> U0_PCIE_TEST_OUT_PCIE_415_384_R {
+        U0_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_120.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_120.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_120_SPEC>;
 #[doc = "Register `stg_syscfg_120` writer"]
 pub type W = crate::W<STG_SYSCFG_120_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_447_416` reader - u0_plda_pcie_test_out_pcie_447_416"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_447_416` reader - u0_pcie_test_out_pcie_447_416"]
+pub type U0_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_447_416(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_447_416(&self) -> U0_PCIE_TEST_OUT_PCIE_447_416_R {
+        U0_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_121.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_121.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_121_SPEC>;
 #[doc = "Register `stg_syscfg_121` writer"]
 pub type W = crate::W<STG_SYSCFG_121_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_479_448` reader - u0_plda_pcie_test_out_pcie_479_448"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_479_448` reader - u0_pcie_test_out_pcie_479_448"]
+pub type U0_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_479_448(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_479_448(&self) -> U0_PCIE_TEST_OUT_PCIE_479_448_R {
+        U0_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_122.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_122.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_122_SPEC>;
 #[doc = "Register `stg_syscfg_122` writer"]
 pub type W = crate::W<STG_SYSCFG_122_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_511_480` reader - u0_plda_pcie_test_out_pcie_511_480"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_511_480` reader - u0_pcie_test_out_pcie_511_480"]
+pub type U0_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_511_480(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_511_480(&self) -> U0_PCIE_TEST_OUT_PCIE_511_480_R {
+        U0_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_123.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_123.rs
@@ -2,40 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_123_SPEC>;
 #[doc = "Register `stg_syscfg_123` writer"]
 pub type W = crate::W<STG_SYSCFG_123_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_sel` reader - u0_plda_pcie_test_sel"]
-pub type U0_PLDA_PCIE_TEST_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_test_sel` writer - u0_plda_pcie_test_sel"]
-pub type U0_PLDA_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u0_plda_pcie_tl_clock_freq` reader - u0_plda_pcie_tl_clock_freq"]
-pub type U0_PLDA_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_tl_clock_freq` writer - u0_plda_pcie_tl_clock_freq"]
-pub type U0_PLDA_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
+#[doc = "Field `u0_pcie_test_sel` reader - u0_pcie_test_sel"]
+pub type U0_PCIE_TEST_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_test_sel` writer - u0_pcie_test_sel"]
+pub type U0_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_tl_clock_freq` reader - u0_pcie_tl_clock_freq"]
+pub type U0_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_tl_clock_freq` writer - u0_pcie_tl_clock_freq"]
+pub type U0_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
 impl R {
-    #[doc = "Bits 0:3 - u0_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u0_pcie_test_sel"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_sel(&self) -> U0_PLDA_PCIE_TEST_SEL_R {
-        U0_PLDA_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
+    pub fn u0_pcie_test_sel(&self) -> U0_PCIE_TEST_SEL_R {
+        U0_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:25 - u0_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u0_pcie_tl_clock_freq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_clock_freq(&self) -> U0_PLDA_PCIE_TL_CLOCK_FREQ_R {
-        U0_PLDA_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
+    pub fn u0_pcie_tl_clock_freq(&self) -> U0_PCIE_TL_CLOCK_FREQ_R {
+        U0_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - u0_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u0_pcie_test_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_sel(&mut self) -> U0_PLDA_PCIE_TEST_SEL_W<STG_SYSCFG_123_SPEC> {
-        U0_PLDA_PCIE_TEST_SEL_W::new(self, 0)
+    pub fn u0_pcie_test_sel(&mut self) -> U0_PCIE_TEST_SEL_W<STG_SYSCFG_123_SPEC> {
+        U0_PCIE_TEST_SEL_W::new(self, 0)
     }
-    #[doc = "Bits 4:25 - u0_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u0_pcie_tl_clock_freq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tl_clock_freq(
-        &mut self,
-    ) -> U0_PLDA_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_123_SPEC> {
-        U0_PLDA_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
+    pub fn u0_pcie_tl_clock_freq(&mut self) -> U0_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_123_SPEC> {
+        U0_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_124.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_124.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_124_SPEC>;
 #[doc = "Register `stg_syscfg_124` writer"]
 pub type W = crate::W<STG_SYSCFG_124_SPEC>;
-#[doc = "Field `u0_plda_pcie_tl_ctrl_hotplug` reader - u0_plda_pcie_tl_ctrl_hotplug"]
-pub type U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_tl_report_hotplug` reader - u0_plda_pcie_tl_report_hotplug"]
-pub type U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_tl_report_hotplug` writer - u0_plda_pcie_tl_report_hotplug"]
-pub type U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `u0_pcie_tl_ctrl_hotplug` reader - u0_pcie_tl_ctrl_hotplug"]
+pub type U0_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_tl_report_hotplug` reader - u0_pcie_tl_report_hotplug"]
+pub type U0_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_tl_report_hotplug` writer - u0_pcie_tl_report_hotplug"]
+pub type U0_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
 impl R {
-    #[doc = "Bits 0:15 - u0_plda_pcie_tl_ctrl_hotplug"]
+    #[doc = "Bits 0:15 - u0_pcie_tl_ctrl_hotplug"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_ctrl_hotplug(&self) -> U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R {
-        U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
+    pub fn u0_pcie_tl_ctrl_hotplug(&self) -> U0_PCIE_TL_CTRL_HOTPLUG_R {
+        U0_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:31 - u0_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u0_pcie_tl_report_hotplug"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_report_hotplug(&self) -> U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R {
-        U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn u0_pcie_tl_report_hotplug(&self) -> U0_PCIE_TL_REPORT_HOTPLUG_R {
+        U0_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 16:31 - u0_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u0_pcie_tl_report_hotplug"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tl_report_hotplug(
+    pub fn u0_pcie_tl_report_hotplug(
         &mut self,
-    ) -> U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_124_SPEC> {
-        U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
+    ) -> U0_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_124_SPEC> {
+        U0_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_125.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_125.rs
@@ -2,34 +2,34 @@
 pub type R = crate::R<STG_SYSCFG_125_SPEC>;
 #[doc = "Register `stg_syscfg_125` writer"]
 pub type W = crate::W<STG_SYSCFG_125_SPEC>;
-#[doc = "Field `u0_plda_pcie_tx_pattern` reader - u0_plda_pcie_tx_pattern"]
-pub type U0_PLDA_PCIE_TX_PATTERN_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_tx_pattern` writer - u0_plda_pcie_tx_pattern"]
-pub type U0_PLDA_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_bus_width` reader - u0_plda_pcie_usb3_bus_width"]
-pub type U0_PLDA_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_usb3_bus_width` writer - u0_plda_pcie_usb3_bus_width"]
-pub type U0_PLDA_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_phy_enable` reader - u0_plda_pcie_usb3_phy_enable"]
-pub type U0_PLDA_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_usb3_phy_enable` writer - u0_plda_pcie_usb3_phy_enable"]
-pub type U0_PLDA_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_usb3_rate` reader - u0_plda_pcie_usb3_rate"]
-pub type U0_PLDA_PCIE_USB3_RATE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_usb3_rate` writer - u0_plda_pcie_usb3_rate"]
-pub type U0_PLDA_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_rx_standby` reader - u0_plda_pcie_usb3_rx_standby"]
-pub type U0_PLDA_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_usb3_rx_standby` writer - u0_plda_pcie_usb3_rx_standby"]
-pub type U0_PLDA_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_xwdecerr` reader - u0_plda_pcie_xwdecerr"]
-pub type U0_PLDA_PCIE_XWDECERR_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_xwerrclr` reader - u0_plda_pcie_xwerrclr"]
-pub type U0_PLDA_PCIE_XWERRCLR_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_xwerrclr` writer - u0_plda_pcie_xwerrclr"]
-pub type U0_PLDA_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_xwslverr` reader - u0_plda_pcie_xwslverr"]
-pub type U0_PLDA_PCIE_XWSLVERR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_tx_pattern` reader - u0_pcie_tx_pattern"]
+pub type U0_PCIE_TX_PATTERN_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_tx_pattern` writer - u0_pcie_tx_pattern"]
+pub type U0_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_bus_width` reader - u0_pcie_usb3_bus_width"]
+pub type U0_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_usb3_bus_width` writer - u0_pcie_usb3_bus_width"]
+pub type U0_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_phy_enable` reader - u0_pcie_usb3_phy_enable"]
+pub type U0_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_usb3_phy_enable` writer - u0_pcie_usb3_phy_enable"]
+pub type U0_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_usb3_rate` reader - u0_pcie_usb3_rate"]
+pub type U0_PCIE_USB3_RATE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_usb3_rate` writer - u0_pcie_usb3_rate"]
+pub type U0_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_rx_standby` reader - u0_pcie_usb3_rx_standby"]
+pub type U0_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
+#[doc = "Field `u0_pcie_usb3_rx_standby` writer - u0_pcie_usb3_rx_standby"]
+pub type U0_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_xwdecerr` reader - u0_pcie_xwdecerr"]
+pub type U0_PCIE_XWDECERR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_xwerrclr` reader - u0_pcie_xwerrclr"]
+pub type U0_PCIE_XWERRCLR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_xwerrclr` writer - u0_pcie_xwerrclr"]
+pub type U0_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_xwslverr` reader - u0_pcie_xwslverr"]
+pub type U0_PCIE_XWSLVERR_R = crate::BitReader;
 #[doc = "Field `u0_sec_top_sramcfg_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U0_SEC_TOP_SRAMCFG_SLP_R = crate::BitReader;
 #[doc = "Field `u0_sec_top_sramcfg_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -65,45 +65,45 @@ pub type U0_SEC_TOP_SRAMCFG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_plda_pcie_align_detect` reader - u0_plda_pcie_align_detect"]
 pub type U0_PLDA_PCIE_ALIGN_DETECT_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u0_pcie_tx_pattern"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tx_pattern(&self) -> U0_PLDA_PCIE_TX_PATTERN_R {
-        U0_PLDA_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_tx_pattern(&self) -> U0_PCIE_TX_PATTERN_R {
+        U0_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:3 - u0_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u0_pcie_usb3_bus_width"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_bus_width(&self) -> U0_PLDA_PCIE_USB3_BUS_WIDTH_R {
-        U0_PLDA_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
+    pub fn u0_pcie_usb3_bus_width(&self) -> U0_PCIE_USB3_BUS_WIDTH_R {
+        U0_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
     }
-    #[doc = "Bit 4 - u0_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u0_pcie_usb3_phy_enable"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_phy_enable(&self) -> U0_PLDA_PCIE_USB3_PHY_ENABLE_R {
-        U0_PLDA_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_pcie_usb3_phy_enable(&self) -> U0_PCIE_USB3_PHY_ENABLE_R {
+        U0_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:6 - u0_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u0_pcie_usb3_rate"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_rate(&self) -> U0_PLDA_PCIE_USB3_RATE_R {
-        U0_PLDA_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
+    pub fn u0_pcie_usb3_rate(&self) -> U0_PCIE_USB3_RATE_R {
+        U0_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
     }
-    #[doc = "Bit 7 - u0_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u0_pcie_usb3_rx_standby"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_rx_standby(&self) -> U0_PLDA_PCIE_USB3_RX_STANDBY_R {
-        U0_PLDA_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_pcie_usb3_rx_standby(&self) -> U0_PCIE_USB3_RX_STANDBY_R {
+        U0_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_xwdecerr"]
+    #[doc = "Bit 8 - u0_pcie_xwdecerr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwdecerr(&self) -> U0_PLDA_PCIE_XWDECERR_R {
-        U0_PLDA_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_pcie_xwdecerr(&self) -> U0_PCIE_XWDECERR_R {
+        U0_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u0_pcie_xwerrclr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwerrclr(&self) -> U0_PLDA_PCIE_XWERRCLR_R {
-        U0_PLDA_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_pcie_xwerrclr(&self) -> U0_PCIE_XWERRCLR_R {
+        U0_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_xwslverr"]
+    #[doc = "Bit 10 - u0_pcie_xwslverr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwslverr(&self) -> U0_PLDA_PCIE_XWSLVERR_R {
-        U0_PLDA_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_pcie_xwslverr(&self) -> U0_PCIE_XWSLVERR_R {
+        U0_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -152,47 +152,41 @@ impl R {
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u0_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u0_pcie_tx_pattern"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tx_pattern(&mut self) -> U0_PLDA_PCIE_TX_PATTERN_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_TX_PATTERN_W::new(self, 0)
+    pub fn u0_pcie_tx_pattern(&mut self) -> U0_PCIE_TX_PATTERN_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_TX_PATTERN_W::new(self, 0)
     }
-    #[doc = "Bits 2:3 - u0_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u0_pcie_usb3_bus_width"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_bus_width(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
+    pub fn u0_pcie_usb3_bus_width(&mut self) -> U0_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
     }
-    #[doc = "Bit 4 - u0_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u0_pcie_usb3_phy_enable"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_phy_enable(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
+    pub fn u0_pcie_usb3_phy_enable(&mut self) -> U0_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
     }
-    #[doc = "Bits 5:6 - u0_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u0_pcie_usb3_rate"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_rate(&mut self) -> U0_PLDA_PCIE_USB3_RATE_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_RATE_W::new(self, 5)
+    pub fn u0_pcie_usb3_rate(&mut self) -> U0_PCIE_USB3_RATE_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_RATE_W::new(self, 5)
     }
-    #[doc = "Bit 7 - u0_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u0_pcie_usb3_rx_standby"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_rx_standby(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_RX_STANDBY_W::new(self, 7)
+    pub fn u0_pcie_usb3_rx_standby(&mut self) -> U0_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_RX_STANDBY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u0_pcie_xwerrclr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_xwerrclr(&mut self) -> U0_PLDA_PCIE_XWERRCLR_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_XWERRCLR_W::new(self, 9)
+    pub fn u0_pcie_xwerrclr(&mut self) -> U0_PCIE_XWERRCLR_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_XWERRCLR_W::new(self, 9)
     }
     #[doc = "Bit 11 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_126.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_126.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_126_SPEC>;
 #[doc = "Register `stg_syscfg_126` writer"]
 pub type W = crate::W<STG_SYSCFG_126_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_31_0` reader - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_31_0` reader - u0_pcie_axi4_mst0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_127.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_127.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_127_SPEC>;
 #[doc = "Register `stg_syscfg_127` writer"]
 pub type W = crate::W<STG_SYSCFG_127_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_63_32` reader - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_63_32` reader - u0_pcie_axi4_mst0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_128.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_128.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_128_SPEC>;
 #[doc = "Register `stg_syscfg_128` writer"]
 pub type W = crate::W<STG_SYSCFG_128_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_95_64` reader - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_95_64` reader - u0_pcie_axi4_mst0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_129.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_129.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_129_SPEC>;
 #[doc = "Register `stg_syscfg_129` writer"]
 pub type W = crate::W<STG_SYSCFG_129_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_127_96` reader - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_127_96` reader - u0_pcie_axi4_mst0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_127_96(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_130.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_130.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_130_SPEC>;
 #[doc = "Register `stg_syscfg_130` writer"]
 pub type W = crate::W<STG_SYSCFG_130_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_159_128` reader - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_159_128` reader - u0_pcie_axi4_mst0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_159_128(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_131.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_131.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_131_SPEC>;
 #[doc = "Register `stg_syscfg_131` writer"]
 pub type W = crate::W<STG_SYSCFG_131_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_191_160` reader - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_191_160` reader - u0_pcie_axi4_mst0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_191_160(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_132.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_132.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_132_SPEC>;
 #[doc = "Register `stg_syscfg_132` writer"]
 pub type W = crate::W<STG_SYSCFG_132_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_223_192` reader - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_223_192` reader - u0_pcie_axi4_mst0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_223_192(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_133.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_133.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_133_SPEC>;
 #[doc = "Register `stg_syscfg_133` writer"]
 pub type W = crate::W<STG_SYSCFG_133_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_255_224` reader - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_255_224` reader - u0_pcie_axi4_mst0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_255_224(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_134.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_134.rs
@@ -2,29 +2,27 @@
 pub type R = crate::R<STG_SYSCFG_134_SPEC>;
 #[doc = "Register `stg_syscfg_134` writer"]
 pub type W = crate::W<STG_SYSCFG_134_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_257_256` reader - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arfunc` reader - u0_plda_pcie_axi4_mst0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arregion` reader - u0_plda_pcie_axi4_mst0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_257_256` reader - u0_pcie_axi4_mst0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_arfunc` reader - u0_pcie_axi4_mst0_arfunc"]
+pub type U0_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_arregion` reader - u0_pcie_axi4_mst0_arregion"]
+pub type U0_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_mst0_aratomop_257_256(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_mst0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_mst0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_arfunc(&self) -> U0_PCIE_AXI4_MST0_ARFUNC_R {
+        U0_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_mst0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_mst0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_arregion(&self) -> U0_PCIE_AXI4_MST0_ARREGION_R {
+        U0_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_135.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_135.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_135_SPEC>;
 #[doc = "Register `stg_syscfg_135` writer"]
 pub type W = crate::W<STG_SYSCFG_135_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aruser_31_0` reader - u1_plda_pcie_axi4_mst0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_aruser_31_0` reader - u1_pcie_axi4_mst0_aruser_31_0"]
+pub type U1_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_aruser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aruser_31_0(&self) -> U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_aruser_31_0(&self) -> U1_PCIE_AXI4_MST0_ARUSER_31_0_R {
+        U1_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_136.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_136.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_136_SPEC>;
 #[doc = "Register `stg_syscfg_136` writer"]
 pub type W = crate::W<STG_SYSCFG_136_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aruser_52_32` reader - u1_plda_pcie_axi4_mst0_aruser_52_32"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_aruser_52_32` reader - u1_pcie_axi4_mst0_aruser_52_32"]
+pub type U1_PCIE_AXI4_MST0_ARUSER_52_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:20 - u1_plda_pcie_axi4_mst0_aruser_52_32"]
+    #[doc = "Bits 0:20 - u1_pcie_axi4_mst0_aruser_52_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aruser_52_32(&self) -> U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R::new(self.bits & 0x001f_ffff)
+    pub fn u1_pcie_axi4_mst0_aruser_52_32(&self) -> U1_PCIE_AXI4_MST0_ARUSER_52_32_R {
+        U1_PCIE_AXI4_MST0_ARUSER_52_32_R::new(self.bits & 0x001f_ffff)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_137.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_137.rs
@@ -2,20 +2,20 @@
 pub type R = crate::R<STG_SYSCFG_137_SPEC>;
 #[doc = "Register `stg_syscfg_137` writer"]
 pub type W = crate::W<STG_SYSCFG_137_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awfunc` reader - u1_plda_pcie_axi4_mst0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awregion` reader - u1_plda_pcie_axi4_mst0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_awfunc` reader - u1_pcie_axi4_mst0_awfunc"]
+pub type U1_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_mst0_awregion` reader - u1_pcie_axi4_mst0_awregion"]
+pub type U1_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_mst0_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_mst0_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awfunc(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_mst0_awfunc(&self) -> U1_PCIE_AXI4_MST0_AWFUNC_R {
+        U1_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:18 - u1_plda_pcie_axi4_mst0_awregion"]
+    #[doc = "Bits 15:18 - u1_pcie_axi4_mst0_awregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awregion(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWREGION_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_mst0_awregion(&self) -> U1_PCIE_AXI4_MST0_AWREGION_R {
+        U1_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_138.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_138.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_138_SPEC>;
 #[doc = "Register `stg_syscfg_138` writer"]
 pub type W = crate::W<STG_SYSCFG_138_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awuser_31_0` reader - u1_plda_pcie_axi4_mst0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_awuser_31_0` reader - u1_pcie_axi4_mst0_awuser_31_0"]
+pub type U1_PCIE_AXI4_MST0_AWUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_awuser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awuser_31_0(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_awuser_31_0(&self) -> U1_PCIE_AXI4_MST0_AWUSER_31_0_R {
+        U1_PCIE_AXI4_MST0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_139.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_139.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_139_SPEC>;
 #[doc = "Register `stg_syscfg_139` writer"]
 pub type W = crate::W<STG_SYSCFG_139_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awuser_42_32` reader - u1_plda_pcie_axi4_mst0_awuser_42_32"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_rderr` reader - u1_plda_pcie_axi4_mst0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_rderr` writer - u1_plda_pcie_axi4_mst0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_axi4_mst0_awuser_42_32` reader - u1_pcie_axi4_mst0_awuser_42_32"]
+pub type U1_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_mst0_rderr` reader - u1_pcie_axi4_mst0_rderr"]
+pub type U1_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_rderr` writer - u1_pcie_axi4_mst0_rderr"]
+pub type U1_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:10 - u1_plda_pcie_axi4_mst0_awuser_42_32"]
+    #[doc = "Bits 0:10 - u1_pcie_axi4_mst0_awuser_42_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awuser_42_32(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
+    pub fn u1_pcie_axi4_mst0_awuser_42_32(&self) -> U1_PCIE_AXI4_MST0_AWUSER_42_32_R {
+        U1_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
     }
-    #[doc = "Bits 11:18 - u1_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u1_pcie_axi4_mst0_rderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_rderr(&self) -> U1_PLDA_PCIE_AXI4_MST0_RDERR_R {
-        U1_PLDA_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
+    pub fn u1_pcie_axi4_mst0_rderr(&self) -> U1_PCIE_AXI4_MST0_RDERR_R {
+        U1_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 11:18 - u1_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u1_pcie_axi4_mst0_rderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_rderr(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_139_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
+    pub fn u1_pcie_axi4_mst0_rderr(&mut self) -> U1_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_139_SPEC> {
+        U1_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_140.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_140.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_140_SPEC>;
 #[doc = "Register `stg_syscfg_140` writer"]
 pub type W = crate::W<STG_SYSCFG_140_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_ruser` reader - u1_plda_pcie_axi4_mst0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_ruser` writer - u1_plda_pcie_axi4_mst0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_ruser` reader - u1_pcie_axi4_mst0_ruser"]
+pub type U1_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_ruser` writer - u1_pcie_axi4_mst0_ruser"]
+pub type U1_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_ruser"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_ruser(&self) -> U1_PLDA_PCIE_AXI4_MST0_RUSER_R {
-        U1_PLDA_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_ruser(&self) -> U1_PCIE_AXI4_MST0_RUSER_R {
+        U1_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_ruser"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_ruser(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_140_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
+    pub fn u1_pcie_axi4_mst0_ruser(&mut self) -> U1_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_140_SPEC> {
+        U1_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_141.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_141.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_141_SPEC>;
 #[doc = "Register `stg_syscfg_141` writer"]
 pub type W = crate::W<STG_SYSCFG_141_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_wderr` reader - u1_plda_pcie_axi4_mst0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_wderr` reader - u1_pcie_axi4_mst0_wderr"]
+pub type U1_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_mst0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_mst0_wderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_wderr(&self) -> U1_PLDA_PCIE_AXI4_MST0_WDERR_R {
-        U1_PLDA_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_axi4_mst0_wderr(&self) -> U1_PCIE_AXI4_MST0_WDERR_R {
+        U1_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_142.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_142.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_142_SPEC>;
 #[doc = "Register `stg_syscfg_142` writer"]
 pub type W = crate::W<STG_SYSCFG_142_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_31_0` reader - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_31_0` writer - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_31_0` reader - u1_pcie_axi4_slv0_aratomop_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_31_0` writer - u1_pcie_axi4_slv0_aratomop_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_31_0(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_31_0(
+    pub fn u1_pcie_axi4_slv0_aratomop_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_142_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_142_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_143.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_143.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_143_SPEC>;
 #[doc = "Register `stg_syscfg_143` writer"]
 pub type W = crate::W<STG_SYSCFG_143_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_63_32` reader - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_63_32` writer - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_63_32` reader - u1_pcie_axi4_slv0_aratomop_63_32"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_63_32` writer - u1_pcie_axi4_slv0_aratomop_63_32"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_63_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_63_32(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_63_32(
+    pub fn u1_pcie_axi4_slv0_aratomop_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_143_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_143_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_144.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_144.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_144_SPEC>;
 #[doc = "Register `stg_syscfg_144` writer"]
 pub type W = crate::W<STG_SYSCFG_144_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_95_64` reader - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_95_64` writer - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_95_64` reader - u1_pcie_axi4_slv0_aratomop_95_64"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_95_64` writer - u1_pcie_axi4_slv0_aratomop_95_64"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_95_64(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_95_64(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_95_64(
+    pub fn u1_pcie_axi4_slv0_aratomop_95_64(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_144_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_144_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_145.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_145.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_145_SPEC>;
 #[doc = "Register `stg_syscfg_145` writer"]
 pub type W = crate::W<STG_SYSCFG_145_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_127_96` reader - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_127_96` writer - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_127_96` reader - u1_pcie_axi4_slv0_aratomop_127_96"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_127_96` writer - u1_pcie_axi4_slv0_aratomop_127_96"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_127_96(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_127_96(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_127_96(
+    pub fn u1_pcie_axi4_slv0_aratomop_127_96(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_145_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_145_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_146.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_146.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_146_SPEC>;
 #[doc = "Register `stg_syscfg_146` writer"]
 pub type W = crate::W<STG_SYSCFG_146_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_159_128` reader - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_159_128` writer - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_159_128` reader - u1_pcie_axi4_slv0_aratomop_159_128"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_159_128` writer - u1_pcie_axi4_slv0_aratomop_159_128"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_159_128(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_159_128(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_159_128(
+    pub fn u1_pcie_axi4_slv0_aratomop_159_128(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_146_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_146_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_147.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_147.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_147_SPEC>;
 #[doc = "Register `stg_syscfg_147` writer"]
 pub type W = crate::W<STG_SYSCFG_147_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_191_160` reader - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_191_160` writer - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_191_160` reader - u1_pcie_axi4_slv0_aratomop_191_160"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_191_160` writer - u1_pcie_axi4_slv0_aratomop_191_160"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_191_160(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_191_160(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_191_160(
+    pub fn u1_pcie_axi4_slv0_aratomop_191_160(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_147_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_147_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_148.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_148.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_148_SPEC>;
 #[doc = "Register `stg_syscfg_148` writer"]
 pub type W = crate::W<STG_SYSCFG_148_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_223_192` reader - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_223_192` writer - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_223_192` reader - u1_pcie_axi4_slv0_aratomop_223_192"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_223_192` writer - u1_pcie_axi4_slv0_aratomop_223_192"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_223_192(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_223_192(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_223_192(
+    pub fn u1_pcie_axi4_slv0_aratomop_223_192(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_148_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_148_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_149.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_149.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_149_SPEC>;
 #[doc = "Register `stg_syscfg_149` writer"]
 pub type W = crate::W<STG_SYSCFG_149_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_255_224` reader - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_255_224` writer - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_255_224` reader - u1_pcie_axi4_slv0_aratomop_255_224"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_255_224` writer - u1_pcie_axi4_slv0_aratomop_255_224"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_255_224(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_255_224(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_255_224(
+    pub fn u1_pcie_axi4_slv0_aratomop_255_224(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_149_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_149_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_150.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_150.rs
@@ -2,61 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_150_SPEC>;
 #[doc = "Register `stg_syscfg_150` writer"]
 pub type W = crate::W<STG_SYSCFG_150_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aratomop_257_256` reader - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aratomop_257_256` writer - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arfunc` reader - u1_plda_pcie_axi4_slv0_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arfunc` writer - u1_plda_pcie_axi4_slv0_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arregion` reader - u1_plda_pcie_axi4_slv0_arregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arregion` writer - u1_plda_pcie_axi4_slv0_arregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_axi4_mst0_aratomop_257_256` reader - u1_pcie_axi4_mst0_aratomop_257_256"]
+pub type U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_aratomop_257_256` writer - u1_pcie_axi4_mst0_aratomop_257_256"]
+pub type U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_axi4_slv0_arfunc` reader - u1_pcie_axi4_slv0_arfunc"]
+pub type U1_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_arfunc` writer - u1_pcie_axi4_slv0_arfunc"]
+pub type U1_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_arregion` reader - u1_pcie_axi4_slv0_arregion"]
+pub type U1_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_arregion` writer - u1_pcie_axi4_slv0_arregion"]
+pub type U1_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:1 - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u1_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u1_pcie_axi4_mst0_aratomop_257_256(&self) -> U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u1_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u1_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_arfunc(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slv0_arfunc(&self) -> U1_PCIE_AXI4_SLV0_ARFUNC_R {
+        U1_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u1_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u1_pcie_axi4_slv0_arregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_arregion(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_slv0_arregion(&self) -> U1_PCIE_AXI4_SLV0_ARREGION_R {
+        U1_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u1_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_aratomop_257_256(
+    pub fn u1_pcie_axi4_mst0_aratomop_257_256(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W::new(self, 0)
     }
-    #[doc = "Bits 2:16 - u1_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u1_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_arfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
+    pub fn u1_pcie_axi4_slv0_arfunc(&mut self) -> U1_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
     }
-    #[doc = "Bits 17:20 - u1_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u1_pcie_axi4_slv0_arregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_arregion(
+    pub fn u1_pcie_axi4_slv0_arregion(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
+    ) -> U1_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_151.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_151.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_151_SPEC>;
 #[doc = "Register `stg_syscfg_151` writer"]
 pub type W = crate::W<STG_SYSCFG_151_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_31_0` reader - u1_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_31_0` writer - u1_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_31_0` reader - u1_pcie_axi4_slv0_aruser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_31_0` writer - u1_pcie_axi4_slv0_aruser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aruser_31_0(&self) -> U1_PCIE_AXI4_SLV0_ARUSER_31_0_R {
+        U1_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_31_0(
+    pub fn u1_pcie_axi4_slv0_aruser_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_151_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_151_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_152.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_152.rs
@@ -2,59 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_152_SPEC>;
 #[doc = "Register `stg_syscfg_152` writer"]
 pub type W = crate::W<STG_SYSCFG_152_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_40_32` reader - u1_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_40_32` writer - u1_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awfunc` reader - u1_plda_pcie_axi4_slv0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awfunc` writer - u1_plda_pcie_axi4_slv0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awregion` reader - u1_plda_pcie_axi4_slv0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awregion` writer - u1_plda_pcie_axi4_slv0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_40_32` reader - u1_pcie_axi4_slv0_aruser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_40_32` writer - u1_pcie_axi4_slv0_aruser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awfunc` reader - u1_pcie_axi4_slv0_awfunc"]
+pub type U1_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awfunc` writer - u1_pcie_axi4_slv0_awfunc"]
+pub type U1_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awregion` reader - u1_pcie_axi4_slv0_awregion"]
+pub type U1_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_awregion` writer - u1_pcie_axi4_slv0_awregion"]
+pub type U1_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_40_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u1_pcie_axi4_slv0_aruser_40_32(&self) -> U1_PCIE_AXI4_SLV0_ARUSER_40_32_R {
+        U1_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:23 - u1_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u1_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awfunc(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slv0_awfunc(&self) -> U1_PCIE_AXI4_SLV0_AWFUNC_R {
+        U1_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
     }
-    #[doc = "Bits 24:27 - u1_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u1_pcie_axi4_slv0_awregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awregion(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_slv0_awregion(&self) -> U1_PCIE_AXI4_SLV0_AWREGION_R {
+        U1_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_40_32(
+    pub fn u1_pcie_axi4_slv0_aruser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
     }
-    #[doc = "Bits 9:23 - u1_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u1_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
+    pub fn u1_pcie_axi4_slv0_awfunc(&mut self) -> U1_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
     }
-    #[doc = "Bits 24:27 - u1_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u1_pcie_axi4_slv0_awregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awregion(
+    pub fn u1_pcie_axi4_slv0_awregion(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
+    ) -> U1_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_153.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_153.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_153_SPEC>;
 #[doc = "Register `stg_syscfg_153` writer"]
 pub type W = crate::W<STG_SYSCFG_153_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_31_0` reader - u1_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_31_0` writer - u1_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_31_0` reader - u1_pcie_axi4_slv0_awuser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_31_0` writer - u1_pcie_axi4_slv0_awuser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_awuser_31_0(&self) -> U1_PCIE_AXI4_SLV0_AWUSER_31_0_R {
+        U1_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_31_0(
+    pub fn u1_pcie_axi4_slv0_awuser_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_153_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_153_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_154.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_154.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_154_SPEC>;
 #[doc = "Register `stg_syscfg_154` writer"]
 pub type W = crate::W<STG_SYSCFG_154_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` reader - u1_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` writer - u1_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_rderr` reader - u1_plda_pcie_axi4_slv0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_40_32` reader - u1_pcie_axi4_slv0_awuser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_40_32` writer - u1_pcie_axi4_slv0_awuser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_rderr` reader - u1_pcie_axi4_slv0_rderr"]
+pub type U1_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u1_pcie_axi4_slv0_awuser_40_32(&self) -> U1_PCIE_AXI4_SLV0_AWUSER_40_32_R {
+        U1_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:16 - u1_plda_pcie_axi4_slv0_rderr"]
+    #[doc = "Bits 9:16 - u1_pcie_axi4_slv0_rderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_rderr(&self) -> U1_PLDA_PCIE_AXI4_SLV0_RDERR_R {
-        U1_PLDA_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
+    pub fn u1_pcie_axi4_slv0_rderr(&self) -> U1_PCIE_AXI4_SLV0_RDERR_R {
+        U1_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(
+    pub fn u1_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_155.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_155.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_155_SPEC>;
 #[doc = "Register `stg_syscfg_155` writer"]
 pub type W = crate::W<STG_SYSCFG_155_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_ruser` reader - u1_plda_pcie_axi4_slv0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_ruser` reader - u1_pcie_axi4_slv0_ruser"]
+pub type U1_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_ruser"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_ruser(&self) -> U1_PLDA_PCIE_AXI4_SLV0_RUSER_R {
-        U1_PLDA_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_ruser(&self) -> U1_PCIE_AXI4_SLV0_RUSER_R {
+        U1_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_156.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_156.rs
@@ -2,42 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_156_SPEC>;
 #[doc = "Register `stg_syscfg_156` writer"]
 pub type W = crate::W<STG_SYSCFG_156_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_wderr` reader - u1_plda_pcie_axi4_slv0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_wderr` writer - u1_plda_pcie_axi4_slv0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_arfunc` reader - u1_plda_pcie_axi4_slvl_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_arfunc` writer - u1_plda_pcie_axi4_slvl_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_wderr` reader - u1_pcie_axi4_slv0_wderr"]
+pub type U1_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_wderr` writer - u1_pcie_axi4_slv0_wderr"]
+pub type U1_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_axi4_slvl_arfunc` reader - u1_pcie_axi4_slvl_arfunc"]
+pub type U1_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slvl_arfunc` writer - u1_pcie_axi4_slvl_arfunc"]
+pub type U1_PCIE_AXI4_SLVL_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_slv0_wderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_wderr(&self) -> U1_PLDA_PCIE_AXI4_SLV0_WDERR_R {
-        U1_PLDA_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_axi4_slv0_wderr(&self) -> U1_PCIE_AXI4_SLV0_WDERR_R {
+        U1_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bits 8:22 - u1_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u1_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slvl_arfunc(&self) -> U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slvl_arfunc(&self) -> U1_PCIE_AXI4_SLVL_ARFUNC_R {
+        U1_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_slv0_wderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_wderr(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_156_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
+    pub fn u1_pcie_axi4_slv0_wderr(&mut self) -> U1_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_156_SPEC> {
+        U1_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
     }
-    #[doc = "Bits 8:22 - u1_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u1_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slvl_arfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W<STG_SYSCFG_156_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W::new(self, 8)
+    pub fn u1_pcie_axi4_slvl_arfunc(&mut self) -> U1_PCIE_AXI4_SLVL_ARFUNC_W<STG_SYSCFG_156_SPEC> {
+        U1_PCIE_AXI4_SLVL_ARFUNC_W::new(self, 8)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_157.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_157.rs
@@ -2,94 +2,90 @@
 pub type R = crate::R<STG_SYSCFG_157_SPEC>;
 #[doc = "Register `stg_syscfg_157` writer"]
 pub type W = crate::W<STG_SYSCFG_157_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_awfunc` reader - u1_plda_pcie_axi4_slvl_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_awfunc` writer - u1_plda_pcie_axi4_slvl_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_bus_width_o` reader - u1_plda_pcie_bus_width_o"]
-pub type U1_PLDA_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_bypass_codec` reader - u1_plda_pcie_bypass_codec"]
-pub type U1_PLDA_PCIE_BYPASS_CODEC_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_bypass_codec` writer - u1_plda_pcie_bypass_codec"]
-pub type U1_PLDA_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_ckref_src` reader - u1_plda_pcie_ckref_src"]
-pub type U1_PLDA_PCIE_CKREF_SRC_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_ckref_src` writer - u1_plda_pcie_ckref_src"]
-pub type U1_PLDA_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_clk_sel` reader - u1_plda_pcie_clk_sel"]
-pub type U1_PLDA_PCIE_CLK_SEL_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_clk_sel` writer - u1_plda_pcie_clk_sel"]
-pub type U1_PLDA_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_clkreq` reader - u1_plda_pcie_clkreq"]
-pub type U1_PLDA_PCIE_CLKREQ_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_clkreq` writer - u1_plda_pcie_clkreq"]
-pub type U1_PLDA_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi4_slvl_awfunc` reader - u1_pcie_axi4_slvl_awfunc"]
+pub type U1_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slvl_awfunc` writer - u1_pcie_axi4_slvl_awfunc"]
+pub type U1_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_bus_width_o` reader - u1_pcie_bus_width_o"]
+pub type U1_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_bypass_codec` reader - u1_pcie_bypass_codec"]
+pub type U1_PCIE_BYPASS_CODEC_R = crate::BitReader;
+#[doc = "Field `u1_pcie_bypass_codec` writer - u1_pcie_bypass_codec"]
+pub type U1_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_ckref_src` reader - u1_pcie_ckref_src"]
+pub type U1_PCIE_CKREF_SRC_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_ckref_src` writer - u1_pcie_ckref_src"]
+pub type U1_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_clk_sel` reader - u1_pcie_clk_sel"]
+pub type U1_PCIE_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_clk_sel` writer - u1_pcie_clk_sel"]
+pub type U1_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_clkreq` reader - u1_pcie_clkreq"]
+pub type U1_PCIE_CLKREQ_R = crate::BitReader;
+#[doc = "Field `u1_pcie_clkreq` writer - u1_pcie_clkreq"]
+pub type U1_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slvl_awfunc(&self) -> U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slvl_awfunc(&self) -> U1_PCIE_AXI4_SLVL_AWFUNC_R {
+        U1_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:16 - u1_plda_pcie_bus_width_o"]
+    #[doc = "Bits 15:16 - u1_pcie_bus_width_o"]
     #[inline(always)]
-    pub fn u1_plda_pcie_bus_width_o(&self) -> U1_PLDA_PCIE_BUS_WIDTH_O_R {
-        U1_PLDA_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
+    pub fn u1_pcie_bus_width_o(&self) -> U1_PCIE_BUS_WIDTH_O_R {
+        U1_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
     }
-    #[doc = "Bit 17 - u1_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u1_pcie_bypass_codec"]
     #[inline(always)]
-    pub fn u1_plda_pcie_bypass_codec(&self) -> U1_PLDA_PCIE_BYPASS_CODEC_R {
-        U1_PLDA_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_bypass_codec(&self) -> U1_PCIE_BYPASS_CODEC_R {
+        U1_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bits 18:19 - u1_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u1_pcie_ckref_src"]
     #[inline(always)]
-    pub fn u1_plda_pcie_ckref_src(&self) -> U1_PLDA_PCIE_CKREF_SRC_R {
-        U1_PLDA_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
+    pub fn u1_pcie_ckref_src(&self) -> U1_PCIE_CKREF_SRC_R {
+        U1_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u1_pcie_clk_sel"]
     #[inline(always)]
-    pub fn u1_plda_pcie_clk_sel(&self) -> U1_PLDA_PCIE_CLK_SEL_R {
-        U1_PLDA_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u1_pcie_clk_sel(&self) -> U1_PCIE_CLK_SEL_R {
+        U1_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u1_pcie_clkreq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_clkreq(&self) -> U1_PLDA_PCIE_CLKREQ_R {
-        U1_PLDA_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_clkreq(&self) -> U1_PCIE_CLKREQ_R {
+        U1_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slvl_awfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
+    pub fn u1_pcie_axi4_slvl_awfunc(&mut self) -> U1_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
     }
-    #[doc = "Bit 17 - u1_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u1_pcie_bypass_codec"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_bypass_codec(
-        &mut self,
-    ) -> U1_PLDA_PCIE_BYPASS_CODEC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_BYPASS_CODEC_W::new(self, 17)
+    pub fn u1_pcie_bypass_codec(&mut self) -> U1_PCIE_BYPASS_CODEC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_BYPASS_CODEC_W::new(self, 17)
     }
-    #[doc = "Bits 18:19 - u1_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u1_pcie_ckref_src"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_ckref_src(&mut self) -> U1_PLDA_PCIE_CKREF_SRC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CKREF_SRC_W::new(self, 18)
+    pub fn u1_pcie_ckref_src(&mut self) -> U1_PCIE_CKREF_SRC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CKREF_SRC_W::new(self, 18)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u1_pcie_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_clk_sel(&mut self) -> U1_PLDA_PCIE_CLK_SEL_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CLK_SEL_W::new(self, 20)
+    pub fn u1_pcie_clk_sel(&mut self) -> U1_PCIE_CLK_SEL_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CLK_SEL_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u1_pcie_clkreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_clkreq(&mut self) -> U1_PLDA_PCIE_CLKREQ_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CLKREQ_W::new(self, 22)
+    pub fn u1_pcie_clkreq(&mut self) -> U1_PCIE_CLKREQ_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CLKREQ_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_17.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_17.rs
@@ -46,8 +46,8 @@ pub type U0_HIFI4_TRIGIN_IDMA_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_HIFI4_TRIGOUT_IDMA_R = crate::BitReader;
 #[doc = "Field `u0_hifi4_xocdmode` reader - Debug signal"]
 pub type U0_HIFI4_XOCDMODE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_align_detect` reader - u0_plda_pcie_align_detect"]
-pub type U0_PLDA_PCIE_ALIGN_DETECT_R = crate::BitReader;
+#[doc = "Field `u0_pcie_align_detect` reader - u0_pcie_align_detect"]
+pub type U0_PCIE_ALIGN_DETECT_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -109,10 +109,10 @@ impl R {
     pub fn u0_hifi4_xocdmode(&self) -> U0_HIFI4_XOCDMODE_R {
         U0_HIFI4_XOCDMODE_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_plda_pcie_align_detect"]
+    #[doc = "Bit 16 - u0_pcie_align_detect"]
     #[inline(always)]
-    pub fn u0_plda_pcie_align_detect(&self) -> U0_PLDA_PCIE_ALIGN_DETECT_R {
-        U0_PLDA_PCIE_ALIGN_DETECT_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_align_detect(&self) -> U0_PCIE_ALIGN_DETECT_R {
+        U0_PCIE_ALIGN_DETECT_R::new(((self.bits >> 16) & 1) != 0)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_18.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_18.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_18_SPEC>;
 #[doc = "Register `stg_syscfg_18` writer"]
 pub type W = crate::W<STG_SYSCFG_18_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_31_0` reader - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_31_0` reader - u0_pcie_axi4_mst0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_184.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_184.rs
@@ -2,64 +2,62 @@
 pub type R = crate::R<STG_SYSCFG_184_SPEC>;
 #[doc = "Register `stg_syscfg_184` writer"]
 pub type W = crate::W<STG_SYSCFG_184_SPEC>;
-#[doc = "Field `u1_plda_pcie_k_phyparam_839_832` reader - u1_plda_pcie_k_phyparam_839_832"]
-pub type U1_PLDA_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_k_phyparam_839_832` writer - u1_plda_pcie_k_phyparam_839_832"]
-pub type U1_PLDA_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u1_plda_pcie_k_rp_nep` reader - u1_plda_pcie_k_rp_nep"]
-pub type U1_PLDA_PCIE_K_RP_NEP_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_k_rp_nep` writer - u1_plda_pcie_k_rp_nep"]
-pub type U1_PLDA_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_l1sub_entack` reader - u1_plda_pcie_l1sub_entack"]
-pub type U1_PLDA_PCIE_L1SUB_ENTACK_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_l1sub_entreq` reader - u1_plda_pcie_l1sub_entreq"]
-pub type U1_PLDA_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_l1sub_entreq` writer - u1_plda_pcie_l1sub_entreq"]
-pub type U1_PLDA_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_k_phyparam_839_832` reader - u1_pcie_k_phyparam_839_832"]
+pub type U1_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_k_phyparam_839_832` writer - u1_pcie_k_phyparam_839_832"]
+pub type U1_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_k_rp_nep` reader - u1_pcie_k_rp_nep"]
+pub type U1_PCIE_K_RP_NEP_R = crate::BitReader;
+#[doc = "Field `u1_pcie_k_rp_nep` writer - u1_pcie_k_rp_nep"]
+pub type U1_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_l1sub_entack` reader - u1_pcie_l1sub_entack"]
+pub type U1_PCIE_L1SUB_ENTACK_R = crate::BitReader;
+#[doc = "Field `u1_pcie_l1sub_entreq` reader - u1_pcie_l1sub_entreq"]
+pub type U1_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
+#[doc = "Field `u1_pcie_l1sub_entreq` writer - u1_pcie_l1sub_entreq"]
+pub type U1_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u1_pcie_k_phyparam_839_832"]
     #[inline(always)]
-    pub fn u1_plda_pcie_k_phyparam_839_832(&self) -> U1_PLDA_PCIE_K_PHYPARAM_839_832_R {
-        U1_PLDA_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_k_phyparam_839_832(&self) -> U1_PCIE_K_PHYPARAM_839_832_R {
+        U1_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u1_pcie_k_rp_nep"]
     #[inline(always)]
-    pub fn u1_plda_pcie_k_rp_nep(&self) -> U1_PLDA_PCIE_K_RP_NEP_R {
-        U1_PLDA_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_pcie_k_rp_nep(&self) -> U1_PCIE_K_RP_NEP_R {
+        U1_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_l1sub_entack"]
+    #[doc = "Bit 9 - u1_pcie_l1sub_entack"]
     #[inline(always)]
-    pub fn u1_plda_pcie_l1sub_entack(&self) -> U1_PLDA_PCIE_L1SUB_ENTACK_R {
-        U1_PLDA_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u1_pcie_l1sub_entack(&self) -> U1_PCIE_L1SUB_ENTACK_R {
+        U1_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u1_pcie_l1sub_entreq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_l1sub_entreq(&self) -> U1_PLDA_PCIE_L1SUB_ENTREQ_R {
-        U1_PLDA_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u1_pcie_l1sub_entreq(&self) -> U1_PCIE_L1SUB_ENTREQ_R {
+        U1_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u1_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u1_pcie_k_phyparam_839_832"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_k_phyparam_839_832(
+    pub fn u1_pcie_k_phyparam_839_832(
         &mut self,
-    ) -> U1_PLDA_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
+    ) -> U1_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u1_pcie_k_rp_nep"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_k_rp_nep(&mut self) -> U1_PLDA_PCIE_K_RP_NEP_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_K_RP_NEP_W::new(self, 8)
+    pub fn u1_pcie_k_rp_nep(&mut self) -> U1_PCIE_K_RP_NEP_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_K_RP_NEP_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u1_pcie_l1sub_entreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_l1sub_entreq(
-        &mut self,
-    ) -> U1_PLDA_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_L1SUB_ENTREQ_W::new(self, 10)
+    pub fn u1_pcie_l1sub_entreq(&mut self) -> U1_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_L1SUB_ENTREQ_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_185.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_185.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_185_SPEC>;
 #[doc = "Register `stg_syscfg_185` writer"]
 pub type W = crate::W<STG_SYSCFG_185_SPEC>;
-#[doc = "Field `u1_plda_pcie_local_interrupt_in` reader - u1_plda_pcie_local_interrupt_in"]
-pub type U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_local_interrupt_in` writer - u1_plda_pcie_local_interrupt_in"]
-pub type U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_local_interrupt_in` reader - u1_pcie_local_interrupt_in"]
+pub type U1_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_local_interrupt_in` writer - u1_pcie_local_interrupt_in"]
+pub type U1_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u1_pcie_local_interrupt_in"]
     #[inline(always)]
-    pub fn u1_plda_pcie_local_interrupt_in(&self) -> U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R {
-        U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
+    pub fn u1_pcie_local_interrupt_in(&self) -> U1_PCIE_LOCAL_INTERRUPT_IN_R {
+        U1_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u1_pcie_local_interrupt_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_local_interrupt_in(
+    pub fn u1_pcie_local_interrupt_in(
         &mut self,
-    ) -> U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_185_SPEC> {
-        U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
+    ) -> U1_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_185_SPEC> {
+        U1_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_186.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_186.rs
@@ -2,108 +2,104 @@
 pub type R = crate::R<STG_SYSCFG_186_SPEC>;
 #[doc = "Register `stg_syscfg_186` writer"]
 pub type W = crate::W<STG_SYSCFG_186_SPEC>;
-#[doc = "Field `u1_plda_pcie_mperstn` reader - u1_plda_pcie_mperstn"]
-pub type U1_PLDA_PCIE_MPERSTN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_mperstn` writer - u1_plda_pcie_mperstn"]
-pub type U1_PLDA_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_ebuf_mode` reader - u1_plda_pcie_pcie_ebuf_mode"]
-pub type U1_PLDA_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_ebuf_mode` writer - u1_plda_pcie_pcie_ebuf_mode"]
-pub type U1_PLDA_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_phy_test_cfg` reader - u1_plda_pcie_pcie_phy_test_cfg"]
-pub type U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pcie_phy_test_cfg` writer - u1_plda_pcie_pcie_phy_test_cfg"]
-pub type U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
-#[doc = "Field `u1_plda_pcie_pcie_rx_eq_training` reader - u1_plda_pcie_pcie_rx_eq_training"]
-pub type U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_rx_eq_training` writer - u1_plda_pcie_pcie_rx_eq_training"]
-pub type U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_rxterm_en` reader - u1_plda_pcie_pcie_rxterm_en"]
-pub type U1_PLDA_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_rxterm_en` writer - u1_plda_pcie_pcie_rxterm_en"]
-pub type U1_PLDA_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_tx_oneszeros` reader - u1_plda_pcie_pcie_tx_oneszeros"]
-pub type U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_tx_oneszeros` writer - u1_plda_pcie_pcie_tx_oneszeros"]
-pub type U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_mperstn` reader - u1_pcie_mperstn"]
+pub type U1_PCIE_MPERSTN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_mperstn` writer - u1_pcie_mperstn"]
+pub type U1_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_ebuf_mode` reader - u1_pcie_pcie_ebuf_mode"]
+pub type U1_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_ebuf_mode` writer - u1_pcie_pcie_ebuf_mode"]
+pub type U1_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_phy_test_cfg` reader - u1_pcie_pcie_phy_test_cfg"]
+pub type U1_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pcie_phy_test_cfg` writer - u1_pcie_pcie_phy_test_cfg"]
+pub type U1_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
+#[doc = "Field `u1_pcie_pcie_rx_eq_training` reader - u1_pcie_pcie_rx_eq_training"]
+pub type U1_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_rx_eq_training` writer - u1_pcie_pcie_rx_eq_training"]
+pub type U1_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_rxterm_en` reader - u1_pcie_pcie_rxterm_en"]
+pub type U1_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_rxterm_en` writer - u1_pcie_pcie_rxterm_en"]
+pub type U1_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_tx_oneszeros` reader - u1_pcie_pcie_tx_oneszeros"]
+pub type U1_PCIE_PCIE_TX_ONESZEROS_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_tx_oneszeros` writer - u1_pcie_pcie_tx_oneszeros"]
+pub type U1_PCIE_PCIE_TX_ONESZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u1_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u1_pcie_mperstn"]
     #[inline(always)]
-    pub fn u1_plda_pcie_mperstn(&self) -> U1_PLDA_PCIE_MPERSTN_R {
-        U1_PLDA_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
+    pub fn u1_pcie_mperstn(&self) -> U1_PCIE_MPERSTN_R {
+        U1_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u1_pcie_pcie_ebuf_mode"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_ebuf_mode(&self) -> U1_PLDA_PCIE_PCIE_EBUF_MODE_R {
-        U1_PLDA_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_pcie_pcie_ebuf_mode(&self) -> U1_PCIE_PCIE_EBUF_MODE_R {
+        U1_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:24 - u1_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u1_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_phy_test_cfg(&self) -> U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R {
-        U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
+    pub fn u1_pcie_pcie_phy_test_cfg(&self) -> U1_PCIE_PCIE_PHY_TEST_CFG_R {
+        U1_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
     }
-    #[doc = "Bit 25 - u1_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u1_pcie_pcie_rx_eq_training"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_rx_eq_training(&self) -> U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R {
-        U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u1_pcie_pcie_rx_eq_training(&self) -> U1_PCIE_PCIE_RX_EQ_TRAINING_R {
+        U1_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u1_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u1_pcie_pcie_rxterm_en"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_rxterm_en(&self) -> U1_PLDA_PCIE_PCIE_RXTERM_EN_R {
-        U1_PLDA_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_pcie_pcie_rxterm_en(&self) -> U1_PCIE_PCIE_RXTERM_EN_R {
+        U1_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u1_plda_pcie_pcie_tx_oneszeros"]
+    #[doc = "Bit 27 - u1_pcie_pcie_tx_oneszeros"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_tx_oneszeros(&self) -> U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R {
-        U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u1_pcie_pcie_tx_oneszeros(&self) -> U1_PCIE_PCIE_TX_ONESZEROS_R {
+        U1_PCIE_PCIE_TX_ONESZEROS_R::new(((self.bits >> 27) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u1_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u1_pcie_mperstn"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_mperstn(&mut self) -> U1_PLDA_PCIE_MPERSTN_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_MPERSTN_W::new(self, 0)
+    pub fn u1_pcie_mperstn(&mut self) -> U1_PCIE_MPERSTN_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_MPERSTN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u1_pcie_pcie_ebuf_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_ebuf_mode(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
+    pub fn u1_pcie_pcie_ebuf_mode(&mut self) -> U1_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
     }
-    #[doc = "Bits 2:24 - u1_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u1_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_phy_test_cfg(
+    pub fn u1_pcie_pcie_phy_test_cfg(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
+    ) -> U1_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
     }
-    #[doc = "Bit 25 - u1_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u1_pcie_pcie_rx_eq_training"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_rx_eq_training(
+    pub fn u1_pcie_pcie_rx_eq_training(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
+    ) -> U1_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
     }
-    #[doc = "Bit 26 - u1_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u1_pcie_pcie_rxterm_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_rxterm_en(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
+    pub fn u1_pcie_pcie_rxterm_en(&mut self) -> U1_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
     }
-    #[doc = "Bit 27 - u1_plda_pcie_pcie_tx_oneszeros"]
+    #[doc = "Bit 27 - u1_pcie_pcie_tx_oneszeros"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_tx_oneszeros(
+    pub fn u1_pcie_pcie_tx_oneszeros(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W::new(self, 27)
+    ) -> U1_PCIE_PCIE_TX_ONESZEROS_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_TX_ONESZEROS_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_187.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_187.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_187_SPEC>;
 #[doc = "Register `stg_syscfg_187` writer"]
 pub type W = crate::W<STG_SYSCFG_187_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf0_offset` reader - u1_plda_pcie_pf0_offset"]
-pub type U1_PLDA_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf0_offset` writer - u1_plda_pcie_pf0_offset"]
-pub type U1_PLDA_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf0_offset` reader - u1_pcie_pf0_offset"]
+pub type U1_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf0_offset` writer - u1_pcie_pf0_offset"]
+pub type U1_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf0_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf0_offset(&self) -> U1_PLDA_PCIE_PF0_OFFSET_R {
-        U1_PLDA_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf0_offset(&self) -> U1_PCIE_PF0_OFFSET_R {
+        U1_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf0_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf0_offset(&mut self) -> U1_PLDA_PCIE_PF0_OFFSET_W<STG_SYSCFG_187_SPEC> {
-        U1_PLDA_PCIE_PF0_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf0_offset(&mut self) -> U1_PCIE_PF0_OFFSET_W<STG_SYSCFG_187_SPEC> {
+        U1_PCIE_PF0_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_188.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_188.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_188_SPEC>;
 #[doc = "Register `stg_syscfg_188` writer"]
 pub type W = crate::W<STG_SYSCFG_188_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf1_offset` reader - u1_plda_pcie_pf1_offset"]
-pub type U1_PLDA_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf1_offset` writer - u1_plda_pcie_pf1_offset"]
-pub type U1_PLDA_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf1_offset` reader - u1_pcie_pf1_offset"]
+pub type U1_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf1_offset` writer - u1_pcie_pf1_offset"]
+pub type U1_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf1_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf1_offset(&self) -> U1_PLDA_PCIE_PF1_OFFSET_R {
-        U1_PLDA_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf1_offset(&self) -> U1_PCIE_PF1_OFFSET_R {
+        U1_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf1_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf1_offset(&mut self) -> U1_PLDA_PCIE_PF1_OFFSET_W<STG_SYSCFG_188_SPEC> {
-        U1_PLDA_PCIE_PF1_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf1_offset(&mut self) -> U1_PCIE_PF1_OFFSET_W<STG_SYSCFG_188_SPEC> {
+        U1_PCIE_PF1_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_189.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_189.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_189_SPEC>;
 #[doc = "Register `stg_syscfg_189` writer"]
 pub type W = crate::W<STG_SYSCFG_189_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf2_offset` reader - u1_plda_pcie_pf2_offset"]
-pub type U1_PLDA_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf2_offset` writer - u1_plda_pcie_pf2_offset"]
-pub type U1_PLDA_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf2_offset` reader - u1_pcie_pf2_offset"]
+pub type U1_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf2_offset` writer - u1_pcie_pf2_offset"]
+pub type U1_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf2_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf2_offset(&self) -> U1_PLDA_PCIE_PF2_OFFSET_R {
-        U1_PLDA_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf2_offset(&self) -> U1_PCIE_PF2_OFFSET_R {
+        U1_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf2_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf2_offset(&mut self) -> U1_PLDA_PCIE_PF2_OFFSET_W<STG_SYSCFG_189_SPEC> {
-        U1_PLDA_PCIE_PF2_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf2_offset(&mut self) -> U1_PCIE_PF2_OFFSET_W<STG_SYSCFG_189_SPEC> {
+        U1_PCIE_PF2_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_19.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_19.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_19_SPEC>;
 #[doc = "Register `stg_syscfg_19` writer"]
 pub type W = crate::W<STG_SYSCFG_19_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_63_32` reader - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_63_32` reader - u0_pcie_axi4_mst0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_190.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_190.rs
@@ -2,76 +2,74 @@
 pub type R = crate::R<STG_SYSCFG_190_SPEC>;
 #[doc = "Register `stg_syscfg_190` writer"]
 pub type W = crate::W<STG_SYSCFG_190_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf3_offset` reader - u1_plda_pcie_pf3_offset"]
-pub type U1_PLDA_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf3_offset` writer - u1_plda_pcie_pf3_offset"]
-pub type U1_PLDA_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
-#[doc = "Field `u1_plda_pcie_phy_mode` reader - u1_plda_pcie_phy_mode"]
-pub type U1_PLDA_PCIE_PHY_MODE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_phy_mode` writer - u1_plda_pcie_phy_mode"]
-pub type U1_PLDA_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_pl_clkrem_allow` reader - u1_plda_pcie_pl_clkrem_allow"]
-pub type U1_PLDA_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_clkrem_allow` writer - u1_plda_pcie_pl_clkrem_allow"]
-pub type U1_PLDA_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pl_clkreq_oen` reader - u1_plda_pcie_pl_clkreq_oen"]
-pub type U1_PLDA_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_equ_phase` reader - u1_plda_pcie_pl_equ_phase"]
-pub type U1_PLDA_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_pl_ltssm` reader - u1_plda_pcie_pl_ltssm"]
-pub type U1_PLDA_PCIE_PL_LTSSM_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pf3_offset` reader - u1_pcie_pf3_offset"]
+pub type U1_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf3_offset` writer - u1_pcie_pf3_offset"]
+pub type U1_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_phy_mode` reader - u1_pcie_phy_mode"]
+pub type U1_PCIE_PHY_MODE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_phy_mode` writer - u1_pcie_phy_mode"]
+pub type U1_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_pl_clkrem_allow` reader - u1_pcie_pl_clkrem_allow"]
+pub type U1_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_clkrem_allow` writer - u1_pcie_pl_clkrem_allow"]
+pub type U1_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pl_clkreq_oen` reader - u1_pcie_pl_clkreq_oen"]
+pub type U1_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_equ_phase` reader - u1_pcie_pl_equ_phase"]
+pub type U1_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pl_ltssm` reader - u1_pcie_pl_ltssm"]
+pub type U1_PCIE_PL_LTSSM_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf3_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf3_offset(&self) -> U1_PLDA_PCIE_PF3_OFFSET_R {
-        U1_PLDA_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf3_offset(&self) -> U1_PCIE_PF3_OFFSET_R {
+        U1_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u1_pcie_phy_mode"]
     #[inline(always)]
-    pub fn u1_plda_pcie_phy_mode(&self) -> U1_PLDA_PCIE_PHY_MODE_R {
-        U1_PLDA_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u1_pcie_phy_mode(&self) -> U1_PCIE_PHY_MODE_R {
+        U1_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u1_pcie_pl_clkrem_allow"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_clkrem_allow(&self) -> U1_PLDA_PCIE_PL_CLKREM_ALLOW_R {
-        U1_PLDA_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_pl_clkrem_allow(&self) -> U1_PCIE_PL_CLKREM_ALLOW_R {
+        U1_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u1_plda_pcie_pl_clkreq_oen"]
+    #[doc = "Bit 23 - u1_pcie_pl_clkreq_oen"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_clkreq_oen(&self) -> U1_PLDA_PCIE_PL_CLKREQ_OEN_R {
-        U1_PLDA_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u1_pcie_pl_clkreq_oen(&self) -> U1_PCIE_PL_CLKREQ_OEN_R {
+        U1_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bits 24:25 - u1_plda_pcie_pl_equ_phase"]
+    #[doc = "Bits 24:25 - u1_pcie_pl_equ_phase"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_equ_phase(&self) -> U1_PLDA_PCIE_PL_EQU_PHASE_R {
-        U1_PLDA_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
+    pub fn u1_pcie_pl_equ_phase(&self) -> U1_PCIE_PL_EQU_PHASE_R {
+        U1_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
     }
-    #[doc = "Bits 26:30 - u1_plda_pcie_pl_ltssm"]
+    #[doc = "Bits 26:30 - u1_pcie_pl_ltssm"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_ltssm(&self) -> U1_PLDA_PCIE_PL_LTSSM_R {
-        U1_PLDA_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn u1_pcie_pl_ltssm(&self) -> U1_PCIE_PL_LTSSM_R {
+        U1_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf3_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf3_offset(&mut self) -> U1_PLDA_PCIE_PF3_OFFSET_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PF3_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf3_offset(&mut self) -> U1_PCIE_PF3_OFFSET_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PF3_OFFSET_W::new(self, 0)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u1_pcie_phy_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_phy_mode(&mut self) -> U1_PLDA_PCIE_PHY_MODE_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PHY_MODE_W::new(self, 20)
+    pub fn u1_pcie_phy_mode(&mut self) -> U1_PCIE_PHY_MODE_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PHY_MODE_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u1_pcie_pl_clkrem_allow"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_clkrem_allow(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
+    pub fn u1_pcie_pl_clkrem_allow(&mut self) -> U1_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_191.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_191.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_191_SPEC>;
 #[doc = "Register `stg_syscfg_191` writer"]
 pub type W = crate::W<STG_SYSCFG_191_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_pclk_rate` reader - u1_plda_pcie_pl_pclk_rate"]
-pub type U1_PLDA_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pl_pclk_rate` reader - u1_pcie_pl_pclk_rate"]
+pub type U1_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:4 - u1_plda_pcie_pl_pclk_rate"]
+    #[doc = "Bits 0:4 - u1_pcie_pl_pclk_rate"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_pclk_rate(&self) -> U1_PLDA_PCIE_PL_PCLK_RATE_R {
-        U1_PLDA_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
+    pub fn u1_pcie_pl_pclk_rate(&self) -> U1_PCIE_PL_PCLK_RATE_R {
+        U1_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_192.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_192.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_192_SPEC>;
 #[doc = "Register `stg_syscfg_192` writer"]
 pub type W = crate::W<STG_SYSCFG_192_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_31_0` reader - u1_plda_pcie_pl_sideband_in_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_31_0` writer - u1_plda_pcie_pl_sideband_in_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_31_0` reader - u1_pcie_pl_sideband_in_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_31_0` writer - u1_pcie_pl_sideband_in_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_in_31_0(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_in_31_0(&self) -> U1_PCIE_PL_SIDEBAND_IN_31_0_R {
+        U1_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_in_31_0(
+    pub fn u1_pcie_pl_sideband_in_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W<STG_SYSCFG_192_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_IN_31_0_W<STG_SYSCFG_192_SPEC> {
+        U1_PCIE_PL_SIDEBAND_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_193.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_193.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_193_SPEC>;
 #[doc = "Register `stg_syscfg_193` writer"]
 pub type W = crate::W<STG_SYSCFG_193_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_63_32` reader - u1_plda_pcie_pl_sideband_in_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_63_32` writer - u1_plda_pcie_pl_sideband_in_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_63_32` reader - u1_pcie_pl_sideband_in_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_63_32` writer - u1_pcie_pl_sideband_in_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_in_63_32(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_in_63_32(&self) -> U1_PCIE_PL_SIDEBAND_IN_63_32_R {
+        U1_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_in_63_32(
+    pub fn u1_pcie_pl_sideband_in_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W<STG_SYSCFG_193_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_IN_63_32_W<STG_SYSCFG_193_SPEC> {
+        U1_PCIE_PL_SIDEBAND_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_194.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_194.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_194_SPEC>;
 #[doc = "Register `stg_syscfg_194` writer"]
 pub type W = crate::W<STG_SYSCFG_194_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_31_0` reader - u1_plda_pcie_pl_sideband_out_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_31_0` writer - u1_plda_pcie_pl_sideband_out_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_31_0` reader - u1_pcie_pl_sideband_out_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_31_0` writer - u1_pcie_pl_sideband_out_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_out_31_0(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_out_31_0(&self) -> U1_PCIE_PL_SIDEBAND_OUT_31_0_R {
+        U1_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_out_31_0(
+    pub fn u1_pcie_pl_sideband_out_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W<STG_SYSCFG_194_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_OUT_31_0_W<STG_SYSCFG_194_SPEC> {
+        U1_PCIE_PL_SIDEBAND_OUT_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_195.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_195.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_195_SPEC>;
 #[doc = "Register `stg_syscfg_195` writer"]
 pub type W = crate::W<STG_SYSCFG_195_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_63_32` reader - u1_plda_pcie_pl_sideband_out_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_63_32` writer - u1_plda_pcie_pl_sideband_out_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_63_32` reader - u1_pcie_pl_sideband_out_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_63_32` writer - u1_pcie_pl_sideband_out_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_out_63_32(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_out_63_32(&self) -> U1_PCIE_PL_SIDEBAND_OUT_63_32_R {
+        U1_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_out_63_32(
+    pub fn u1_pcie_pl_sideband_out_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W<STG_SYSCFG_195_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_OUT_63_32_W<STG_SYSCFG_195_SPEC> {
+        U1_PCIE_PL_SIDEBAND_OUT_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_196.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_196.rs
@@ -2,37 +2,37 @@
 pub type R = crate::R<STG_SYSCFG_196_SPEC>;
 #[doc = "Register `stg_syscfg_196` writer"]
 pub type W = crate::W<STG_SYSCFG_196_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_wake_in` reader - u1_plda_pcie_pl_wake_in"]
-pub type U1_PLDA_PCIE_PL_WAKE_IN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_wake_in` writer - u1_plda_pcie_pl_wake_in"]
-pub type U1_PLDA_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pl_wake_oen` reader - u1_plda_pcie_pl_wake_oen"]
-pub type U1_PLDA_PCIE_PL_WAKE_OEN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_rx_standby_o` reader - u1_plda_pcie_rx_standby_o"]
-pub type U1_PLDA_PCIE_RX_STANDBY_O_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_wake_in` reader - u1_pcie_pl_wake_in"]
+pub type U1_PCIE_PL_WAKE_IN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_wake_in` writer - u1_pcie_pl_wake_in"]
+pub type U1_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pl_wake_oen` reader - u1_pcie_pl_wake_oen"]
+pub type U1_PCIE_PL_WAKE_OEN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_rx_standby_o` reader - u1_pcie_rx_standby_o"]
+pub type U1_PCIE_RX_STANDBY_O_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u1_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u1_pcie_pl_wake_in"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_wake_in(&self) -> U1_PLDA_PCIE_PL_WAKE_IN_R {
-        U1_PLDA_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
+    pub fn u1_pcie_pl_wake_in(&self) -> U1_PCIE_PL_WAKE_IN_R {
+        U1_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pl_wake_oen"]
+    #[doc = "Bit 1 - u1_pcie_pl_wake_oen"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_wake_oen(&self) -> U1_PLDA_PCIE_PL_WAKE_OEN_R {
-        U1_PLDA_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_pcie_pl_wake_oen(&self) -> U1_PCIE_PL_WAKE_OEN_R {
+        U1_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u1_plda_pcie_rx_standby_o"]
+    #[doc = "Bit 2 - u1_pcie_rx_standby_o"]
     #[inline(always)]
-    pub fn u1_plda_pcie_rx_standby_o(&self) -> U1_PLDA_PCIE_RX_STANDBY_O_R {
-        U1_PLDA_PCIE_RX_STANDBY_O_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_pcie_rx_standby_o(&self) -> U1_PCIE_RX_STANDBY_O_R {
+        U1_PCIE_RX_STANDBY_O_R::new(((self.bits >> 2) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u1_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u1_pcie_pl_wake_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_wake_in(&mut self) -> U1_PLDA_PCIE_PL_WAKE_IN_W<STG_SYSCFG_196_SPEC> {
-        U1_PLDA_PCIE_PL_WAKE_IN_W::new(self, 0)
+    pub fn u1_pcie_pl_wake_in(&mut self) -> U1_PCIE_PL_WAKE_IN_W<STG_SYSCFG_196_SPEC> {
+        U1_PCIE_PL_WAKE_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_197.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_197.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_197_SPEC>;
 #[doc = "Register `stg_syscfg_197` writer"]
 pub type W = crate::W<STG_SYSCFG_197_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_in_31_0` reader - u1_plda_pcie_test_in_31_0"]
-pub type U1_PLDA_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_in_31_0` writer - u1_plda_pcie_test_in_31_0"]
-pub type U1_PLDA_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_in_31_0` reader - u1_pcie_test_in_31_0"]
+pub type U1_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_in_31_0` writer - u1_pcie_test_in_31_0"]
+pub type U1_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_in_31_0(&self) -> U1_PLDA_PCIE_TEST_IN_31_0_R {
-        U1_PLDA_PCIE_TEST_IN_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_in_31_0(&self) -> U1_PCIE_TEST_IN_31_0_R {
+        U1_PCIE_TEST_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_in_31_0(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TEST_IN_31_0_W<STG_SYSCFG_197_SPEC> {
-        U1_PLDA_PCIE_TEST_IN_31_0_W::new(self, 0)
+    pub fn u1_pcie_test_in_31_0(&mut self) -> U1_PCIE_TEST_IN_31_0_W<STG_SYSCFG_197_SPEC> {
+        U1_PCIE_TEST_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_198.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_198.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_198_SPEC>;
 #[doc = "Register `stg_syscfg_198` writer"]
 pub type W = crate::W<STG_SYSCFG_198_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_in_63_32` reader - u1_plda_pcie_test_in_63_32"]
-pub type U1_PLDA_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_in_63_32` writer - u1_plda_pcie_test_in_63_32"]
-pub type U1_PLDA_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_in_63_32` reader - u1_pcie_test_in_63_32"]
+pub type U1_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_in_63_32` writer - u1_pcie_test_in_63_32"]
+pub type U1_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_in_63_32(&self) -> U1_PLDA_PCIE_TEST_IN_63_32_R {
-        U1_PLDA_PCIE_TEST_IN_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_in_63_32(&self) -> U1_PCIE_TEST_IN_63_32_R {
+        U1_PCIE_TEST_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_in_63_32(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TEST_IN_63_32_W<STG_SYSCFG_198_SPEC> {
-        U1_PLDA_PCIE_TEST_IN_63_32_W::new(self, 0)
+    pub fn u1_pcie_test_in_63_32(&mut self) -> U1_PCIE_TEST_IN_63_32_W<STG_SYSCFG_198_SPEC> {
+        U1_PCIE_TEST_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_199.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_199.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_199_SPEC>;
 #[doc = "Register `stg_syscfg_199` writer"]
 pub type W = crate::W<STG_SYSCFG_199_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_31_0` reader - u1_plda_pcie_test_out_bridge_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_31_0` writer - u1_plda_pcie_test_out_bridge_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_31_0` reader - u1_pcie_test_out_bridge_31_0"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_31_0` writer - u1_pcie_test_out_bridge_31_0"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_31_0(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_31_0(&self) -> U1_PCIE_TEST_OUT_BRIDGE_31_0_R {
+        U1_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_31_0(
+    pub fn u1_pcie_test_out_bridge_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W<STG_SYSCFG_199_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_31_0_W<STG_SYSCFG_199_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_2.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_2.rs
@@ -2,318 +2,312 @@
 pub type R = crate::R<STG_SYSCFG_2_SPEC>;
 #[doc = "Register `stg_syscfg_2` writer"]
 pub type W = crate::W<STG_SYSCFG_2_SPEC>;
-#[doc = "Field `u0_cdn_usb_rx_dp` reader - u0_cdn_usb_rx_dp"]
-pub type U0_CDN_USB_RX_DP_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rx_rcv` reader - u0_cdn_usb_rx_rcv"]
-pub type U0_CDN_USB_RX_RCV_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_self_test` reader - For software bist_test"]
-pub type U0_CDN_USB_SELF_TEST_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_self_test` writer - For software bist_test"]
-pub type U0_CDN_USB_SELF_TEST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_sessend` reader - u0_cdn_usb_sessend"]
-pub type U0_CDN_USB_SESSEND_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_sessvalid` reader - u0_cdn_usb_sessvalid"]
-pub type U0_CDN_USB_SESSVALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_sof` reader - u0_cdn_usb_sof"]
-pub type U0_CDN_USB_SOF_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_test_bist` reader - For software bist_test"]
-pub type U0_CDN_USB_TEST_BIST_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_ack` reader - u0_cdn_usb_usbdev_main_power_off_ack"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_ready` reader - u0_cdn_usb_usbdev_main_power_off_ready"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_req` reader - u0_cdn_usb_usbdev_main_power_off_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_req` writer - u0_cdn_usb_usbdev_main_power_off_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_ready` reader - u0_cdn_usb_usbdev_main_power_on_ready"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_req` reader - u0_cdn_usb_usbdev_main_power_on_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_valid` reader - u0_cdn_usb_usbdev_main_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_valid` writer - u0_cdn_usb_usbdev_main_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_ack` reader - u0_cdn_usb_usbdev_power_off_ack"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_ready` reader - u0_cdn_usb_usbdev_power_off_ready"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_req` reader - u0_cdn_usb_usbdev_power_off_req"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_req` writer - u0_cdn_usb_usbdev_power_off_req"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_ready` reader - u0_cdn_usb_usbdev_power_on_ready"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_req` reader - u0_cdn_usb_usbdev_power_on_req"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_valid` reader - u0_cdn_usb_usbdev_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_valid` writer - u0_cdn_usb_usbdev_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_dmpulldown_sit` reader - u0_cdn_usb_utmi_dmpulldown_sit"]
-pub type U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_dmpulldown_sit` writer - u0_cdn_usb_utmi_dmpulldown_sit"]
-pub type U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_dppulldown_sit` reader - u0_cdn_usb_utmi_dppulldown_sit"]
-pub type U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_dppulldown_sit` writer - u0_cdn_usb_utmi_dppulldown_sit"]
-pub type U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_fslsserialmode_sit` reader - u0_cdn_usb_utmi_fslsserialmode_sit"]
-pub type U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_fslsserialmode_sit` writer - u0_cdn_usb_utmi_fslsserialmode_sit"]
-pub type U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_hostdisconnect_sit` reader - u0_cdn_usb_utmi_hostdisconnect_sit"]
-pub type U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_iddig_sit` reader - u0_cdn_usb_utmi_iddig_sit"]
-pub type U0_CDN_USB_UTMI_IDDIG_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_idpullup_sit` reader - u0_cdn_usb_utmi_idpullup_sit"]
-pub type U0_CDN_USB_UTMI_IDPULLUP_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_idpullup_sit` writer - u0_cdn_usb_utmi_idpullup_sit"]
-pub type U0_CDN_USB_UTMI_IDPULLUP_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_linestate_sit` reader - u0_cdn_usb_utmi_linestate_sit"]
-pub type U0_CDN_USB_UTMI_LINESTATE_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_opmode_sit` reader - u0_cdn_usb_utmi_opmode_sit"]
-pub type U0_CDN_USB_UTMI_OPMODE_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_opmode_sit` writer - u0_cdn_usb_utmi_opmode_sit"]
-pub type U0_CDN_USB_UTMI_OPMODE_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_cdn_usb_utmi_rxactive_sit` reader - u0_cdn_usb_utmi_rxactive_sit"]
-pub type U0_CDN_USB_UTMI_RXACTIVE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_rxerror_sit` reader - u0_cdn_usb_utmi_rxerror_sit"]
-pub type U0_CDN_USB_UTMI_RXERROR_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_rxvalid_sit` reader - u0_cdn_usb_utmi_rxvalid_sit"]
-pub type U0_CDN_USB_UTMI_RXVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_dp` reader - u0_usb_rx_dp"]
+pub type U0_USB_RX_DP_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_rcv` reader - u0_usb_rx_rcv"]
+pub type U0_USB_RX_RCV_R = crate::BitReader;
+#[doc = "Field `u0_usb_self_test` reader - For software bist_test"]
+pub type U0_USB_SELF_TEST_R = crate::BitReader;
+#[doc = "Field `u0_usb_self_test` writer - For software bist_test"]
+pub type U0_USB_SELF_TEST_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_sessend` reader - u0_usb_sessend"]
+pub type U0_USB_SESSEND_R = crate::BitReader;
+#[doc = "Field `u0_usb_sessvalid` reader - u0_usb_sessvalid"]
+pub type U0_USB_SESSVALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_sof` reader - u0_usb_sof"]
+pub type U0_USB_SOF_R = crate::BitReader;
+#[doc = "Field `u0_usb_test_bist` reader - For software bist_test"]
+pub type U0_USB_TEST_BIST_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_ack` reader - u0_usb_usbdev_main_power_off_ack"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_ready` reader - u0_usb_usbdev_main_power_off_ready"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_req` reader - u0_usb_usbdev_main_power_off_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_req` writer - u0_usb_usbdev_main_power_off_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_main_power_on_ready` reader - u0_usb_usbdev_main_power_on_ready"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_req` reader - u0_usb_usbdev_main_power_on_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_valid` reader - u0_usb_usbdev_main_power_on_valid"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_valid` writer - u0_usb_usbdev_main_power_on_valid"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_power_off_ack` reader - u0_usb_usbdev_power_off_ack"]
+pub type U0_USB_USBDEV_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_ready` reader - u0_usb_usbdev_power_off_ready"]
+pub type U0_USB_USBDEV_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_req` reader - u0_usb_usbdev_power_off_req"]
+pub type U0_USB_USBDEV_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_req` writer - u0_usb_usbdev_power_off_req"]
+pub type U0_USB_USBDEV_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_power_on_ready` reader - u0_usb_usbdev_power_on_ready"]
+pub type U0_USB_USBDEV_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_req` reader - u0_usb_usbdev_power_on_req"]
+pub type U0_USB_USBDEV_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_valid` reader - u0_usb_usbdev_power_on_valid"]
+pub type U0_USB_USBDEV_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_valid` writer - u0_usb_usbdev_power_on_valid"]
+pub type U0_USB_USBDEV_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_dmpulldown_sit` reader - u0_usb_utmi_dmpulldown_sit"]
+pub type U0_USB_UTMI_DMPULLDOWN_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_dmpulldown_sit` writer - u0_usb_utmi_dmpulldown_sit"]
+pub type U0_USB_UTMI_DMPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_dppulldown_sit` reader - u0_usb_utmi_dppulldown_sit"]
+pub type U0_USB_UTMI_DPPULLDOWN_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_dppulldown_sit` writer - u0_usb_utmi_dppulldown_sit"]
+pub type U0_USB_UTMI_DPPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_fslsserialmode_sit` reader - u0_usb_utmi_fslsserialmode_sit"]
+pub type U0_USB_UTMI_FSLSSERIALMODE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_fslsserialmode_sit` writer - u0_usb_utmi_fslsserialmode_sit"]
+pub type U0_USB_UTMI_FSLSSERIALMODE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_hostdisconnect_sit` reader - u0_usb_utmi_hostdisconnect_sit"]
+pub type U0_USB_UTMI_HOSTDISCONNECT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_iddig_sit` reader - u0_usb_utmi_iddig_sit"]
+pub type U0_USB_UTMI_IDDIG_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_idpullup_sit` reader - u0_usb_utmi_idpullup_sit"]
+pub type U0_USB_UTMI_IDPULLUP_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_idpullup_sit` writer - u0_usb_utmi_idpullup_sit"]
+pub type U0_USB_UTMI_IDPULLUP_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_linestate_sit` reader - u0_usb_utmi_linestate_sit"]
+pub type U0_USB_UTMI_LINESTATE_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_opmode_sit` reader - u0_usb_utmi_opmode_sit"]
+pub type U0_USB_UTMI_OPMODE_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_opmode_sit` writer - u0_usb_utmi_opmode_sit"]
+pub type U0_USB_UTMI_OPMODE_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_usb_utmi_rxactive_sit` reader - u0_usb_utmi_rxactive_sit"]
+pub type U0_USB_UTMI_RXACTIVE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_rxerror_sit` reader - u0_usb_utmi_rxerror_sit"]
+pub type U0_USB_UTMI_RXERROR_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_rxvalid_sit` reader - u0_usb_utmi_rxvalid_sit"]
+pub type U0_USB_UTMI_RXVALID_SIT_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_cdn_usb_rx_dp"]
+    #[doc = "Bit 0 - u0_usb_rx_dp"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_dp(&self) -> U0_CDN_USB_RX_DP_R {
-        U0_CDN_USB_RX_DP_R::new((self.bits & 1) != 0)
+    pub fn u0_usb_rx_dp(&self) -> U0_USB_RX_DP_R {
+        U0_USB_RX_DP_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_cdn_usb_rx_rcv"]
+    #[doc = "Bit 1 - u0_usb_rx_rcv"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_rcv(&self) -> U0_CDN_USB_RX_RCV_R {
-        U0_CDN_USB_RX_RCV_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_usb_rx_rcv(&self) -> U0_USB_RX_RCV_R {
+        U0_USB_RX_RCV_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - For software bist_test"]
     #[inline(always)]
-    pub fn u0_cdn_usb_self_test(&self) -> U0_CDN_USB_SELF_TEST_R {
-        U0_CDN_USB_SELF_TEST_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_usb_self_test(&self) -> U0_USB_SELF_TEST_R {
+        U0_USB_SELF_TEST_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_sessend"]
+    #[doc = "Bit 3 - u0_usb_sessend"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sessend(&self) -> U0_CDN_USB_SESSEND_R {
-        U0_CDN_USB_SESSEND_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_usb_sessend(&self) -> U0_USB_SESSEND_R {
+        U0_USB_SESSEND_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_sessvalid"]
+    #[doc = "Bit 4 - u0_usb_sessvalid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sessvalid(&self) -> U0_CDN_USB_SESSVALID_R {
-        U0_CDN_USB_SESSVALID_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_usb_sessvalid(&self) -> U0_USB_SESSVALID_R {
+        U0_USB_SESSVALID_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_sof"]
+    #[doc = "Bit 5 - u0_usb_sof"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sof(&self) -> U0_CDN_USB_SOF_R {
-        U0_CDN_USB_SOF_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_sof(&self) -> U0_USB_SOF_R {
+        U0_USB_SOF_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - For software bist_test"]
     #[inline(always)]
-    pub fn u0_cdn_usb_test_bist(&self) -> U0_CDN_USB_TEST_BIST_R {
-        U0_CDN_USB_TEST_BIST_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_test_bist(&self) -> U0_USB_TEST_BIST_R {
+        U0_USB_TEST_BIST_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_usbdev_main_power_off_ack"]
+    #[doc = "Bit 7 - u0_usb_usbdev_main_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_ack(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_ack(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_usbdev_main_power_off_ready"]
+    #[doc = "Bit 8 - u0_usb_usbdev_main_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_ready(
-        &self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_ready(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_READY_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_READY_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_usbdev_main_power_off_req"]
+    #[doc = "Bit 9 - u0_usb_usbdev_main_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_req(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_req(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_usbdev_main_power_on_ready"]
+    #[doc = "Bit 10 - u0_usb_usbdev_main_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_ready(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_ready(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_READY_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_READY_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_usbdev_main_power_on_req"]
+    #[doc = "Bit 11 - u0_usb_usbdev_main_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_req(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_req(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_REQ_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_REQ_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_usbdev_main_power_on_valid"]
+    #[doc = "Bit 12 - u0_usb_usbdev_main_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_valid(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_valid(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_VALID_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_VALID_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_usbdev_power_off_ack"]
+    #[doc = "Bit 13 - u0_usb_usbdev_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_ack(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_ACK_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_ACK_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_ack(&self) -> U0_USB_USBDEV_POWER_OFF_ACK_R {
+        U0_USB_USBDEV_POWER_OFF_ACK_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_usbdev_power_off_ready"]
+    #[doc = "Bit 14 - u0_usb_usbdev_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_ready(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_READY_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_READY_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_ready(&self) -> U0_USB_USBDEV_POWER_OFF_READY_R {
+        U0_USB_USBDEV_POWER_OFF_READY_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_usbdev_power_off_req"]
+    #[doc = "Bit 15 - u0_usb_usbdev_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_req(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_REQ_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_REQ_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_req(&self) -> U0_USB_USBDEV_POWER_OFF_REQ_R {
+        U0_USB_USBDEV_POWER_OFF_REQ_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_usbdev_power_on_ready"]
+    #[doc = "Bit 16 - u0_usb_usbdev_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_ready(&self) -> U0_CDN_USB_USBDEV_POWER_ON_READY_R {
-        U0_CDN_USB_USBDEV_POWER_ON_READY_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_ready(&self) -> U0_USB_USBDEV_POWER_ON_READY_R {
+        U0_USB_USBDEV_POWER_ON_READY_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_usbdev_power_on_req"]
+    #[doc = "Bit 17 - u0_usb_usbdev_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_req(&self) -> U0_CDN_USB_USBDEV_POWER_ON_REQ_R {
-        U0_CDN_USB_USBDEV_POWER_ON_REQ_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_req(&self) -> U0_USB_USBDEV_POWER_ON_REQ_R {
+        U0_USB_USBDEV_POWER_ON_REQ_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_usbdev_power_on_valid"]
+    #[doc = "Bit 18 - u0_usb_usbdev_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_valid(&self) -> U0_CDN_USB_USBDEV_POWER_ON_VALID_R {
-        U0_CDN_USB_USBDEV_POWER_ON_VALID_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_valid(&self) -> U0_USB_USBDEV_POWER_ON_VALID_R {
+        U0_USB_USBDEV_POWER_ON_VALID_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_utmi_dmpulldown_sit"]
+    #[doc = "Bit 19 - u0_usb_utmi_dmpulldown_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_dmpulldown_sit(&self) -> U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R {
-        U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_utmi_dmpulldown_sit(&self) -> U0_USB_UTMI_DMPULLDOWN_SIT_R {
+        U0_USB_UTMI_DMPULLDOWN_SIT_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_utmi_dppulldown_sit"]
+    #[doc = "Bit 20 - u0_usb_utmi_dppulldown_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_dppulldown_sit(&self) -> U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R {
-        U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_utmi_dppulldown_sit(&self) -> U0_USB_UTMI_DPPULLDOWN_SIT_R {
+        U0_USB_UTMI_DPPULLDOWN_SIT_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_utmi_fslsserialmode_sit"]
+    #[doc = "Bit 21 - u0_usb_utmi_fslsserialmode_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_fslsserialmode_sit(&self) -> U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R {
-        U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_utmi_fslsserialmode_sit(&self) -> U0_USB_UTMI_FSLSSERIALMODE_SIT_R {
+        U0_USB_UTMI_FSLSSERIALMODE_SIT_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_utmi_hostdisconnect_sit"]
+    #[doc = "Bit 22 - u0_usb_utmi_hostdisconnect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_hostdisconnect_sit(&self) -> U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R {
-        U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_utmi_hostdisconnect_sit(&self) -> U0_USB_UTMI_HOSTDISCONNECT_SIT_R {
+        U0_USB_UTMI_HOSTDISCONNECT_SIT_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_utmi_iddig_sit"]
+    #[doc = "Bit 23 - u0_usb_utmi_iddig_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_iddig_sit(&self) -> U0_CDN_USB_UTMI_IDDIG_SIT_R {
-        U0_CDN_USB_UTMI_IDDIG_SIT_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_utmi_iddig_sit(&self) -> U0_USB_UTMI_IDDIG_SIT_R {
+        U0_USB_UTMI_IDDIG_SIT_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_utmi_idpullup_sit"]
+    #[doc = "Bit 24 - u0_usb_utmi_idpullup_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_idpullup_sit(&self) -> U0_CDN_USB_UTMI_IDPULLUP_SIT_R {
-        U0_CDN_USB_UTMI_IDPULLUP_SIT_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_usb_utmi_idpullup_sit(&self) -> U0_USB_UTMI_IDPULLUP_SIT_R {
+        U0_USB_UTMI_IDPULLUP_SIT_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bits 25:26 - u0_cdn_usb_utmi_linestate_sit"]
+    #[doc = "Bits 25:26 - u0_usb_utmi_linestate_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_linestate_sit(&self) -> U0_CDN_USB_UTMI_LINESTATE_SIT_R {
-        U0_CDN_USB_UTMI_LINESTATE_SIT_R::new(((self.bits >> 25) & 3) as u8)
+    pub fn u0_usb_utmi_linestate_sit(&self) -> U0_USB_UTMI_LINESTATE_SIT_R {
+        U0_USB_UTMI_LINESTATE_SIT_R::new(((self.bits >> 25) & 3) as u8)
     }
-    #[doc = "Bits 27:28 - u0_cdn_usb_utmi_opmode_sit"]
+    #[doc = "Bits 27:28 - u0_usb_utmi_opmode_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_opmode_sit(&self) -> U0_CDN_USB_UTMI_OPMODE_SIT_R {
-        U0_CDN_USB_UTMI_OPMODE_SIT_R::new(((self.bits >> 27) & 3) as u8)
+    pub fn u0_usb_utmi_opmode_sit(&self) -> U0_USB_UTMI_OPMODE_SIT_R {
+        U0_USB_UTMI_OPMODE_SIT_R::new(((self.bits >> 27) & 3) as u8)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_utmi_rxactive_sit"]
+    #[doc = "Bit 29 - u0_usb_utmi_rxactive_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxactive_sit(&self) -> U0_CDN_USB_UTMI_RXACTIVE_SIT_R {
-        U0_CDN_USB_UTMI_RXACTIVE_SIT_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_utmi_rxactive_sit(&self) -> U0_USB_UTMI_RXACTIVE_SIT_R {
+        U0_USB_UTMI_RXACTIVE_SIT_R::new(((self.bits >> 29) & 1) != 0)
     }
-    #[doc = "Bit 30 - u0_cdn_usb_utmi_rxerror_sit"]
+    #[doc = "Bit 30 - u0_usb_utmi_rxerror_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxerror_sit(&self) -> U0_CDN_USB_UTMI_RXERROR_SIT_R {
-        U0_CDN_USB_UTMI_RXERROR_SIT_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_usb_utmi_rxerror_sit(&self) -> U0_USB_UTMI_RXERROR_SIT_R {
+        U0_USB_UTMI_RXERROR_SIT_R::new(((self.bits >> 30) & 1) != 0)
     }
-    #[doc = "Bit 31 - u0_cdn_usb_utmi_rxvalid_sit"]
+    #[doc = "Bit 31 - u0_usb_utmi_rxvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxvalid_sit(&self) -> U0_CDN_USB_UTMI_RXVALID_SIT_R {
-        U0_CDN_USB_UTMI_RXVALID_SIT_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_usb_utmi_rxvalid_sit(&self) -> U0_USB_UTMI_RXVALID_SIT_R {
+        U0_USB_UTMI_RXVALID_SIT_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 2 - For software bist_test"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_self_test(&mut self) -> U0_CDN_USB_SELF_TEST_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_SELF_TEST_W::new(self, 2)
+    pub fn u0_usb_self_test(&mut self) -> U0_USB_SELF_TEST_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_SELF_TEST_W::new(self, 2)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_usbdev_main_power_off_req"]
+    #[doc = "Bit 9 - u0_usb_usbdev_main_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_main_power_off_req(
+    pub fn u0_usb_usbdev_main_power_off_req(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W::new(self, 9)
+    ) -> U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W::new(self, 9)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_usbdev_main_power_on_valid"]
+    #[doc = "Bit 12 - u0_usb_usbdev_main_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_main_power_on_valid(
+    pub fn u0_usb_usbdev_main_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W::new(self, 12)
+    ) -> U0_USB_USBDEV_MAIN_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_MAIN_POWER_ON_VALID_W::new(self, 12)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_usbdev_power_off_req"]
+    #[doc = "Bit 15 - u0_usb_usbdev_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_power_off_req(
+    pub fn u0_usb_usbdev_power_off_req(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_POWER_OFF_REQ_W::new(self, 15)
+    ) -> U0_USB_USBDEV_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_POWER_OFF_REQ_W::new(self, 15)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_usbdev_power_on_valid"]
+    #[doc = "Bit 18 - u0_usb_usbdev_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_power_on_valid(
+    pub fn u0_usb_usbdev_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_POWER_ON_VALID_W::new(self, 18)
+    ) -> U0_USB_USBDEV_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_POWER_ON_VALID_W::new(self, 18)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_utmi_dmpulldown_sit"]
+    #[doc = "Bit 19 - u0_usb_utmi_dmpulldown_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_dmpulldown_sit(
+    pub fn u0_usb_utmi_dmpulldown_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W::new(self, 19)
+    ) -> U0_USB_UTMI_DMPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_DMPULLDOWN_SIT_W::new(self, 19)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_utmi_dppulldown_sit"]
+    #[doc = "Bit 20 - u0_usb_utmi_dppulldown_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_dppulldown_sit(
+    pub fn u0_usb_utmi_dppulldown_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W::new(self, 20)
+    ) -> U0_USB_UTMI_DPPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_DPPULLDOWN_SIT_W::new(self, 20)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_utmi_fslsserialmode_sit"]
+    #[doc = "Bit 21 - u0_usb_utmi_fslsserialmode_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_fslsserialmode_sit(
+    pub fn u0_usb_utmi_fslsserialmode_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W::new(self, 21)
+    ) -> U0_USB_UTMI_FSLSSERIALMODE_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_FSLSSERIALMODE_SIT_W::new(self, 21)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_utmi_idpullup_sit"]
+    #[doc = "Bit 24 - u0_usb_utmi_idpullup_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_idpullup_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_IDPULLUP_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_IDPULLUP_SIT_W::new(self, 24)
+    pub fn u0_usb_utmi_idpullup_sit(&mut self) -> U0_USB_UTMI_IDPULLUP_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_IDPULLUP_SIT_W::new(self, 24)
     }
-    #[doc = "Bits 27:28 - u0_cdn_usb_utmi_opmode_sit"]
+    #[doc = "Bits 27:28 - u0_usb_utmi_opmode_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_opmode_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_OPMODE_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_OPMODE_SIT_W::new(self, 27)
+    pub fn u0_usb_utmi_opmode_sit(&mut self) -> U0_USB_UTMI_OPMODE_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_OPMODE_SIT_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_20.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_20.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_20_SPEC>;
 #[doc = "Register `stg_syscfg_20` writer"]
 pub type W = crate::W<STG_SYSCFG_20_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_95_64` reader - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_95_64` reader - u0_pcie_axi4_mst0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_200.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_200.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_200_SPEC>;
 #[doc = "Register `stg_syscfg_200` writer"]
 pub type W = crate::W<STG_SYSCFG_200_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_63_32` reader - u1_plda_pcie_test_out_bridge_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_63_32` writer - u1_plda_pcie_test_out_bridge_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_63_32` reader - u1_pcie_test_out_bridge_63_32"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_63_32` writer - u1_pcie_test_out_bridge_63_32"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_63_32(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_63_32(&self) -> U1_PCIE_TEST_OUT_BRIDGE_63_32_R {
+        U1_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_63_32(
+    pub fn u1_pcie_test_out_bridge_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W<STG_SYSCFG_200_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_63_32_W<STG_SYSCFG_200_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_201.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_201.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_201_SPEC>;
 #[doc = "Register `stg_syscfg_201` writer"]
 pub type W = crate::W<STG_SYSCFG_201_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_95_64` reader - u1_plda_pcie_test_out_bridge_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_95_64` writer - u1_plda_pcie_test_out_bridge_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_95_64` reader - u1_pcie_test_out_bridge_95_64"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_95_64` writer - u1_pcie_test_out_bridge_95_64"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_95_64(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_95_64(&self) -> U1_PCIE_TEST_OUT_BRIDGE_95_64_R {
+        U1_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_95_64(
+    pub fn u1_pcie_test_out_bridge_95_64(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W<STG_SYSCFG_201_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_95_64_W<STG_SYSCFG_201_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_202.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_202.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_202_SPEC>;
 #[doc = "Register `stg_syscfg_202` writer"]
 pub type W = crate::W<STG_SYSCFG_202_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_127_96` reader - u1_plda_pcie_test_out_bridge_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_127_96` writer - u1_plda_pcie_test_out_bridge_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_127_96` reader - u1_pcie_test_out_bridge_127_96"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_127_96` writer - u1_pcie_test_out_bridge_127_96"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_127_96(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_127_96(&self) -> U1_PCIE_TEST_OUT_BRIDGE_127_96_R {
+        U1_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_127_96(
+    pub fn u1_pcie_test_out_bridge_127_96(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W<STG_SYSCFG_202_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_127_96_W<STG_SYSCFG_202_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_203.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_203.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_203_SPEC>;
 #[doc = "Register `stg_syscfg_203` writer"]
 pub type W = crate::W<STG_SYSCFG_203_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_159_128` reader - u1_plda_pcie_test_out_bridge_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_159_128` writer - u1_plda_pcie_test_out_bridge_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_159_128` reader - u1_pcie_test_out_bridge_159_128"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_159_128` writer - u1_pcie_test_out_bridge_159_128"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_159_128(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_159_128(&self) -> U1_PCIE_TEST_OUT_BRIDGE_159_128_R {
+        U1_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_159_128(
+    pub fn u1_pcie_test_out_bridge_159_128(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W<STG_SYSCFG_203_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_159_128_W<STG_SYSCFG_203_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_204.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_204.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_204_SPEC>;
 #[doc = "Register `stg_syscfg_204` writer"]
 pub type W = crate::W<STG_SYSCFG_204_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_191_160` reader - u1_plda_pcie_test_out_bridge_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_191_160` writer - u1_plda_pcie_test_out_bridge_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_191_160` reader - u1_pcie_test_out_bridge_191_160"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_191_160` writer - u1_pcie_test_out_bridge_191_160"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_191_160(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_191_160(&self) -> U1_PCIE_TEST_OUT_BRIDGE_191_160_R {
+        U1_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_191_160(
+    pub fn u1_pcie_test_out_bridge_191_160(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W<STG_SYSCFG_204_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_191_160_W<STG_SYSCFG_204_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_205.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_205.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_205_SPEC>;
 #[doc = "Register `stg_syscfg_205` writer"]
 pub type W = crate::W<STG_SYSCFG_205_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_223_192` reader - u1_plda_pcie_test_out_bridge_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_223_192` writer - u1_plda_pcie_test_out_bridge_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_223_192` reader - u1_pcie_test_out_bridge_223_192"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_223_192` writer - u1_pcie_test_out_bridge_223_192"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_223_192(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_223_192(&self) -> U1_PCIE_TEST_OUT_BRIDGE_223_192_R {
+        U1_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_223_192(
+    pub fn u1_pcie_test_out_bridge_223_192(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W<STG_SYSCFG_205_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_223_192_W<STG_SYSCFG_205_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_206.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_206.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_206_SPEC>;
 #[doc = "Register `stg_syscfg_206` writer"]
 pub type W = crate::W<STG_SYSCFG_206_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_255_224` reader - u1_plda_pcie_test_out_bridge_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_255_224` writer - u1_plda_pcie_test_out_bridge_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_255_224` reader - u1_pcie_test_out_bridge_255_224"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_255_224` writer - u1_pcie_test_out_bridge_255_224"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_255_224(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_255_224(&self) -> U1_PCIE_TEST_OUT_BRIDGE_255_224_R {
+        U1_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_255_224(
+    pub fn u1_pcie_test_out_bridge_255_224(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W<STG_SYSCFG_206_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_255_224_W<STG_SYSCFG_206_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_207.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_207.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_207_SPEC>;
 #[doc = "Register `stg_syscfg_207` writer"]
 pub type W = crate::W<STG_SYSCFG_207_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_287_256` reader - u1_plda_pcie_test_out_bridge_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_287_256` writer - u1_plda_pcie_test_out_bridge_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_287_256` reader - u1_pcie_test_out_bridge_287_256"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_287_256` writer - u1_pcie_test_out_bridge_287_256"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_287_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_287_256(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_287_256(&self) -> U1_PCIE_TEST_OUT_BRIDGE_287_256_R {
+        U1_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_287_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_287_256(
+    pub fn u1_pcie_test_out_bridge_287_256(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W<STG_SYSCFG_207_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_287_256_W<STG_SYSCFG_207_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_287_256_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_208.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_208.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_208_SPEC>;
 #[doc = "Register `stg_syscfg_208` writer"]
 pub type W = crate::W<STG_SYSCFG_208_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_319_288` reader - u1_plda_pcie_test_out_bridge_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_319_288` writer - u1_plda_pcie_test_out_bridge_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_319_288` reader - u1_pcie_test_out_bridge_319_288"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_319_288` writer - u1_pcie_test_out_bridge_319_288"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_319_288"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_319_288(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_319_288(&self) -> U1_PCIE_TEST_OUT_BRIDGE_319_288_R {
+        U1_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_319_288"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_319_288(
+    pub fn u1_pcie_test_out_bridge_319_288(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W<STG_SYSCFG_208_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_319_288_W<STG_SYSCFG_208_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_319_288_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_209.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_209.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_209_SPEC>;
 #[doc = "Register `stg_syscfg_209` writer"]
 pub type W = crate::W<STG_SYSCFG_209_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_351_320` reader - u1_plda_pcie_test_out_bridge_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_351_320` writer - u1_plda_pcie_test_out_bridge_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_351_320` reader - u1_pcie_test_out_bridge_351_320"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_351_320` writer - u1_pcie_test_out_bridge_351_320"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_351_320"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_351_320(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_351_320(&self) -> U1_PCIE_TEST_OUT_BRIDGE_351_320_R {
+        U1_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_351_320"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_351_320(
+    pub fn u1_pcie_test_out_bridge_351_320(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W<STG_SYSCFG_209_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_351_320_W<STG_SYSCFG_209_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_351_320_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_21.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_21.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_21_SPEC>;
 #[doc = "Register `stg_syscfg_21` writer"]
 pub type W = crate::W<STG_SYSCFG_21_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_127_96` reader - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_127_96` reader - u0_pcie_axi4_mst0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_127_96(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_210.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_210.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_210_SPEC>;
 #[doc = "Register `stg_syscfg_210` writer"]
 pub type W = crate::W<STG_SYSCFG_210_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_383_352` reader - u1_plda_pcie_test_out_bridge_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_383_352` writer - u1_plda_pcie_test_out_bridge_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_383_352` reader - u1_pcie_test_out_bridge_383_352"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_383_352` writer - u1_pcie_test_out_bridge_383_352"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_383_352"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_383_352(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_383_352(&self) -> U1_PCIE_TEST_OUT_BRIDGE_383_352_R {
+        U1_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_383_352"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_383_352(
+    pub fn u1_pcie_test_out_bridge_383_352(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W<STG_SYSCFG_210_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_383_352_W<STG_SYSCFG_210_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_383_352_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_211.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_211.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_211_SPEC>;
 #[doc = "Register `stg_syscfg_211` writer"]
 pub type W = crate::W<STG_SYSCFG_211_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_415_384` reader - u1_plda_pcie_test_out_bridge_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_415_384` writer - u1_plda_pcie_test_out_bridge_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_415_384` reader - u1_pcie_test_out_bridge_415_384"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_415_384` writer - u1_pcie_test_out_bridge_415_384"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_415_384"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_415_384(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_415_384(&self) -> U1_PCIE_TEST_OUT_BRIDGE_415_384_R {
+        U1_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_415_384"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_415_384(
+    pub fn u1_pcie_test_out_bridge_415_384(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W<STG_SYSCFG_211_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_415_384_W<STG_SYSCFG_211_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_415_384_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_212.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_212.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_212_SPEC>;
 #[doc = "Register `stg_syscfg_212` writer"]
 pub type W = crate::W<STG_SYSCFG_212_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_447_416` reader - u1_plda_pcie_test_out_bridge_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_447_416` writer - u1_plda_pcie_test_out_bridge_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_447_416` reader - u1_pcie_test_out_bridge_447_416"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_447_416` writer - u1_pcie_test_out_bridge_447_416"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_447_416"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_447_416(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_447_416(&self) -> U1_PCIE_TEST_OUT_BRIDGE_447_416_R {
+        U1_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_447_416"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_447_416(
+    pub fn u1_pcie_test_out_bridge_447_416(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W<STG_SYSCFG_212_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_447_416_W<STG_SYSCFG_212_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_447_416_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_213.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_213.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_213_SPEC>;
 #[doc = "Register `stg_syscfg_213` writer"]
 pub type W = crate::W<STG_SYSCFG_213_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_479_448` reader - u1_plda_pcie_test_out_bridge_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_479_448` writer - u1_plda_pcie_test_out_bridge_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_479_448` reader - u1_pcie_test_out_bridge_479_448"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_479_448` writer - u1_pcie_test_out_bridge_479_448"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_479_448"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_479_448(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_479_448(&self) -> U1_PCIE_TEST_OUT_BRIDGE_479_448_R {
+        U1_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_479_448"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_479_448(
+    pub fn u1_pcie_test_out_bridge_479_448(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W<STG_SYSCFG_213_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_479_448_W<STG_SYSCFG_213_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_479_448_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_214.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_214.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_214_SPEC>;
 #[doc = "Register `stg_syscfg_214` writer"]
 pub type W = crate::W<STG_SYSCFG_214_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_511_480` reader - u1_plda_pcie_test_out_bridge_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_511_480` writer - u1_plda_pcie_test_out_bridge_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_511_480` reader - u1_pcie_test_out_bridge_511_480"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_511_480` writer - u1_pcie_test_out_bridge_511_480"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_511_480"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_511_480(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_511_480(&self) -> U1_PCIE_TEST_OUT_BRIDGE_511_480_R {
+        U1_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_511_480"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_511_480(
+    pub fn u1_pcie_test_out_bridge_511_480(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W<STG_SYSCFG_214_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_511_480_W<STG_SYSCFG_214_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_511_480_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_215.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_215.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_215_SPEC>;
 #[doc = "Register `stg_syscfg_215` writer"]
 pub type W = crate::W<STG_SYSCFG_215_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_31_0` reader - u1_plda_pcie_test_out_pcie_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_31_0` reader - u1_pcie_test_out_pcie_31_0"]
+pub type U1_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_31_0(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_31_0(&self) -> U1_PCIE_TEST_OUT_PCIE_31_0_R {
+        U1_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_216.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_216.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_216_SPEC>;
 #[doc = "Register `stg_syscfg_216` writer"]
 pub type W = crate::W<STG_SYSCFG_216_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_63_32` reader - u1_plda_pcie_test_out_pcie_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_63_32` reader - u1_pcie_test_out_pcie_63_32"]
+pub type U1_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_63_32(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_63_32(&self) -> U1_PCIE_TEST_OUT_PCIE_63_32_R {
+        U1_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_217.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_217.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_217_SPEC>;
 #[doc = "Register `stg_syscfg_217` writer"]
 pub type W = crate::W<STG_SYSCFG_217_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_95_64` reader - u1_plda_pcie_test_out_pcie_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_95_64` reader - u1_pcie_test_out_pcie_95_64"]
+pub type U1_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_95_64(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_95_64(&self) -> U1_PCIE_TEST_OUT_PCIE_95_64_R {
+        U1_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_218.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_218.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_218_SPEC>;
 #[doc = "Register `stg_syscfg_218` writer"]
 pub type W = crate::W<STG_SYSCFG_218_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_127_96` reader - u1_plda_pcie_test_out_pcie_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_127_96` reader - u1_pcie_test_out_pcie_127_96"]
+pub type U1_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_127_96(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_127_96(&self) -> U1_PCIE_TEST_OUT_PCIE_127_96_R {
+        U1_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_219.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_219.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_219_SPEC>;
 #[doc = "Register `stg_syscfg_219` writer"]
 pub type W = crate::W<STG_SYSCFG_219_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_159_128` reader - u1_plda_pcie_test_out_pcie_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_159_128` reader - u1_pcie_test_out_pcie_159_128"]
+pub type U1_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_159_128(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_159_128(&self) -> U1_PCIE_TEST_OUT_PCIE_159_128_R {
+        U1_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_22.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_22.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_22_SPEC>;
 #[doc = "Register `stg_syscfg_22` writer"]
 pub type W = crate::W<STG_SYSCFG_22_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_159_128` reader - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_159_128` reader - u0_pcie_axi4_mst0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_159_128(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_220.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_220.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_220_SPEC>;
 #[doc = "Register `stg_syscfg_220` writer"]
 pub type W = crate::W<STG_SYSCFG_220_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_191_160` reader - u1_plda_pcie_test_out_pcie_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_191_160` reader - u1_pcie_test_out_pcie_191_160"]
+pub type U1_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_191_160(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_191_160(&self) -> U1_PCIE_TEST_OUT_PCIE_191_160_R {
+        U1_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_221.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_221.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_221_SPEC>;
 #[doc = "Register `stg_syscfg_221` writer"]
 pub type W = crate::W<STG_SYSCFG_221_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_223_192` reader - u1_plda_pcie_test_out_pcie_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_223_192` reader - u1_pcie_test_out_pcie_223_192"]
+pub type U1_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_223_192(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_223_192(&self) -> U1_PCIE_TEST_OUT_PCIE_223_192_R {
+        U1_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_222.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_222.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_222_SPEC>;
 #[doc = "Register `stg_syscfg_222` writer"]
 pub type W = crate::W<STG_SYSCFG_222_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_255_224` reader - u1_plda_pcie_test_out_pcie_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_255_224` reader - u1_pcie_test_out_pcie_255_224"]
+pub type U1_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_255_224(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_255_224(&self) -> U1_PCIE_TEST_OUT_PCIE_255_224_R {
+        U1_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_223.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_223.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_223_SPEC>;
 #[doc = "Register `stg_syscfg_223` writer"]
 pub type W = crate::W<STG_SYSCFG_223_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_287_256` reader - u1_plda_pcie_test_out_pcie_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_287_256` reader - u1_pcie_test_out_pcie_287_256"]
+pub type U1_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_287_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_287_256(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_287_256(&self) -> U1_PCIE_TEST_OUT_PCIE_287_256_R {
+        U1_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_224.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_224.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_224_SPEC>;
 #[doc = "Register `stg_syscfg_224` writer"]
 pub type W = crate::W<STG_SYSCFG_224_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_319_288` reader - u1_plda_pcie_test_out_pcie_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_319_288` reader - u1_pcie_test_out_pcie_319_288"]
+pub type U1_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_319_288"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_319_288(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_319_288(&self) -> U1_PCIE_TEST_OUT_PCIE_319_288_R {
+        U1_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_225.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_225.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_225_SPEC>;
 #[doc = "Register `stg_syscfg_225` writer"]
 pub type W = crate::W<STG_SYSCFG_225_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_351_320` reader - u1_plda_pcie_test_out_pcie_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_351_320` reader - u1_pcie_test_out_pcie_351_320"]
+pub type U1_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_351_320"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_351_320(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_351_320(&self) -> U1_PCIE_TEST_OUT_PCIE_351_320_R {
+        U1_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_226.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_226.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_226_SPEC>;
 #[doc = "Register `stg_syscfg_226` writer"]
 pub type W = crate::W<STG_SYSCFG_226_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_383_352` reader - u1_plda_pcie_test_out_pcie_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_383_352` reader - u1_pcie_test_out_pcie_383_352"]
+pub type U1_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_383_352"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_383_352(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_383_352(&self) -> U1_PCIE_TEST_OUT_PCIE_383_352_R {
+        U1_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_227.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_227.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_227_SPEC>;
 #[doc = "Register `stg_syscfg_227` writer"]
 pub type W = crate::W<STG_SYSCFG_227_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_415_384` reader - u1_plda_pcie_test_out_pcie_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_415_384` reader - u1_pcie_test_out_pcie_415_384"]
+pub type U1_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_415_384"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_415_384(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_415_384(&self) -> U1_PCIE_TEST_OUT_PCIE_415_384_R {
+        U1_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_228.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_228.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_228_SPEC>;
 #[doc = "Register `stg_syscfg_228` writer"]
 pub type W = crate::W<STG_SYSCFG_228_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_447_416` reader - u1_plda_pcie_test_out_pcie_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_447_416` reader - u1_pcie_test_out_pcie_447_416"]
+pub type U1_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_447_416"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_447_416(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_447_416(&self) -> U1_PCIE_TEST_OUT_PCIE_447_416_R {
+        U1_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_229.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_229.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_229_SPEC>;
 #[doc = "Register `stg_syscfg_229` writer"]
 pub type W = crate::W<STG_SYSCFG_229_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_479_448` reader - u1_plda_pcie_test_out_pcie_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_479_448` reader - u1_pcie_test_out_pcie_479_448"]
+pub type U1_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_479_448"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_479_448(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_479_448(&self) -> U1_PCIE_TEST_OUT_PCIE_479_448_R {
+        U1_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_23.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_23.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_23_SPEC>;
 #[doc = "Register `stg_syscfg_23` writer"]
 pub type W = crate::W<STG_SYSCFG_23_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_191_160` reader - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_191_160` reader - u0_pcie_axi4_mst0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_191_160(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_230.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_230.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_230_SPEC>;
 #[doc = "Register `stg_syscfg_230` writer"]
 pub type W = crate::W<STG_SYSCFG_230_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_511_480` reader - u1_plda_pcie_test_out_pcie_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_511_480` reader - u1_pcie_test_out_pcie_511_480"]
+pub type U1_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_511_480"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_511_480(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_511_480(&self) -> U1_PCIE_TEST_OUT_PCIE_511_480_R {
+        U1_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_231.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_231.rs
@@ -2,40 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_231_SPEC>;
 #[doc = "Register `stg_syscfg_231` writer"]
 pub type W = crate::W<STG_SYSCFG_231_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_sel` reader - u1_plda_pcie_test_sel"]
-pub type U1_PLDA_PCIE_TEST_SEL_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_test_sel` writer - u1_plda_pcie_test_sel"]
-pub type U1_PLDA_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u1_plda_pcie_tl_clock_freq` reader - u1_plda_pcie_tl_clock_freq"]
-pub type U1_PLDA_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_tl_clock_freq` writer - u1_plda_pcie_tl_clock_freq"]
-pub type U1_PLDA_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
+#[doc = "Field `u1_pcie_test_sel` reader - u1_pcie_test_sel"]
+pub type U1_PCIE_TEST_SEL_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_test_sel` writer - u1_pcie_test_sel"]
+pub type U1_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_tl_clock_freq` reader - u1_pcie_tl_clock_freq"]
+pub type U1_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_tl_clock_freq` writer - u1_pcie_tl_clock_freq"]
+pub type U1_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
 impl R {
-    #[doc = "Bits 0:3 - u1_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u1_pcie_test_sel"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_sel(&self) -> U1_PLDA_PCIE_TEST_SEL_R {
-        U1_PLDA_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
+    pub fn u1_pcie_test_sel(&self) -> U1_PCIE_TEST_SEL_R {
+        U1_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:25 - u1_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u1_pcie_tl_clock_freq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_clock_freq(&self) -> U1_PLDA_PCIE_TL_CLOCK_FREQ_R {
-        U1_PLDA_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
+    pub fn u1_pcie_tl_clock_freq(&self) -> U1_PCIE_TL_CLOCK_FREQ_R {
+        U1_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - u1_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u1_pcie_test_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_sel(&mut self) -> U1_PLDA_PCIE_TEST_SEL_W<STG_SYSCFG_231_SPEC> {
-        U1_PLDA_PCIE_TEST_SEL_W::new(self, 0)
+    pub fn u1_pcie_test_sel(&mut self) -> U1_PCIE_TEST_SEL_W<STG_SYSCFG_231_SPEC> {
+        U1_PCIE_TEST_SEL_W::new(self, 0)
     }
-    #[doc = "Bits 4:25 - u1_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u1_pcie_tl_clock_freq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tl_clock_freq(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_231_SPEC> {
-        U1_PLDA_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
+    pub fn u1_pcie_tl_clock_freq(&mut self) -> U1_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_231_SPEC> {
+        U1_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_232.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_232.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_232_SPEC>;
 #[doc = "Register `stg_syscfg_232` writer"]
 pub type W = crate::W<STG_SYSCFG_232_SPEC>;
-#[doc = "Field `u1_plda_pcie_tl_ctrl_hotplug` reader - u1_plda_pcie_tl_ctrl_hotplug"]
-pub type U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_tl_report_hotplug` reader - u1_plda_pcie_tl_report_hotplug"]
-pub type U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_tl_report_hotplug` writer - u1_plda_pcie_tl_report_hotplug"]
-pub type U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `u1_pcie_tl_ctrl_hotplug` reader - u1_pcie_tl_ctrl_hotplug"]
+pub type U1_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_tl_report_hotplug` reader - u1_pcie_tl_report_hotplug"]
+pub type U1_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_tl_report_hotplug` writer - u1_pcie_tl_report_hotplug"]
+pub type U1_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
 impl R {
-    #[doc = "Bits 0:15 - u1_plda_pcie_tl_ctrl_hotplug"]
+    #[doc = "Bits 0:15 - u1_pcie_tl_ctrl_hotplug"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_ctrl_hotplug(&self) -> U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R {
-        U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
+    pub fn u1_pcie_tl_ctrl_hotplug(&self) -> U1_PCIE_TL_CTRL_HOTPLUG_R {
+        U1_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:31 - u1_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u1_pcie_tl_report_hotplug"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_report_hotplug(&self) -> U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R {
-        U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn u1_pcie_tl_report_hotplug(&self) -> U1_PCIE_TL_REPORT_HOTPLUG_R {
+        U1_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 16:31 - u1_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u1_pcie_tl_report_hotplug"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tl_report_hotplug(
+    pub fn u1_pcie_tl_report_hotplug(
         &mut self,
-    ) -> U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_232_SPEC> {
-        U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
+    ) -> U1_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_232_SPEC> {
+        U1_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_233.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_233.rs
@@ -2,118 +2,112 @@
 pub type R = crate::R<STG_SYSCFG_233_SPEC>;
 #[doc = "Register `stg_syscfg_233` writer"]
 pub type W = crate::W<STG_SYSCFG_233_SPEC>;
-#[doc = "Field `u1_plda_pcie_tx_pattern` reader - u1_plda_pcie_tx_pattern"]
-pub type U1_PLDA_PCIE_TX_PATTERN_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_tx_pattern` writer - u1_plda_pcie_tx_pattern"]
-pub type U1_PLDA_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_bus_width` reader - u1_plda_pcie_usb3_bus_width"]
-pub type U1_PLDA_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_usb3_bus_width` writer - u1_plda_pcie_usb3_bus_width"]
-pub type U1_PLDA_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_phy_enable` reader - u1_plda_pcie_usb3_phy_enable"]
-pub type U1_PLDA_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_usb3_phy_enable` writer - u1_plda_pcie_usb3_phy_enable"]
-pub type U1_PLDA_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_usb3_rate` reader - u1_plda_pcie_usb3_rate"]
-pub type U1_PLDA_PCIE_USB3_RATE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_usb3_rate` writer - u1_plda_pcie_usb3_rate"]
-pub type U1_PLDA_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_rx_standby` reader - u1_plda_pcie_usb3_rx_standby"]
-pub type U1_PLDA_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_usb3_rx_standby` writer - u1_plda_pcie_usb3_rx_standby"]
-pub type U1_PLDA_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_xwdecerr` reader - u1_plda_pcie_xwdecerr"]
-pub type U1_PLDA_PCIE_XWDECERR_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_xwerrclr` reader - u1_plda_pcie_xwerrclr"]
-pub type U1_PLDA_PCIE_XWERRCLR_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_xwerrclr` writer - u1_plda_pcie_xwerrclr"]
-pub type U1_PLDA_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_xwslverr` reader - u1_plda_pcie_xwslverr"]
-pub type U1_PLDA_PCIE_XWSLVERR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_tx_pattern` reader - u1_pcie_tx_pattern"]
+pub type U1_PCIE_TX_PATTERN_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_tx_pattern` writer - u1_pcie_tx_pattern"]
+pub type U1_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_bus_width` reader - u1_pcie_usb3_bus_width"]
+pub type U1_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_usb3_bus_width` writer - u1_pcie_usb3_bus_width"]
+pub type U1_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_phy_enable` reader - u1_pcie_usb3_phy_enable"]
+pub type U1_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_usb3_phy_enable` writer - u1_pcie_usb3_phy_enable"]
+pub type U1_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_usb3_rate` reader - u1_pcie_usb3_rate"]
+pub type U1_PCIE_USB3_RATE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_usb3_rate` writer - u1_pcie_usb3_rate"]
+pub type U1_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_rx_standby` reader - u1_pcie_usb3_rx_standby"]
+pub type U1_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
+#[doc = "Field `u1_pcie_usb3_rx_standby` writer - u1_pcie_usb3_rx_standby"]
+pub type U1_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_xwdecerr` reader - u1_pcie_xwdecerr"]
+pub type U1_PCIE_XWDECERR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_xwerrclr` reader - u1_pcie_xwerrclr"]
+pub type U1_PCIE_XWERRCLR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_xwerrclr` writer - u1_pcie_xwerrclr"]
+pub type U1_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_xwslverr` reader - u1_pcie_xwslverr"]
+pub type U1_PCIE_XWSLVERR_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:1 - u1_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u1_pcie_tx_pattern"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tx_pattern(&self) -> U1_PLDA_PCIE_TX_PATTERN_R {
-        U1_PLDA_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
+    pub fn u1_pcie_tx_pattern(&self) -> U1_PCIE_TX_PATTERN_R {
+        U1_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:3 - u1_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u1_pcie_usb3_bus_width"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_bus_width(&self) -> U1_PLDA_PCIE_USB3_BUS_WIDTH_R {
-        U1_PLDA_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
+    pub fn u1_pcie_usb3_bus_width(&self) -> U1_PCIE_USB3_BUS_WIDTH_R {
+        U1_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
     }
-    #[doc = "Bit 4 - u1_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u1_pcie_usb3_phy_enable"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_phy_enable(&self) -> U1_PLDA_PCIE_USB3_PHY_ENABLE_R {
-        U1_PLDA_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u1_pcie_usb3_phy_enable(&self) -> U1_PCIE_USB3_PHY_ENABLE_R {
+        U1_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:6 - u1_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u1_pcie_usb3_rate"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_rate(&self) -> U1_PLDA_PCIE_USB3_RATE_R {
-        U1_PLDA_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
+    pub fn u1_pcie_usb3_rate(&self) -> U1_PCIE_USB3_RATE_R {
+        U1_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
     }
-    #[doc = "Bit 7 - u1_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u1_pcie_usb3_rx_standby"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_rx_standby(&self) -> U1_PLDA_PCIE_USB3_RX_STANDBY_R {
-        U1_PLDA_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_pcie_usb3_rx_standby(&self) -> U1_PCIE_USB3_RX_STANDBY_R {
+        U1_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_xwdecerr"]
+    #[doc = "Bit 8 - u1_pcie_xwdecerr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwdecerr(&self) -> U1_PLDA_PCIE_XWDECERR_R {
-        U1_PLDA_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_pcie_xwdecerr(&self) -> U1_PCIE_XWDECERR_R {
+        U1_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u1_pcie_xwerrclr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwerrclr(&self) -> U1_PLDA_PCIE_XWERRCLR_R {
-        U1_PLDA_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u1_pcie_xwerrclr(&self) -> U1_PCIE_XWERRCLR_R {
+        U1_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_xwslverr"]
+    #[doc = "Bit 10 - u1_pcie_xwslverr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwslverr(&self) -> U1_PLDA_PCIE_XWSLVERR_R {
-        U1_PLDA_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u1_pcie_xwslverr(&self) -> U1_PCIE_XWSLVERR_R {
+        U1_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u1_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u1_pcie_tx_pattern"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tx_pattern(&mut self) -> U1_PLDA_PCIE_TX_PATTERN_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_TX_PATTERN_W::new(self, 0)
+    pub fn u1_pcie_tx_pattern(&mut self) -> U1_PCIE_TX_PATTERN_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_TX_PATTERN_W::new(self, 0)
     }
-    #[doc = "Bits 2:3 - u1_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u1_pcie_usb3_bus_width"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_bus_width(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
+    pub fn u1_pcie_usb3_bus_width(&mut self) -> U1_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
     }
-    #[doc = "Bit 4 - u1_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u1_pcie_usb3_phy_enable"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_phy_enable(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
+    pub fn u1_pcie_usb3_phy_enable(&mut self) -> U1_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
     }
-    #[doc = "Bits 5:6 - u1_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u1_pcie_usb3_rate"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_rate(&mut self) -> U1_PLDA_PCIE_USB3_RATE_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_RATE_W::new(self, 5)
+    pub fn u1_pcie_usb3_rate(&mut self) -> U1_PCIE_USB3_RATE_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_RATE_W::new(self, 5)
     }
-    #[doc = "Bit 7 - u1_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u1_pcie_usb3_rx_standby"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_rx_standby(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_RX_STANDBY_W::new(self, 7)
+    pub fn u1_pcie_usb3_rx_standby(&mut self) -> U1_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_RX_STANDBY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u1_pcie_xwerrclr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_xwerrclr(&mut self) -> U1_PLDA_PCIE_XWERRCLR_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_XWERRCLR_W::new(self, 9)
+    pub fn u1_pcie_xwerrclr(&mut self) -> U1_PCIE_XWERRCLR_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_XWERRCLR_W::new(self, 9)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_24.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_24.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_24_SPEC>;
 #[doc = "Register `stg_syscfg_24` writer"]
 pub type W = crate::W<STG_SYSCFG_24_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_223_192` reader - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_223_192` reader - u0_pcie_axi4_mst0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_223_192(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_25.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_25.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_25_SPEC>;
 #[doc = "Register `stg_syscfg_25` writer"]
 pub type W = crate::W<STG_SYSCFG_25_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_255_224` reader - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_255_224` reader - u0_pcie_axi4_mst0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_255_224(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_26.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_26.rs
@@ -2,29 +2,27 @@
 pub type R = crate::R<STG_SYSCFG_26_SPEC>;
 #[doc = "Register `stg_syscfg_26` writer"]
 pub type W = crate::W<STG_SYSCFG_26_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_257_256` reader - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arfunc` reader - u0_plda_pcie_axi4_mst0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arregion` reader - u0_plda_pcie_axi4_mst0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_257_256` reader - u0_pcie_axi4_mst0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_arfunc` reader - u0_pcie_axi4_mst0_arfunc"]
+pub type U0_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_arregion` reader - u0_pcie_axi4_mst0_arregion"]
+pub type U0_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_mst0_aratomop_257_256(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_mst0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_mst0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_arfunc(&self) -> U0_PCIE_AXI4_MST0_ARFUNC_R {
+        U0_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_mst0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_mst0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_arregion(&self) -> U0_PCIE_AXI4_MST0_ARREGION_R {
+        U0_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_27.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_27.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_27_SPEC>;
 #[doc = "Register `stg_syscfg_27` writer"]
 pub type W = crate::W<STG_SYSCFG_27_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aruser_31_0` reader - u0_plda_pcie_axi4_mst0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aruser_31_0` reader - u0_pcie_axi4_mst0_aruser_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aruser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aruser_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aruser_31_0(&self) -> U0_PCIE_AXI4_MST0_ARUSER_31_0_R {
+        U0_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_28.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_28.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_28_SPEC>;
 #[doc = "Register `stg_syscfg_28` writer"]
 pub type W = crate::W<STG_SYSCFG_28_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aruser_63_32` reader - u0_plda_pcie_axi4_mst0_aruser_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aruser_63_32` reader - u0_pcie_axi4_mst0_aruser_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARUSER_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aruser_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aruser_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aruser_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aruser_63_32(&self) -> U0_PCIE_AXI4_MST0_ARUSER_63_32_R {
+        U0_PCIE_AXI4_MST0_ARUSER_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_29.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_29.rs
@@ -2,20 +2,20 @@
 pub type R = crate::R<STG_SYSCFG_29_SPEC>;
 #[doc = "Register `stg_syscfg_29` writer"]
 pub type W = crate::W<STG_SYSCFG_29_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awfunc` reader - u0_plda_pcie_axi4_mst0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awregion` reader - u0_plda_pcie_axi4_mst0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_awfunc` reader - u0_pcie_axi4_mst0_awfunc"]
+pub type U0_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_awregion` reader - u0_pcie_axi4_mst0_awregion"]
+pub type U0_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_mst0_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_mst0_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_awfunc(&self) -> U0_PCIE_AXI4_MST0_AWFUNC_R {
+        U0_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:18 - u0_plda_pcie_axi4_mst0_awregion"]
+    #[doc = "Bits 15:18 - u0_pcie_axi4_mst0_awregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_awregion(&self) -> U0_PCIE_AXI4_MST0_AWREGION_R {
+        U0_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_3.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_3.rs
@@ -2,231 +2,223 @@
 pub type R = crate::R<STG_SYSCFG_3_SPEC>;
 #[doc = "Register `stg_syscfg_3` writer"]
 pub type W = crate::W<STG_SYSCFG_3_SPEC>;
-#[doc = "Field `u0_cdn_usb_utmi_rxvalidh_sit` reader - u0_cdn_usb_utmi_rxvalidh_sit"]
-pub type U0_CDN_USB_UTMI_RXVALIDH_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_sessvld` reader - u0_cdn_usb_utmi_sessvld"]
-pub type U0_CDN_USB_UTMI_SESSVLD_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_sessvld` writer - u0_cdn_usb_utmi_sessvld"]
-pub type U0_CDN_USB_UTMI_SESSVLD_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_termselect_sit` reader - u0_cdn_usb_utmi_termselect_sit"]
-pub type U0_CDN_USB_UTMI_TERMSELECT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_termselect_sit` writer - u0_cdn_usb_utmi_termselect_sit"]
-pub type U0_CDN_USB_UTMI_TERMSELECT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_dat_sit` reader - u0_cdn_usb_utmi_tx_dat_sit"]
-pub type U0_CDN_USB_UTMI_TX_DAT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_dat_sit` writer - u0_cdn_usb_utmi_tx_dat_sit"]
-pub type U0_CDN_USB_UTMI_TX_DAT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_enable_n_sit` reader - u0_cdn_usb_utmi_tx_enable_n_sit"]
-pub type U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_enable_n_sit` writer - u0_cdn_usb_utmi_tx_enable_n_sit"]
-pub type U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_se0_sit` reader - u0_cdn_usb_utmi_tx_se0_sit"]
-pub type U0_CDN_USB_UTMI_TX_SE0_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_se0_sit` writer - u0_cdn_usb_utmi_tx_se0_sit"]
-pub type U0_CDN_USB_UTMI_TX_SE0_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txbitstuffenable_sit` reader - u0_cdn_usb_utmi_txbitstuffenable_sit"]
-pub type U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txbitstuffenable_sit` writer - u0_cdn_usb_utmi_txbitstuffenable_sit"]
-pub type U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txready_sit` reader - u0_cdn_usb_utmi_txready_sit"]
-pub type U0_CDN_USB_UTMI_TXREADY_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalid_sit` reader - u0_cdn_usb_utmi_txvalid_sit"]
-pub type U0_CDN_USB_UTMI_TXVALID_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalid_sit` writer - u0_cdn_usb_utmi_txvalid_sit"]
-pub type U0_CDN_USB_UTMI_TXVALID_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txvalidh_sit` reader - u0_cdn_usb_utmi_txvalidh_sit"]
-pub type U0_CDN_USB_UTMI_TXVALIDH_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalidh_sit` writer - u0_cdn_usb_utmi_txvalidh_sit"]
-pub type U0_CDN_USB_UTMI_TXVALIDH_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_vbusvalid_sit` reader - u0_cdn_usb_utmi_vbusvalid_sit"]
-pub type U0_CDN_USB_UTMI_VBUSVALID_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_xcvrselect_sit` reader - u0_cdn_usb_utmi_xcvrselect_sit"]
-pub type U0_CDN_USB_UTMI_XCVRSELECT_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_xcvrselect_sit` writer - u0_cdn_usb_utmi_xcvrselect_sit"]
-pub type U0_CDN_USB_UTMI_XCVRSELECT_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_cdn_usb_utmi_vdm_src_en` reader - u0_cdn_usb_utmi_vdm_src_en"]
-pub type U0_CDN_USB_UTMI_VDM_SRC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_vdp_src_en` reader - u0_cdn_usb_utmi_vdp_src_en"]
-pub type U0_CDN_USB_UTMI_VDP_SRC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_wakeup` reader - u0_cdn_usb_wakeup"]
-pub type U0_CDN_USB_WAKEUP_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_wakeup` writer - u0_cdn_usb_wakeup"]
-pub type U0_CDN_USB_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhc_d0_ack` reader - u0_cdn_usb_xhc_d0_ack"]
-pub type U0_CDN_USB_XHC_D0_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhc_d0_req` reader - u0_cdn_usb_xhc_d0_req"]
-pub type U0_CDN_USB_XHC_D0_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhc_d0_req` writer - u0_cdn_usb_xhc_d0_req"]
-pub type U0_CDN_USB_XHC_D0_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_rxvalidh_sit` reader - u0_usb_utmi_rxvalidh_sit"]
+pub type U0_USB_UTMI_RXVALIDH_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_sessvld` reader - u0_usb_utmi_sessvld"]
+pub type U0_USB_UTMI_SESSVLD_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_sessvld` writer - u0_usb_utmi_sessvld"]
+pub type U0_USB_UTMI_SESSVLD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_termselect_sit` reader - u0_usb_utmi_termselect_sit"]
+pub type U0_USB_UTMI_TERMSELECT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_termselect_sit` writer - u0_usb_utmi_termselect_sit"]
+pub type U0_USB_UTMI_TERMSELECT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_dat_sit` reader - u0_usb_utmi_tx_dat_sit"]
+pub type U0_USB_UTMI_TX_DAT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_dat_sit` writer - u0_usb_utmi_tx_dat_sit"]
+pub type U0_USB_UTMI_TX_DAT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_enable_n_sit` reader - u0_usb_utmi_tx_enable_n_sit"]
+pub type U0_USB_UTMI_TX_ENABLE_N_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_enable_n_sit` writer - u0_usb_utmi_tx_enable_n_sit"]
+pub type U0_USB_UTMI_TX_ENABLE_N_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_se0_sit` reader - u0_usb_utmi_tx_se0_sit"]
+pub type U0_USB_UTMI_TX_SE0_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_se0_sit` writer - u0_usb_utmi_tx_se0_sit"]
+pub type U0_USB_UTMI_TX_SE0_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txbitstuffenable_sit` reader - u0_usb_utmi_txbitstuffenable_sit"]
+pub type U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txbitstuffenable_sit` writer - u0_usb_utmi_txbitstuffenable_sit"]
+pub type U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txready_sit` reader - u0_usb_utmi_txready_sit"]
+pub type U0_USB_UTMI_TXREADY_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalid_sit` reader - u0_usb_utmi_txvalid_sit"]
+pub type U0_USB_UTMI_TXVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalid_sit` writer - u0_usb_utmi_txvalid_sit"]
+pub type U0_USB_UTMI_TXVALID_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txvalidh_sit` reader - u0_usb_utmi_txvalidh_sit"]
+pub type U0_USB_UTMI_TXVALIDH_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalidh_sit` writer - u0_usb_utmi_txvalidh_sit"]
+pub type U0_USB_UTMI_TXVALIDH_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_vbusvalid_sit` reader - u0_usb_utmi_vbusvalid_sit"]
+pub type U0_USB_UTMI_VBUSVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_xcvrselect_sit` reader - u0_usb_utmi_xcvrselect_sit"]
+pub type U0_USB_UTMI_XCVRSELECT_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_xcvrselect_sit` writer - u0_usb_utmi_xcvrselect_sit"]
+pub type U0_USB_UTMI_XCVRSELECT_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_usb_utmi_vdm_src_en` reader - u0_usb_utmi_vdm_src_en"]
+pub type U0_USB_UTMI_VDM_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_vdp_src_en` reader - u0_usb_utmi_vdp_src_en"]
+pub type U0_USB_UTMI_VDP_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_wakeup` reader - u0_usb_wakeup"]
+pub type U0_USB_WAKEUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_wakeup` writer - u0_usb_wakeup"]
+pub type U0_USB_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhc_d0_ack` reader - u0_usb_xhc_d0_ack"]
+pub type U0_USB_XHC_D0_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhc_d0_req` reader - u0_usb_xhc_d0_req"]
+pub type U0_USB_XHC_D0_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhc_d0_req` writer - u0_usb_xhc_d0_req"]
+pub type U0_USB_XHC_D0_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u0_cdn_usb_utmi_rxvalidh_sit"]
+    #[doc = "Bit 0 - u0_usb_utmi_rxvalidh_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxvalidh_sit(&self) -> U0_CDN_USB_UTMI_RXVALIDH_SIT_R {
-        U0_CDN_USB_UTMI_RXVALIDH_SIT_R::new((self.bits & 1) != 0)
+    pub fn u0_usb_utmi_rxvalidh_sit(&self) -> U0_USB_UTMI_RXVALIDH_SIT_R {
+        U0_USB_UTMI_RXVALIDH_SIT_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_cdn_usb_utmi_sessvld"]
+    #[doc = "Bit 1 - u0_usb_utmi_sessvld"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_sessvld(&self) -> U0_CDN_USB_UTMI_SESSVLD_R {
-        U0_CDN_USB_UTMI_SESSVLD_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_usb_utmi_sessvld(&self) -> U0_USB_UTMI_SESSVLD_R {
+        U0_USB_UTMI_SESSVLD_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_cdn_usb_utmi_termselect_sit"]
+    #[doc = "Bit 2 - u0_usb_utmi_termselect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_termselect_sit(&self) -> U0_CDN_USB_UTMI_TERMSELECT_SIT_R {
-        U0_CDN_USB_UTMI_TERMSELECT_SIT_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_usb_utmi_termselect_sit(&self) -> U0_USB_UTMI_TERMSELECT_SIT_R {
+        U0_USB_UTMI_TERMSELECT_SIT_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_utmi_tx_dat_sit"]
+    #[doc = "Bit 3 - u0_usb_utmi_tx_dat_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_dat_sit(&self) -> U0_CDN_USB_UTMI_TX_DAT_SIT_R {
-        U0_CDN_USB_UTMI_TX_DAT_SIT_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_usb_utmi_tx_dat_sit(&self) -> U0_USB_UTMI_TX_DAT_SIT_R {
+        U0_USB_UTMI_TX_DAT_SIT_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_utmi_tx_enable_n_sit"]
+    #[doc = "Bit 4 - u0_usb_utmi_tx_enable_n_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_enable_n_sit(&self) -> U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R {
-        U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_usb_utmi_tx_enable_n_sit(&self) -> U0_USB_UTMI_TX_ENABLE_N_SIT_R {
+        U0_USB_UTMI_TX_ENABLE_N_SIT_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_utmi_tx_se0_sit"]
+    #[doc = "Bit 5 - u0_usb_utmi_tx_se0_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_se0_sit(&self) -> U0_CDN_USB_UTMI_TX_SE0_SIT_R {
-        U0_CDN_USB_UTMI_TX_SE0_SIT_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_utmi_tx_se0_sit(&self) -> U0_USB_UTMI_TX_SE0_SIT_R {
+        U0_USB_UTMI_TX_SE0_SIT_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_utmi_txbitstuffenable_sit"]
+    #[doc = "Bit 6 - u0_usb_utmi_txbitstuffenable_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txbitstuffenable_sit(&self) -> U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R {
-        U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_utmi_txbitstuffenable_sit(&self) -> U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R {
+        U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_utmi_txready_sit"]
+    #[doc = "Bit 7 - u0_usb_utmi_txready_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txready_sit(&self) -> U0_CDN_USB_UTMI_TXREADY_SIT_R {
-        U0_CDN_USB_UTMI_TXREADY_SIT_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_utmi_txready_sit(&self) -> U0_USB_UTMI_TXREADY_SIT_R {
+        U0_USB_UTMI_TXREADY_SIT_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_utmi_txvalid_sit"]
+    #[doc = "Bit 8 - u0_usb_utmi_txvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txvalid_sit(&self) -> U0_CDN_USB_UTMI_TXVALID_SIT_R {
-        U0_CDN_USB_UTMI_TXVALID_SIT_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_utmi_txvalid_sit(&self) -> U0_USB_UTMI_TXVALID_SIT_R {
+        U0_USB_UTMI_TXVALID_SIT_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_utmi_txvalidh_sit"]
+    #[doc = "Bit 9 - u0_usb_utmi_txvalidh_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txvalidh_sit(&self) -> U0_CDN_USB_UTMI_TXVALIDH_SIT_R {
-        U0_CDN_USB_UTMI_TXVALIDH_SIT_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_txvalidh_sit(&self) -> U0_USB_UTMI_TXVALIDH_SIT_R {
+        U0_USB_UTMI_TXVALIDH_SIT_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_utmi_vbusvalid_sit"]
+    #[doc = "Bit 10 - u0_usb_utmi_vbusvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vbusvalid_sit(&self) -> U0_CDN_USB_UTMI_VBUSVALID_SIT_R {
-        U0_CDN_USB_UTMI_VBUSVALID_SIT_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_utmi_vbusvalid_sit(&self) -> U0_USB_UTMI_VBUSVALID_SIT_R {
+        U0_USB_UTMI_VBUSVALID_SIT_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bits 11:12 - u0_cdn_usb_utmi_xcvrselect_sit"]
+    #[doc = "Bits 11:12 - u0_usb_utmi_xcvrselect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_xcvrselect_sit(&self) -> U0_CDN_USB_UTMI_XCVRSELECT_SIT_R {
-        U0_CDN_USB_UTMI_XCVRSELECT_SIT_R::new(((self.bits >> 11) & 3) as u8)
+    pub fn u0_usb_utmi_xcvrselect_sit(&self) -> U0_USB_UTMI_XCVRSELECT_SIT_R {
+        U0_USB_UTMI_XCVRSELECT_SIT_R::new(((self.bits >> 11) & 3) as u8)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_utmi_vdm_src_en"]
+    #[doc = "Bit 13 - u0_usb_utmi_vdm_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vdm_src_en(&self) -> U0_CDN_USB_UTMI_VDM_SRC_EN_R {
-        U0_CDN_USB_UTMI_VDM_SRC_EN_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_utmi_vdm_src_en(&self) -> U0_USB_UTMI_VDM_SRC_EN_R {
+        U0_USB_UTMI_VDM_SRC_EN_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_utmi_vdp_src_en"]
+    #[doc = "Bit 14 - u0_usb_utmi_vdp_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vdp_src_en(&self) -> U0_CDN_USB_UTMI_VDP_SRC_EN_R {
-        U0_CDN_USB_UTMI_VDP_SRC_EN_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_utmi_vdp_src_en(&self) -> U0_USB_UTMI_VDP_SRC_EN_R {
+        U0_USB_UTMI_VDP_SRC_EN_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_wakeup"]
+    #[doc = "Bit 15 - u0_usb_wakeup"]
     #[inline(always)]
-    pub fn u0_cdn_usb_wakeup(&self) -> U0_CDN_USB_WAKEUP_R {
-        U0_CDN_USB_WAKEUP_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_wakeup(&self) -> U0_USB_WAKEUP_R {
+        U0_USB_WAKEUP_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_xhc_d0_ack"]
+    #[doc = "Bit 16 - u0_usb_xhc_d0_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhc_d0_ack(&self) -> U0_CDN_USB_XHC_D0_ACK_R {
-        U0_CDN_USB_XHC_D0_ACK_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_xhc_d0_ack(&self) -> U0_USB_XHC_D0_ACK_R {
+        U0_USB_XHC_D0_ACK_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_xhc_d0_req"]
+    #[doc = "Bit 17 - u0_usb_xhc_d0_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhc_d0_req(&self) -> U0_CDN_USB_XHC_D0_REQ_R {
-        U0_CDN_USB_XHC_D0_REQ_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_xhc_d0_req(&self) -> U0_USB_XHC_D0_REQ_R {
+        U0_USB_XHC_D0_REQ_R::new(((self.bits >> 17) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 1 - u0_cdn_usb_utmi_sessvld"]
+    #[doc = "Bit 1 - u0_usb_utmi_sessvld"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_sessvld(&mut self) -> U0_CDN_USB_UTMI_SESSVLD_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_SESSVLD_W::new(self, 1)
+    pub fn u0_usb_utmi_sessvld(&mut self) -> U0_USB_UTMI_SESSVLD_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_SESSVLD_W::new(self, 1)
     }
-    #[doc = "Bit 2 - u0_cdn_usb_utmi_termselect_sit"]
+    #[doc = "Bit 2 - u0_usb_utmi_termselect_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_termselect_sit(
+    pub fn u0_usb_utmi_termselect_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TERMSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TERMSELECT_SIT_W::new(self, 2)
+    ) -> U0_USB_UTMI_TERMSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TERMSELECT_SIT_W::new(self, 2)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_utmi_tx_dat_sit"]
+    #[doc = "Bit 3 - u0_usb_utmi_tx_dat_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_dat_sit(
+    pub fn u0_usb_utmi_tx_dat_sit(&mut self) -> U0_USB_UTMI_TX_DAT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_DAT_SIT_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - u0_usb_utmi_tx_enable_n_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_tx_enable_n_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_DAT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_DAT_SIT_W::new(self, 3)
+    ) -> U0_USB_UTMI_TX_ENABLE_N_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_ENABLE_N_SIT_W::new(self, 4)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_utmi_tx_enable_n_sit"]
+    #[doc = "Bit 5 - u0_usb_utmi_tx_se0_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_enable_n_sit(
+    pub fn u0_usb_utmi_tx_se0_sit(&mut self) -> U0_USB_UTMI_TX_SE0_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_SE0_SIT_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - u0_usb_utmi_txbitstuffenable_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_txbitstuffenable_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W::new(self, 4)
+    ) -> U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W::new(self, 6)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_utmi_tx_se0_sit"]
+    #[doc = "Bit 8 - u0_usb_utmi_txvalid_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_se0_sit(
+    pub fn u0_usb_utmi_txvalid_sit(&mut self) -> U0_USB_UTMI_TXVALID_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXVALID_SIT_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - u0_usb_utmi_txvalidh_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_txvalidh_sit(&mut self) -> U0_USB_UTMI_TXVALIDH_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXVALIDH_SIT_W::new(self, 9)
+    }
+    #[doc = "Bits 11:12 - u0_usb_utmi_xcvrselect_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_xcvrselect_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_SE0_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_SE0_SIT_W::new(self, 5)
+    ) -> U0_USB_UTMI_XCVRSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_XCVRSELECT_SIT_W::new(self, 11)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_utmi_txbitstuffenable_sit"]
+    #[doc = "Bit 15 - u0_usb_wakeup"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_txbitstuffenable_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W::new(self, 6)
+    pub fn u0_usb_wakeup(&mut self) -> U0_USB_WAKEUP_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_WAKEUP_W::new(self, 15)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_utmi_txvalid_sit"]
+    #[doc = "Bit 17 - u0_usb_xhc_d0_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_txvalid_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXVALID_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXVALID_SIT_W::new(self, 8)
-    }
-    #[doc = "Bit 9 - u0_cdn_usb_utmi_txvalidh_sit"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_utmi_txvalidh_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXVALIDH_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXVALIDH_SIT_W::new(self, 9)
-    }
-    #[doc = "Bits 11:12 - u0_cdn_usb_utmi_xcvrselect_sit"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_utmi_xcvrselect_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_XCVRSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_XCVRSELECT_SIT_W::new(self, 11)
-    }
-    #[doc = "Bit 15 - u0_cdn_usb_wakeup"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_wakeup(&mut self) -> U0_CDN_USB_WAKEUP_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_WAKEUP_W::new(self, 15)
-    }
-    #[doc = "Bit 17 - u0_cdn_usb_xhc_d0_req"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_xhc_d0_req(&mut self) -> U0_CDN_USB_XHC_D0_REQ_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_XHC_D0_REQ_W::new(self, 17)
+    pub fn u0_usb_xhc_d0_req(&mut self) -> U0_USB_XHC_D0_REQ_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_XHC_D0_REQ_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_30.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_30.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_30_SPEC>;
 #[doc = "Register `stg_syscfg_30` writer"]
 pub type W = crate::W<STG_SYSCFG_30_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_a2user_31_0` reader - u0_plda_pcie_axi4_mst0_a2user_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_a2user_31_0` reader - u0_pcie_axi4_mst0_a2user_31_0"]
+pub type U0_PCIE_AXI4_MST0_A2USER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_a2user_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_a2user_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_a2user_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_a2user_31_0(&self) -> U0_PCIE_AXI4_MST0_A2USER_31_0_R {
+        U0_PCIE_AXI4_MST0_A2USER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_31.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_31.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_31_SPEC>;
 #[doc = "Register `stg_syscfg_31` writer"]
 pub type W = crate::W<STG_SYSCFG_31_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awuser_42_32` reader - u0_plda_pcie_axi4_mst0_awuser_42_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_rderr` reader - u0_plda_pcie_axi4_mst0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_rderr` writer - u0_plda_pcie_axi4_mst0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_axi4_mst0_awuser_42_32` reader - u0_pcie_axi4_mst0_awuser_42_32"]
+pub type U0_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_rderr` reader - u0_pcie_axi4_mst0_rderr"]
+pub type U0_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_rderr` writer - u0_pcie_axi4_mst0_rderr"]
+pub type U0_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:10 - u0_plda_pcie_axi4_mst0_awuser_42_32"]
+    #[doc = "Bits 0:10 - u0_pcie_axi4_mst0_awuser_42_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awuser_42_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
+    pub fn u0_pcie_axi4_mst0_awuser_42_32(&self) -> U0_PCIE_AXI4_MST0_AWUSER_42_32_R {
+        U0_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
     }
-    #[doc = "Bits 11:18 - u0_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u0_pcie_axi4_mst0_rderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_rderr(&self) -> U0_PLDA_PCIE_AXI4_MST0_RDERR_R {
-        U0_PLDA_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
+    pub fn u0_pcie_axi4_mst0_rderr(&self) -> U0_PCIE_AXI4_MST0_RDERR_R {
+        U0_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 11:18 - u0_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u0_pcie_axi4_mst0_rderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_mst0_rderr(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_31_SPEC> {
-        U0_PLDA_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
+    pub fn u0_pcie_axi4_mst0_rderr(&mut self) -> U0_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_31_SPEC> {
+        U0_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_32.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_32.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_32_SPEC>;
 #[doc = "Register `stg_syscfg_32` writer"]
 pub type W = crate::W<STG_SYSCFG_32_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_ruser` reader - u0_plda_pcie_axi4_mst0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_ruser` writer - u0_plda_pcie_axi4_mst0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_ruser` reader - u0_pcie_axi4_mst0_ruser"]
+pub type U0_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_ruser` writer - u0_pcie_axi4_mst0_ruser"]
+pub type U0_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_ruser"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_ruser(&self) -> U0_PLDA_PCIE_AXI4_MST0_RUSER_R {
-        U0_PLDA_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_ruser(&self) -> U0_PCIE_AXI4_MST0_RUSER_R {
+        U0_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_ruser"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_mst0_ruser(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_32_SPEC> {
-        U0_PLDA_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
+    pub fn u0_pcie_axi4_mst0_ruser(&mut self) -> U0_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_32_SPEC> {
+        U0_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_33.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_33.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_33_SPEC>;
 #[doc = "Register `stg_syscfg_33` writer"]
 pub type W = crate::W<STG_SYSCFG_33_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_wderr` reader - u0_plda_pcie_axi4_mst0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_wderr` reader - u0_pcie_axi4_mst0_wderr"]
+pub type U0_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_mst0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_mst0_wderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_wderr(&self) -> U0_PLDA_PCIE_AXI4_MST0_WDERR_R {
-        U0_PLDA_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_axi4_mst0_wderr(&self) -> U0_PCIE_AXI4_MST0_WDERR_R {
+        U0_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_34.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_34.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_34_SPEC>;
 #[doc = "Register `stg_syscfg_34` writer"]
 pub type W = crate::W<STG_SYSCFG_34_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_31_0` reader - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_31_0` writer - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_31_0` reader - u0_pcie_axi4_slv0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_31_0` writer - u0_pcie_axi4_slv0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_31_0(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_31_0(
+    pub fn u0_pcie_axi4_slv0_aratomop_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_34_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_34_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_35.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_35.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_35_SPEC>;
 #[doc = "Register `stg_syscfg_35` writer"]
 pub type W = crate::W<STG_SYSCFG_35_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_63_32` reader - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_63_32` writer - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_63_32` reader - u0_pcie_axi4_slv0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_63_32` writer - u0_pcie_axi4_slv0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_63_32(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_63_32(
+    pub fn u0_pcie_axi4_slv0_aratomop_63_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_35_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_35_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_36.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_36.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_36_SPEC>;
 #[doc = "Register `stg_syscfg_36` writer"]
 pub type W = crate::W<STG_SYSCFG_36_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_95_64` reader - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_95_64` writer - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_95_64` reader - u0_pcie_axi4_slv0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_95_64` writer - u0_pcie_axi4_slv0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_95_64(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_95_64(
+    pub fn u0_pcie_axi4_slv0_aratomop_95_64(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_36_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_36_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_37.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_37.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_37_SPEC>;
 #[doc = "Register `stg_syscfg_37` writer"]
 pub type W = crate::W<STG_SYSCFG_37_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_127_96` reader - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_127_96` writer - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_127_96` reader - u0_pcie_axi4_slv0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_127_96` writer - u0_pcie_axi4_slv0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_127_96(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_127_96(
+    pub fn u0_pcie_axi4_slv0_aratomop_127_96(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_37_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_37_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_38.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_38.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_38_SPEC>;
 #[doc = "Register `stg_syscfg_38` writer"]
 pub type W = crate::W<STG_SYSCFG_38_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_159_128` reader - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_159_128` writer - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_159_128` reader - u0_pcie_axi4_slv0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_159_128` writer - u0_pcie_axi4_slv0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_159_128(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_159_128(
+    pub fn u0_pcie_axi4_slv0_aratomop_159_128(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_38_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_38_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_39.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_39.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_39_SPEC>;
 #[doc = "Register `stg_syscfg_39` writer"]
 pub type W = crate::W<STG_SYSCFG_39_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_191_160` reader - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_191_160` writer - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_191_160` reader - u0_pcie_axi4_slv0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_191_160` writer - u0_pcie_axi4_slv0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_191_160(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_191_160(
+    pub fn u0_pcie_axi4_slv0_aratomop_191_160(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_39_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_39_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_4.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_4.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_4_SPEC>;
 #[doc = "Register `stg_syscfg_4` writer"]
 pub type W = crate::W<STG_SYSCFG_4_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_bus` reader - u0_cdn_usb_xhci_debug_bus"]
-pub type U0_CDN_USB_XHCI_DEBUG_BUS_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_usb_xhci_debug_bus` reader - u0_usb_xhci_debug_bus"]
+pub type U0_USB_XHCI_DEBUG_BUS_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_cdn_usb_xhci_debug_bus"]
+    #[doc = "Bits 0:31 - u0_usb_xhci_debug_bus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_bus(&self) -> U0_CDN_USB_XHCI_DEBUG_BUS_R {
-        U0_CDN_USB_XHCI_DEBUG_BUS_R::new(self.bits)
+    pub fn u0_usb_xhci_debug_bus(&self) -> U0_USB_XHCI_DEBUG_BUS_R {
+        U0_USB_XHCI_DEBUG_BUS_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_40.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_40.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_40_SPEC>;
 #[doc = "Register `stg_syscfg_40` writer"]
 pub type W = crate::W<STG_SYSCFG_40_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_223_192` reader - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_223_192` writer - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_223_192` reader - u0_pcie_axi4_slv0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_223_192` writer - u0_pcie_axi4_slv0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_223_192(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_223_192(
+    pub fn u0_pcie_axi4_slv0_aratomop_223_192(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_40_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_40_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_41.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_41.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_41_SPEC>;
 #[doc = "Register `stg_syscfg_41` writer"]
 pub type W = crate::W<STG_SYSCFG_41_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_255_224` reader - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_255_224` writer - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_255_224` reader - u0_pcie_axi4_slv0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_255_224` writer - u0_pcie_axi4_slv0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_255_224(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_255_224(
+    pub fn u0_pcie_axi4_slv0_aratomop_255_224(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_41_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_41_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_42.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_42.rs
@@ -2,61 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_42_SPEC>;
 #[doc = "Register `stg_syscfg_42` writer"]
 pub type W = crate::W<STG_SYSCFG_42_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_257_256` reader - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_257_256` writer - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arfunc` reader - u0_plda_pcie_axi4_slv0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arfunc` writer - u0_plda_pcie_axi4_slv0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arregion` reader - u0_plda_pcie_axi4_slv0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arregion` writer - u0_plda_pcie_axi4_slv0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_257_256` reader - u0_pcie_axi4_slv0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_257_256` writer - u0_pcie_axi4_slv0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_axi4_slv0_arfunc` reader - u0_pcie_axi4_slv0_arfunc"]
+pub type U0_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_arfunc` writer - u0_pcie_axi4_slv0_arfunc"]
+pub type U0_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_arregion` reader - u0_pcie_axi4_slv0_arregion"]
+pub type U0_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_arregion` writer - u0_pcie_axi4_slv0_arregion"]
+pub type U0_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_slv0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_slv0_aratomop_257_256(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slv0_arfunc(&self) -> U0_PCIE_AXI4_SLV0_ARFUNC_R {
+        U0_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_slv0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_arregion(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_slv0_arregion(&self) -> U0_PCIE_AXI4_SLV0_ARREGION_R {
+        U0_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_slv0_aratomop_257_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_257_256(
+    pub fn u0_pcie_axi4_slv0_aratomop_257_256(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W::new(self, 0)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_arfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
+    pub fn u0_pcie_axi4_slv0_arfunc(&mut self) -> U0_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_slv0_arregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_arregion(
+    pub fn u0_pcie_axi4_slv0_arregion(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
+    ) -> U0_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_43.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_43.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_43_SPEC>;
 #[doc = "Register `stg_syscfg_43` writer"]
 pub type W = crate::W<STG_SYSCFG_43_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_31_0` reader - u0_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_31_0` writer - u0_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_31_0` reader - u0_pcie_axi4_slv0_aruser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_31_0` writer - u0_pcie_axi4_slv0_aruser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aruser_31_0(&self) -> U0_PCIE_AXI4_SLV0_ARUSER_31_0_R {
+        U0_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_31_0(
+    pub fn u0_pcie_axi4_slv0_aruser_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_43_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_43_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_44.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_44.rs
@@ -2,59 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_44_SPEC>;
 #[doc = "Register `stg_syscfg_44` writer"]
 pub type W = crate::W<STG_SYSCFG_44_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_40_32` reader - u0_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_40_32` writer - u0_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awfunc` reader - u0_plda_pcie_axi4_slv0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awfunc` writer - u0_plda_pcie_axi4_slv0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awregion` reader - u0_plda_pcie_axi4_slv0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awregion` writer - u0_plda_pcie_axi4_slv0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_40_32` reader - u0_pcie_axi4_slv0_aruser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_40_32` writer - u0_pcie_axi4_slv0_aruser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awfunc` reader - u0_pcie_axi4_slv0_awfunc"]
+pub type U0_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awfunc` writer - u0_pcie_axi4_slv0_awfunc"]
+pub type U0_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awregion` reader - u0_pcie_axi4_slv0_awregion"]
+pub type U0_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_awregion` writer - u0_pcie_axi4_slv0_awregion"]
+pub type U0_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_40_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u0_pcie_axi4_slv0_aruser_40_32(&self) -> U0_PCIE_AXI4_SLV0_ARUSER_40_32_R {
+        U0_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:23 - u0_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u0_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awfunc(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slv0_awfunc(&self) -> U0_PCIE_AXI4_SLV0_AWFUNC_R {
+        U0_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
     }
-    #[doc = "Bits 24:27 - u0_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u0_pcie_axi4_slv0_awregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awregion(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_slv0_awregion(&self) -> U0_PCIE_AXI4_SLV0_AWREGION_R {
+        U0_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_40_32(
+    pub fn u0_pcie_axi4_slv0_aruser_40_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
     }
-    #[doc = "Bits 9:23 - u0_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u0_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
+    pub fn u0_pcie_axi4_slv0_awfunc(&mut self) -> U0_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
     }
-    #[doc = "Bits 24:27 - u0_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u0_pcie_axi4_slv0_awregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awregion(
+    pub fn u0_pcie_axi4_slv0_awregion(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
+    ) -> U0_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_45.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_45.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_45_SPEC>;
 #[doc = "Register `stg_syscfg_45` writer"]
 pub type W = crate::W<STG_SYSCFG_45_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_31_0` reader - u0_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_31_0` writer - u0_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_31_0` reader - u0_pcie_axi4_slv0_awuser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_31_0` writer - u0_pcie_axi4_slv0_awuser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_awuser_31_0(&self) -> U0_PCIE_AXI4_SLV0_AWUSER_31_0_R {
+        U0_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_31_0(
+    pub fn u0_pcie_axi4_slv0_awuser_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_45_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_45_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_46.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_46.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_46_SPEC>;
 #[doc = "Register `stg_syscfg_46` writer"]
 pub type W = crate::W<STG_SYSCFG_46_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_40_32` reader - u0_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_40_32` writer - u0_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_rderr` reader - u0_plda_pcie_axi4_slv0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_40_32` reader - u0_pcie_axi4_slv0_awuser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_40_32` writer - u0_pcie_axi4_slv0_awuser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_rderr` reader - u0_pcie_axi4_slv0_rderr"]
+pub type U0_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_40_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u0_pcie_axi4_slv0_awuser_40_32(&self) -> U0_PCIE_AXI4_SLV0_AWUSER_40_32_R {
+        U0_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:16 - u0_plda_pcie_axi4_slv0_rderr"]
+    #[doc = "Bits 9:16 - u0_pcie_axi4_slv0_rderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_rderr(&self) -> U0_PLDA_PCIE_AXI4_SLV0_RDERR_R {
-        U0_PLDA_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
+    pub fn u0_pcie_axi4_slv0_rderr(&self) -> U0_PCIE_AXI4_SLV0_RDERR_R {
+        U0_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_40_32(
+    pub fn u0_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_46_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_46_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_47.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_47.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_47_SPEC>;
 #[doc = "Register `stg_syscfg_47` writer"]
 pub type W = crate::W<STG_SYSCFG_47_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_ruser` reader - u0_plda_pcie_axi4_slv0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_ruser` reader - u0_pcie_axi4_slv0_ruser"]
+pub type U0_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_ruser"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_ruser(&self) -> U0_PLDA_PCIE_AXI4_SLV0_RUSER_R {
-        U0_PLDA_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_ruser(&self) -> U0_PCIE_AXI4_SLV0_RUSER_R {
+        U0_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_48.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_48.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_48_SPEC>;
 #[doc = "Register `stg_syscfg_48` writer"]
 pub type W = crate::W<STG_SYSCFG_48_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_wderr` reader - u0_plda_pcie_axi4_slv0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_wderr` writer - u0_plda_pcie_axi4_slv0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_arfunc` reader - u0_plda_pcie_axi4_slvl_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_wderr` reader - u0_pcie_axi4_slv0_wderr"]
+pub type U0_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_wderr` writer - u0_pcie_axi4_slv0_wderr"]
+pub type U0_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_axi4_slvl_arfunc` reader - u0_pcie_axi4_slvl_arfunc"]
+pub type U0_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_slv0_wderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_wderr(&self) -> U0_PLDA_PCIE_AXI4_SLV0_WDERR_R {
-        U0_PLDA_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_axi4_slv0_wderr(&self) -> U0_PCIE_AXI4_SLV0_WDERR_R {
+        U0_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bits 8:22 - u0_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u0_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slvl_arfunc(&self) -> U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slvl_arfunc(&self) -> U0_PCIE_AXI4_SLVL_ARFUNC_R {
+        U0_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_slv0_wderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_wderr(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_48_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
+    pub fn u0_pcie_axi4_slv0_wderr(&mut self) -> U0_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_48_SPEC> {
+        U0_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_49.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_49.rs
@@ -2,92 +2,90 @@
 pub type R = crate::R<STG_SYSCFG_49_SPEC>;
 #[doc = "Register `stg_syscfg_49` writer"]
 pub type W = crate::W<STG_SYSCFG_49_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_awfunc` reader - u0_plda_pcie_axi4_slvl_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_awfunc` writer - u0_plda_pcie_axi4_slvl_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_bus_width_o` reader - u0_plda_pcie_bus_width_o"]
-pub type U0_PLDA_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_bypass_codec` reader - u0_plda_pcie_bypass_codec"]
-pub type U0_PLDA_PCIE_BYPASS_CODEC_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_bypass_codec` writer - u0_plda_pcie_bypass_codec"]
-pub type U0_PLDA_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_ckref_src` reader - u0_plda_pcie_ckref_src"]
-pub type U0_PLDA_PCIE_CKREF_SRC_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_ckref_src` writer - u0_plda_pcie_ckref_src"]
-pub type U0_PLDA_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_clk_sel` reader - u0_plda_pcie_clk_sel"]
-pub type U0_PLDA_PCIE_CLK_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_clk_sel` writer - u0_plda_pcie_clk_sel"]
-pub type U0_PLDA_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_clkreq` reader - u0_plda_pcie_clkreq"]
-pub type U0_PLDA_PCIE_CLKREQ_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_clkreq` writer - u0_plda_pcie_clkreq"]
-pub type U0_PLDA_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi4_slvl_awfunc` reader - u0_pcie_axi4_slvl_awfunc"]
+pub type U0_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slvl_awfunc` writer - u0_pcie_axi4_slvl_awfunc"]
+pub type U0_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_bus_width_o` reader - u0_pcie_bus_width_o"]
+pub type U0_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_bypass_codec` reader - u0_pcie_bypass_codec"]
+pub type U0_PCIE_BYPASS_CODEC_R = crate::BitReader;
+#[doc = "Field `u0_pcie_bypass_codec` writer - u0_pcie_bypass_codec"]
+pub type U0_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_ckref_src` reader - u0_pcie_ckref_src"]
+pub type U0_PCIE_CKREF_SRC_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_ckref_src` writer - u0_pcie_ckref_src"]
+pub type U0_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_clk_sel` reader - u0_pcie_clk_sel"]
+pub type U0_PCIE_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_clk_sel` writer - u0_pcie_clk_sel"]
+pub type U0_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_clkreq` reader - u0_pcie_clkreq"]
+pub type U0_PCIE_CLKREQ_R = crate::BitReader;
+#[doc = "Field `u0_pcie_clkreq` writer - u0_pcie_clkreq"]
+pub type U0_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slvl_awfunc(&self) -> U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slvl_awfunc(&self) -> U0_PCIE_AXI4_SLVL_AWFUNC_R {
+        U0_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:16 - u0_plda_pcie_bus_width_o"]
+    #[doc = "Bits 15:16 - u0_pcie_bus_width_o"]
     #[inline(always)]
-    pub fn u0_plda_pcie_bus_width_o(&self) -> U0_PLDA_PCIE_BUS_WIDTH_O_R {
-        U0_PLDA_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
+    pub fn u0_pcie_bus_width_o(&self) -> U0_PCIE_BUS_WIDTH_O_R {
+        U0_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
     }
-    #[doc = "Bit 17 - u0_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u0_pcie_bypass_codec"]
     #[inline(always)]
-    pub fn u0_plda_pcie_bypass_codec(&self) -> U0_PLDA_PCIE_BYPASS_CODEC_R {
-        U0_PLDA_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_pcie_bypass_codec(&self) -> U0_PCIE_BYPASS_CODEC_R {
+        U0_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bits 18:19 - u0_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u0_pcie_ckref_src"]
     #[inline(always)]
-    pub fn u0_plda_pcie_ckref_src(&self) -> U0_PLDA_PCIE_CKREF_SRC_R {
-        U0_PLDA_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
+    pub fn u0_pcie_ckref_src(&self) -> U0_PCIE_CKREF_SRC_R {
+        U0_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u0_pcie_clk_sel"]
     #[inline(always)]
-    pub fn u0_plda_pcie_clk_sel(&self) -> U0_PLDA_PCIE_CLK_SEL_R {
-        U0_PLDA_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u0_pcie_clk_sel(&self) -> U0_PCIE_CLK_SEL_R {
+        U0_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u0_pcie_clkreq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_clkreq(&self) -> U0_PLDA_PCIE_CLKREQ_R {
-        U0_PLDA_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_pcie_clkreq(&self) -> U0_PCIE_CLKREQ_R {
+        U0_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slvl_awfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
+    pub fn u0_pcie_axi4_slvl_awfunc(&mut self) -> U0_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
     }
-    #[doc = "Bit 17 - u0_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u0_pcie_bypass_codec"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_bypass_codec(&mut self) -> U0_PLDA_PCIE_BYPASS_CODEC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_BYPASS_CODEC_W::new(self, 17)
+    pub fn u0_pcie_bypass_codec(&mut self) -> U0_PCIE_BYPASS_CODEC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_BYPASS_CODEC_W::new(self, 17)
     }
-    #[doc = "Bits 18:19 - u0_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u0_pcie_ckref_src"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_ckref_src(&mut self) -> U0_PLDA_PCIE_CKREF_SRC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CKREF_SRC_W::new(self, 18)
+    pub fn u0_pcie_ckref_src(&mut self) -> U0_PCIE_CKREF_SRC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CKREF_SRC_W::new(self, 18)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u0_pcie_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_clk_sel(&mut self) -> U0_PLDA_PCIE_CLK_SEL_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CLK_SEL_W::new(self, 20)
+    pub fn u0_pcie_clk_sel(&mut self) -> U0_PCIE_CLK_SEL_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CLK_SEL_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u0_pcie_clkreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_clkreq(&mut self) -> U0_PLDA_PCIE_CLKREQ_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CLKREQ_W::new(self, 22)
+    pub fn u0_pcie_clkreq(&mut self) -> U0_PCIE_CLKREQ_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CLKREQ_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_5.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_5.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_5_SPEC>;
 #[doc = "Register `stg_syscfg_5` writer"]
 pub type W = crate::W<STG_SYSCFG_5_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_link_state` reader - u0_cdn_usb_xhci_debug_link_state"]
-pub type U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_usb_xhci_debug_link_state` reader - u0_usb_xhci_debug_link_state"]
+pub type U0_USB_XHCI_DEBUG_LINK_STATE_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:30 - u0_cdn_usb_xhci_debug_link_state"]
+    #[doc = "Bits 0:30 - u0_usb_xhci_debug_link_state"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_link_state(&self) -> U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R {
-        U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R::new(self.bits & 0x7fff_ffff)
+    pub fn u0_usb_xhci_debug_link_state(&self) -> U0_USB_XHCI_DEBUG_LINK_STATE_R {
+        U0_USB_XHCI_DEBUG_LINK_STATE_R::new(self.bits & 0x7fff_ffff)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_50.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_50.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_50_SPEC>;
 #[doc = "Register `stg_syscfg_50` writer"]
 pub type W = crate::W<STG_SYSCFG_50_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_31_0` reader - u0_plda_pcie_k_phyparam_31_0"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_31_0` writer - u0_plda_pcie_k_phyparam_31_0"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_31_0` reader - u0_pcie_k_phyparam_31_0"]
+pub type U0_PCIE_K_PHYPARAM_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_31_0` writer - u0_pcie_k_phyparam_31_0"]
+pub type U0_PCIE_K_PHYPARAM_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_31_0(&self) -> U0_PLDA_PCIE_K_PHYPARAM_31_0_R {
-        U0_PLDA_PCIE_K_PHYPARAM_31_0_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_31_0(&self) -> U0_PCIE_K_PHYPARAM_31_0_R {
+        U0_PCIE_K_PHYPARAM_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_31_0(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_31_0_W<STG_SYSCFG_50_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_31_0_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_31_0(&mut self) -> U0_PCIE_K_PHYPARAM_31_0_W<STG_SYSCFG_50_SPEC> {
+        U0_PCIE_K_PHYPARAM_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_51.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_51.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_51_SPEC>;
 #[doc = "Register `stg_syscfg_51` writer"]
 pub type W = crate::W<STG_SYSCFG_51_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_63_32` reader - u0_plda_pcie_k_phyparam_63_32"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_63_32` writer - u0_plda_pcie_k_phyparam_63_32"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_63_32` reader - u0_pcie_k_phyparam_63_32"]
+pub type U0_PCIE_K_PHYPARAM_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_63_32` writer - u0_pcie_k_phyparam_63_32"]
+pub type U0_PCIE_K_PHYPARAM_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_63_32(&self) -> U0_PLDA_PCIE_K_PHYPARAM_63_32_R {
-        U0_PLDA_PCIE_K_PHYPARAM_63_32_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_63_32(&self) -> U0_PCIE_K_PHYPARAM_63_32_R {
+        U0_PCIE_K_PHYPARAM_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_63_32(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_63_32_W<STG_SYSCFG_51_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_63_32_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_63_32(&mut self) -> U0_PCIE_K_PHYPARAM_63_32_W<STG_SYSCFG_51_SPEC> {
+        U0_PCIE_K_PHYPARAM_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_52.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_52.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_52_SPEC>;
 #[doc = "Register `stg_syscfg_52` writer"]
 pub type W = crate::W<STG_SYSCFG_52_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_95_64` reader - u0_plda_pcie_k_phyparam_95_64"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_95_64` writer - u0_plda_pcie_k_phyparam_95_64"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_95_64` reader - u0_pcie_k_phyparam_95_64"]
+pub type U0_PCIE_K_PHYPARAM_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_95_64` writer - u0_pcie_k_phyparam_95_64"]
+pub type U0_PCIE_K_PHYPARAM_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_95_64(&self) -> U0_PLDA_PCIE_K_PHYPARAM_95_64_R {
-        U0_PLDA_PCIE_K_PHYPARAM_95_64_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_95_64(&self) -> U0_PCIE_K_PHYPARAM_95_64_R {
+        U0_PCIE_K_PHYPARAM_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_95_64(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_95_64_W<STG_SYSCFG_52_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_95_64_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_95_64(&mut self) -> U0_PCIE_K_PHYPARAM_95_64_W<STG_SYSCFG_52_SPEC> {
+        U0_PCIE_K_PHYPARAM_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_53.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_53.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_53_SPEC>;
 #[doc = "Register `stg_syscfg_53` writer"]
 pub type W = crate::W<STG_SYSCFG_53_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_127_96` reader - u0_plda_pcie_k_phyparam_127_96"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_127_96` writer - u0_plda_pcie_k_phyparam_127_96"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_127_96` reader - u0_pcie_k_phyparam_127_96"]
+pub type U0_PCIE_K_PHYPARAM_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_127_96` writer - u0_pcie_k_phyparam_127_96"]
+pub type U0_PCIE_K_PHYPARAM_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_127_96(&self) -> U0_PLDA_PCIE_K_PHYPARAM_127_96_R {
-        U0_PLDA_PCIE_K_PHYPARAM_127_96_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_127_96(&self) -> U0_PCIE_K_PHYPARAM_127_96_R {
+        U0_PCIE_K_PHYPARAM_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_127_96(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_127_96_W<STG_SYSCFG_53_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_127_96_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_127_96(&mut self) -> U0_PCIE_K_PHYPARAM_127_96_W<STG_SYSCFG_53_SPEC> {
+        U0_PCIE_K_PHYPARAM_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_54.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_54.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_54_SPEC>;
 #[doc = "Register `stg_syscfg_54` writer"]
 pub type W = crate::W<STG_SYSCFG_54_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_159_128` reader - u0_plda_pcie_k_phyparam_159_128"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_159_128` writer - u0_plda_pcie_k_phyparam_159_128"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_159_128` reader - u0_pcie_k_phyparam_159_128"]
+pub type U0_PCIE_K_PHYPARAM_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_159_128` writer - u0_pcie_k_phyparam_159_128"]
+pub type U0_PCIE_K_PHYPARAM_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_159_128(&self) -> U0_PLDA_PCIE_K_PHYPARAM_159_128_R {
-        U0_PLDA_PCIE_K_PHYPARAM_159_128_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_159_128(&self) -> U0_PCIE_K_PHYPARAM_159_128_R {
+        U0_PCIE_K_PHYPARAM_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_159_128(
+    pub fn u0_pcie_k_phyparam_159_128(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_159_128_W<STG_SYSCFG_54_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_159_128_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_159_128_W<STG_SYSCFG_54_SPEC> {
+        U0_PCIE_K_PHYPARAM_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_55.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_55.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_55_SPEC>;
 #[doc = "Register `stg_syscfg_55` writer"]
 pub type W = crate::W<STG_SYSCFG_55_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_191_160` reader - u0_plda_pcie_k_phyparam_191_160"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_191_160` writer - u0_plda_pcie_k_phyparam_191_160"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_191_160` reader - u0_pcie_k_phyparam_191_160"]
+pub type U0_PCIE_K_PHYPARAM_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_191_160` writer - u0_pcie_k_phyparam_191_160"]
+pub type U0_PCIE_K_PHYPARAM_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_191_160(&self) -> U0_PLDA_PCIE_K_PHYPARAM_191_160_R {
-        U0_PLDA_PCIE_K_PHYPARAM_191_160_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_191_160(&self) -> U0_PCIE_K_PHYPARAM_191_160_R {
+        U0_PCIE_K_PHYPARAM_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_191_160(
+    pub fn u0_pcie_k_phyparam_191_160(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_191_160_W<STG_SYSCFG_55_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_191_160_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_191_160_W<STG_SYSCFG_55_SPEC> {
+        U0_PCIE_K_PHYPARAM_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_56.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_56.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_56_SPEC>;
 #[doc = "Register `stg_syscfg_56` writer"]
 pub type W = crate::W<STG_SYSCFG_56_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_223_192` reader - u0_plda_pcie_k_phyparam_223_192"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_223_192` writer - u0_plda_pcie_k_phyparam_223_192"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_223_192` reader - u0_pcie_k_phyparam_223_192"]
+pub type U0_PCIE_K_PHYPARAM_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_223_192` writer - u0_pcie_k_phyparam_223_192"]
+pub type U0_PCIE_K_PHYPARAM_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_223_192(&self) -> U0_PLDA_PCIE_K_PHYPARAM_223_192_R {
-        U0_PLDA_PCIE_K_PHYPARAM_223_192_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_223_192(&self) -> U0_PCIE_K_PHYPARAM_223_192_R {
+        U0_PCIE_K_PHYPARAM_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_223_192(
+    pub fn u0_pcie_k_phyparam_223_192(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_223_192_W<STG_SYSCFG_56_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_223_192_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_223_192_W<STG_SYSCFG_56_SPEC> {
+        U0_PCIE_K_PHYPARAM_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_57.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_57.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_57_SPEC>;
 #[doc = "Register `stg_syscfg_57` writer"]
 pub type W = crate::W<STG_SYSCFG_57_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_255_224` reader - u0_plda_pcie_k_phyparam_255_224"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_255_224` writer - u0_plda_pcie_k_phyparam_255_224"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_255_224` reader - u0_pcie_k_phyparam_255_224"]
+pub type U0_PCIE_K_PHYPARAM_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_255_224` writer - u0_pcie_k_phyparam_255_224"]
+pub type U0_PCIE_K_PHYPARAM_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_255_224(&self) -> U0_PLDA_PCIE_K_PHYPARAM_255_224_R {
-        U0_PLDA_PCIE_K_PHYPARAM_255_224_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_255_224(&self) -> U0_PCIE_K_PHYPARAM_255_224_R {
+        U0_PCIE_K_PHYPARAM_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_255_224(
+    pub fn u0_pcie_k_phyparam_255_224(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_255_224_W<STG_SYSCFG_57_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_255_224_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_255_224_W<STG_SYSCFG_57_SPEC> {
+        U0_PCIE_K_PHYPARAM_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_58.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_58.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_58_SPEC>;
 #[doc = "Register `stg_syscfg_58` writer"]
 pub type W = crate::W<STG_SYSCFG_58_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_287_256` reader - u0_plda_pcie_k_phyparam_287_256"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_287_256_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_287_256` writer - u0_plda_pcie_k_phyparam_287_256"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_287_256` reader - u0_pcie_k_phyparam_287_256"]
+pub type U0_PCIE_K_PHYPARAM_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_287_256` writer - u0_pcie_k_phyparam_287_256"]
+pub type U0_PCIE_K_PHYPARAM_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_287_256(&self) -> U0_PLDA_PCIE_K_PHYPARAM_287_256_R {
-        U0_PLDA_PCIE_K_PHYPARAM_287_256_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_287_256(&self) -> U0_PCIE_K_PHYPARAM_287_256_R {
+        U0_PCIE_K_PHYPARAM_287_256_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_287_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_287_256(
+    pub fn u0_pcie_k_phyparam_287_256(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_287_256_W<STG_SYSCFG_58_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_287_256_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_287_256_W<STG_SYSCFG_58_SPEC> {
+        U0_PCIE_K_PHYPARAM_287_256_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_59.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_59.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_59_SPEC>;
 #[doc = "Register `stg_syscfg_59` writer"]
 pub type W = crate::W<STG_SYSCFG_59_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_319_288` reader - u0_plda_pcie_k_phyparam_319_288"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_319_288_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_319_288` writer - u0_plda_pcie_k_phyparam_319_288"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_319_288` reader - u0_pcie_k_phyparam_319_288"]
+pub type U0_PCIE_K_PHYPARAM_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_319_288` writer - u0_pcie_k_phyparam_319_288"]
+pub type U0_PCIE_K_PHYPARAM_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_319_288(&self) -> U0_PLDA_PCIE_K_PHYPARAM_319_288_R {
-        U0_PLDA_PCIE_K_PHYPARAM_319_288_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_319_288(&self) -> U0_PCIE_K_PHYPARAM_319_288_R {
+        U0_PCIE_K_PHYPARAM_319_288_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_319_288"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_319_288(
+    pub fn u0_pcie_k_phyparam_319_288(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_319_288_W<STG_SYSCFG_59_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_319_288_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_319_288_W<STG_SYSCFG_59_SPEC> {
+        U0_PCIE_K_PHYPARAM_319_288_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_6.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_6.rs
@@ -2,161 +2,159 @@
 pub type R = crate::R<STG_SYSCFG_6_SPEC>;
 #[doc = "Register `stg_syscfg_6` writer"]
 pub type W = crate::W<STG_SYSCFG_6_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_sel` reader - u0_cdn_usb_xhci_debug_sel"]
-pub type U0_CDN_USB_XHCI_DEBUG_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_xhci_debug_sel` writer - u0_cdn_usb_xhci_debug_sel"]
-pub type U0_CDN_USB_XHCI_DEBUG_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_off_ack` reader - u0_cdn_usb_xhci_main_power_off_ack"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_off_req` reader - u0_cdn_usb_xhci_main_power_off_req"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_ready` reader - u0_cdn_usb_xhci_main_power_on_ready"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_ready` writer - u0_cdn_usb_xhci_main_power_on_ready"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_req` reader - u0_cdn_usb_xhci_main_power_on_req"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_valid` reader - u0_cdn_usb_xhci_main_power_on_valid"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_valid` writer - u0_cdn_usb_xhci_main_power_on_valid"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_ack` reader - u0_cdn_usb_xhci_power_off_ack"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_ready` reader - u0_cdn_usb_xhci_power_off_ready"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_req` reader - u0_cdn_usb_xhci_power_off_req"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_req` writer - u0_cdn_usb_xhci_power_off_req"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_ready` reader - u0_cdn_usb_xhci_power_on_ready"]
-pub type U0_CDN_USB_XHCI_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_req` reader - u0_cdn_usb_xhci_power_on_req"]
-pub type U0_CDN_USB_XHCI_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_valid` reader - u0_cdn_usb_xhci_power_on_valid"]
-pub type U0_CDN_USB_XHCI_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_valid` writer - u0_cdn_usb_xhci_power_on_valid"]
-pub type U0_CDN_USB_XHCI_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_e2_sft7110_cease_from_tile_0` reader - u0_e2_sft7110_cease_from_tile_0"]
-pub type U0_E2_SFT7110_CEASE_FROM_TILE_0_R = crate::BitReader;
-#[doc = "Field `u0_e2_sft7110_debug_from_tile_0` reader - u0_e2_sft7110_debug_from_tile_0"]
-pub type U0_E2_SFT7110_DEBUG_FROM_TILE_0_R = crate::BitReader;
-#[doc = "Field `u0_e2_sft7110_halt_from_tile_0` reader - u0_e2_sft7110_halt_from_tile_0"]
-pub type U0_E2_SFT7110_HALT_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_debug_sel` reader - u0_usb_xhci_debug_sel"]
+pub type U0_USB_XHCI_DEBUG_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_usb_xhci_debug_sel` writer - u0_usb_xhci_debug_sel"]
+pub type U0_USB_XHCI_DEBUG_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_usb_xhci_main_power_off_ack` reader - u0_usb_xhci_main_power_off_ack"]
+pub type U0_USB_XHCI_MAIN_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_off_req` reader - u0_usb_xhci_main_power_off_req"]
+pub type U0_USB_XHCI_MAIN_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_ready` reader - u0_usb_xhci_main_power_on_ready"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_ready` writer - u0_usb_xhci_main_power_on_ready"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_READY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_main_power_on_req` reader - u0_usb_xhci_main_power_on_req"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_valid` reader - u0_usb_xhci_main_power_on_valid"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_valid` writer - u0_usb_xhci_main_power_on_valid"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_power_off_ack` reader - u0_usb_xhci_power_off_ack"]
+pub type U0_USB_XHCI_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_ready` reader - u0_usb_xhci_power_off_ready"]
+pub type U0_USB_XHCI_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_req` reader - u0_usb_xhci_power_off_req"]
+pub type U0_USB_XHCI_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_req` writer - u0_usb_xhci_power_off_req"]
+pub type U0_USB_XHCI_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_power_on_ready` reader - u0_usb_xhci_power_on_ready"]
+pub type U0_USB_XHCI_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_req` reader - u0_usb_xhci_power_on_req"]
+pub type U0_USB_XHCI_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_valid` reader - u0_usb_xhci_power_on_valid"]
+pub type U0_USB_XHCI_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_valid` writer - u0_usb_xhci_power_on_valid"]
+pub type U0_USB_XHCI_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_cease_from_tile_0` reader - u0_e2_cease_from_tile_0"]
+pub type U0_E2_CEASE_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_debug_from_tile_0` reader - u0_e2_debug_from_tile_0"]
+pub type U0_E2_DEBUG_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_halt_from_tile_0` reader - u0_e2_halt_from_tile_0"]
+pub type U0_E2_HALT_FROM_TILE_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:4 - u0_cdn_usb_xhci_debug_sel"]
+    #[doc = "Bits 0:4 - u0_usb_xhci_debug_sel"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_sel(&self) -> U0_CDN_USB_XHCI_DEBUG_SEL_R {
-        U0_CDN_USB_XHCI_DEBUG_SEL_R::new((self.bits & 0x1f) as u8)
+    pub fn u0_usb_xhci_debug_sel(&self) -> U0_USB_XHCI_DEBUG_SEL_R {
+        U0_USB_XHCI_DEBUG_SEL_R::new((self.bits & 0x1f) as u8)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_xhci_main_power_off_ack"]
+    #[doc = "Bit 5 - u0_usb_xhci_main_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_off_ack(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_off_ack(&self) -> U0_USB_XHCI_MAIN_POWER_OFF_ACK_R {
+        U0_USB_XHCI_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_xhci_main_power_off_req"]
+    #[doc = "Bit 6 - u0_usb_xhci_main_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_off_req(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_off_req(&self) -> U0_USB_XHCI_MAIN_POWER_OFF_REQ_R {
+        U0_USB_XHCI_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_xhci_main_power_on_ready"]
+    #[doc = "Bit 7 - u0_usb_xhci_main_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_ready(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_ready(&self) -> U0_USB_XHCI_MAIN_POWER_ON_READY_R {
+        U0_USB_XHCI_MAIN_POWER_ON_READY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_xhci_main_power_on_req"]
+    #[doc = "Bit 8 - u0_usb_xhci_main_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_req(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_req(&self) -> U0_USB_XHCI_MAIN_POWER_ON_REQ_R {
+        U0_USB_XHCI_MAIN_POWER_ON_REQ_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_xhci_main_power_on_valid"]
+    #[doc = "Bit 9 - u0_usb_xhci_main_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_valid(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_valid(&self) -> U0_USB_XHCI_MAIN_POWER_ON_VALID_R {
+        U0_USB_XHCI_MAIN_POWER_ON_VALID_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_xhci_power_off_ack"]
+    #[doc = "Bit 10 - u0_usb_xhci_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_ack(&self) -> U0_CDN_USB_XHCI_POWER_OFF_ACK_R {
-        U0_CDN_USB_XHCI_POWER_OFF_ACK_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_ack(&self) -> U0_USB_XHCI_POWER_OFF_ACK_R {
+        U0_USB_XHCI_POWER_OFF_ACK_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_xhci_power_off_ready"]
+    #[doc = "Bit 11 - u0_usb_xhci_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_ready(&self) -> U0_CDN_USB_XHCI_POWER_OFF_READY_R {
-        U0_CDN_USB_XHCI_POWER_OFF_READY_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_ready(&self) -> U0_USB_XHCI_POWER_OFF_READY_R {
+        U0_USB_XHCI_POWER_OFF_READY_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_xhci_power_off_req"]
+    #[doc = "Bit 12 - u0_usb_xhci_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_req(&self) -> U0_CDN_USB_XHCI_POWER_OFF_REQ_R {
-        U0_CDN_USB_XHCI_POWER_OFF_REQ_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_req(&self) -> U0_USB_XHCI_POWER_OFF_REQ_R {
+        U0_USB_XHCI_POWER_OFF_REQ_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_xhci_power_on_ready"]
+    #[doc = "Bit 13 - u0_usb_xhci_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_ready(&self) -> U0_CDN_USB_XHCI_POWER_ON_READY_R {
-        U0_CDN_USB_XHCI_POWER_ON_READY_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_ready(&self) -> U0_USB_XHCI_POWER_ON_READY_R {
+        U0_USB_XHCI_POWER_ON_READY_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_xhci_power_on_req"]
+    #[doc = "Bit 14 - u0_usb_xhci_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_req(&self) -> U0_CDN_USB_XHCI_POWER_ON_REQ_R {
-        U0_CDN_USB_XHCI_POWER_ON_REQ_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_req(&self) -> U0_USB_XHCI_POWER_ON_REQ_R {
+        U0_USB_XHCI_POWER_ON_REQ_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_xhci_power_on_valid"]
+    #[doc = "Bit 15 - u0_usb_xhci_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_valid(&self) -> U0_CDN_USB_XHCI_POWER_ON_VALID_R {
-        U0_CDN_USB_XHCI_POWER_ON_VALID_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_valid(&self) -> U0_USB_XHCI_POWER_ON_VALID_R {
+        U0_USB_XHCI_POWER_ON_VALID_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_e2_sft7110_cease_from_tile_0"]
+    #[doc = "Bit 16 - u0_e2_cease_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_cease_from_tile_0(&self) -> U0_E2_SFT7110_CEASE_FROM_TILE_0_R {
-        U0_E2_SFT7110_CEASE_FROM_TILE_0_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_e2_cease_from_tile_0(&self) -> U0_E2_CEASE_FROM_TILE_0_R {
+        U0_E2_CEASE_FROM_TILE_0_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_e2_sft7110_debug_from_tile_0"]
+    #[doc = "Bit 17 - u0_e2_debug_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_debug_from_tile_0(&self) -> U0_E2_SFT7110_DEBUG_FROM_TILE_0_R {
-        U0_E2_SFT7110_DEBUG_FROM_TILE_0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_e2_debug_from_tile_0(&self) -> U0_E2_DEBUG_FROM_TILE_0_R {
+        U0_E2_DEBUG_FROM_TILE_0_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_e2_sft7110_halt_from_tile_0"]
+    #[doc = "Bit 18 - u0_e2_halt_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_halt_from_tile_0(&self) -> U0_E2_SFT7110_HALT_FROM_TILE_0_R {
-        U0_E2_SFT7110_HALT_FROM_TILE_0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_e2_halt_from_tile_0(&self) -> U0_E2_HALT_FROM_TILE_0_R {
+        U0_E2_HALT_FROM_TILE_0_R::new(((self.bits >> 18) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:4 - u0_cdn_usb_xhci_debug_sel"]
+    #[doc = "Bits 0:4 - u0_usb_xhci_debug_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_debug_sel(&mut self) -> U0_CDN_USB_XHCI_DEBUG_SEL_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_DEBUG_SEL_W::new(self, 0)
+    pub fn u0_usb_xhci_debug_sel(&mut self) -> U0_USB_XHCI_DEBUG_SEL_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_DEBUG_SEL_W::new(self, 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_xhci_main_power_on_ready"]
+    #[doc = "Bit 7 - u0_usb_xhci_main_power_on_ready"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_main_power_on_ready(
+    pub fn u0_usb_xhci_main_power_on_ready(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W::new(self, 7)
+    ) -> U0_USB_XHCI_MAIN_POWER_ON_READY_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_MAIN_POWER_ON_READY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_xhci_main_power_on_valid"]
+    #[doc = "Bit 9 - u0_usb_xhci_main_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_main_power_on_valid(
+    pub fn u0_usb_xhci_main_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W::new(self, 9)
+    ) -> U0_USB_XHCI_MAIN_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_MAIN_POWER_ON_VALID_W::new(self, 9)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_xhci_power_off_req"]
+    #[doc = "Bit 12 - u0_usb_xhci_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_power_off_req(
-        &mut self,
-    ) -> U0_CDN_USB_XHCI_POWER_OFF_REQ_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_POWER_OFF_REQ_W::new(self, 12)
+    pub fn u0_usb_xhci_power_off_req(&mut self) -> U0_USB_XHCI_POWER_OFF_REQ_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_POWER_OFF_REQ_W::new(self, 12)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_xhci_power_on_valid"]
+    #[doc = "Bit 15 - u0_usb_xhci_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_power_on_valid(
+    pub fn u0_usb_xhci_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_POWER_ON_VALID_W::new(self, 15)
+    ) -> U0_USB_XHCI_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_POWER_ON_VALID_W::new(self, 15)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_60.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_60.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_60_SPEC>;
 #[doc = "Register `stg_syscfg_60` writer"]
 pub type W = crate::W<STG_SYSCFG_60_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_351_320` reader - u0_plda_pcie_k_phyparam_351_320"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_351_320_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_351_320` writer - u0_plda_pcie_k_phyparam_351_320"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_351_320` reader - u0_pcie_k_phyparam_351_320"]
+pub type U0_PCIE_K_PHYPARAM_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_351_320` writer - u0_pcie_k_phyparam_351_320"]
+pub type U0_PCIE_K_PHYPARAM_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_351_320(&self) -> U0_PLDA_PCIE_K_PHYPARAM_351_320_R {
-        U0_PLDA_PCIE_K_PHYPARAM_351_320_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_351_320(&self) -> U0_PCIE_K_PHYPARAM_351_320_R {
+        U0_PCIE_K_PHYPARAM_351_320_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_351_320"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_351_320(
+    pub fn u0_pcie_k_phyparam_351_320(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_351_320_W<STG_SYSCFG_60_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_351_320_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_351_320_W<STG_SYSCFG_60_SPEC> {
+        U0_PCIE_K_PHYPARAM_351_320_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_61.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_61.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_61_SPEC>;
 #[doc = "Register `stg_syscfg_61` writer"]
 pub type W = crate::W<STG_SYSCFG_61_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_383_352` reader - u0_plda_pcie_k_phyparam_383_352"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_383_352_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_383_352` writer - u0_plda_pcie_k_phyparam_383_352"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_383_352` reader - u0_pcie_k_phyparam_383_352"]
+pub type U0_PCIE_K_PHYPARAM_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_383_352` writer - u0_pcie_k_phyparam_383_352"]
+pub type U0_PCIE_K_PHYPARAM_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_383_352(&self) -> U0_PLDA_PCIE_K_PHYPARAM_383_352_R {
-        U0_PLDA_PCIE_K_PHYPARAM_383_352_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_383_352(&self) -> U0_PCIE_K_PHYPARAM_383_352_R {
+        U0_PCIE_K_PHYPARAM_383_352_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_383_352"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_383_352(
+    pub fn u0_pcie_k_phyparam_383_352(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_383_352_W<STG_SYSCFG_61_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_383_352_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_383_352_W<STG_SYSCFG_61_SPEC> {
+        U0_PCIE_K_PHYPARAM_383_352_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_62.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_62.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_62_SPEC>;
 #[doc = "Register `stg_syscfg_62` writer"]
 pub type W = crate::W<STG_SYSCFG_62_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_415_384` reader - u0_plda_pcie_k_phyparam_415_384"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_415_384_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_415_384` writer - u0_plda_pcie_k_phyparam_415_384"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_415_384` reader - u0_pcie_k_phyparam_415_384"]
+pub type U0_PCIE_K_PHYPARAM_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_415_384` writer - u0_pcie_k_phyparam_415_384"]
+pub type U0_PCIE_K_PHYPARAM_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_415_384(&self) -> U0_PLDA_PCIE_K_PHYPARAM_415_384_R {
-        U0_PLDA_PCIE_K_PHYPARAM_415_384_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_415_384(&self) -> U0_PCIE_K_PHYPARAM_415_384_R {
+        U0_PCIE_K_PHYPARAM_415_384_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_415_384"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_415_384(
+    pub fn u0_pcie_k_phyparam_415_384(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_415_384_W<STG_SYSCFG_62_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_415_384_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_415_384_W<STG_SYSCFG_62_SPEC> {
+        U0_PCIE_K_PHYPARAM_415_384_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_63.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_63.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_63_SPEC>;
 #[doc = "Register `stg_syscfg_63` writer"]
 pub type W = crate::W<STG_SYSCFG_63_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_447_416` reader - u0_plda_pcie_k_phyparam_447_416"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_447_416_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_447_416` writer - u0_plda_pcie_k_phyparam_447_416"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_447_416` reader - u0_pcie_k_phyparam_447_416"]
+pub type U0_PCIE_K_PHYPARAM_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_447_416` writer - u0_pcie_k_phyparam_447_416"]
+pub type U0_PCIE_K_PHYPARAM_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_447_416(&self) -> U0_PLDA_PCIE_K_PHYPARAM_447_416_R {
-        U0_PLDA_PCIE_K_PHYPARAM_447_416_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_447_416(&self) -> U0_PCIE_K_PHYPARAM_447_416_R {
+        U0_PCIE_K_PHYPARAM_447_416_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_447_416"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_447_416(
+    pub fn u0_pcie_k_phyparam_447_416(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_447_416_W<STG_SYSCFG_63_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_447_416_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_447_416_W<STG_SYSCFG_63_SPEC> {
+        U0_PCIE_K_PHYPARAM_447_416_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_64.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_64.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_64_SPEC>;
 #[doc = "Register `stg_syscfg_64` writer"]
 pub type W = crate::W<STG_SYSCFG_64_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_479_448` reader - u0_plda_pcie_k_phyparam_479_448"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_479_448_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_479_448` writer - u0_plda_pcie_k_phyparam_479_448"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_479_448` reader - u0_pcie_k_phyparam_479_448"]
+pub type U0_PCIE_K_PHYPARAM_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_479_448` writer - u0_pcie_k_phyparam_479_448"]
+pub type U0_PCIE_K_PHYPARAM_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_479_448(&self) -> U0_PLDA_PCIE_K_PHYPARAM_479_448_R {
-        U0_PLDA_PCIE_K_PHYPARAM_479_448_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_479_448(&self) -> U0_PCIE_K_PHYPARAM_479_448_R {
+        U0_PCIE_K_PHYPARAM_479_448_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_479_448"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_479_448(
+    pub fn u0_pcie_k_phyparam_479_448(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_479_448_W<STG_SYSCFG_64_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_479_448_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_479_448_W<STG_SYSCFG_64_SPEC> {
+        U0_PCIE_K_PHYPARAM_479_448_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_65.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_65.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_65_SPEC>;
 #[doc = "Register `stg_syscfg_65` writer"]
 pub type W = crate::W<STG_SYSCFG_65_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_511_480` reader - u0_plda_pcie_k_phyparam_511_480"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_511_480_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_511_480` writer - u0_plda_pcie_k_phyparam_511_480"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_511_480` reader - u0_pcie_k_phyparam_511_480"]
+pub type U0_PCIE_K_PHYPARAM_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_511_480` writer - u0_pcie_k_phyparam_511_480"]
+pub type U0_PCIE_K_PHYPARAM_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_511_480(&self) -> U0_PLDA_PCIE_K_PHYPARAM_511_480_R {
-        U0_PLDA_PCIE_K_PHYPARAM_511_480_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_511_480(&self) -> U0_PCIE_K_PHYPARAM_511_480_R {
+        U0_PCIE_K_PHYPARAM_511_480_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_511_480"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_511_480(
+    pub fn u0_pcie_k_phyparam_511_480(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_511_480_W<STG_SYSCFG_65_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_511_480_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_511_480_W<STG_SYSCFG_65_SPEC> {
+        U0_PCIE_K_PHYPARAM_511_480_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_66.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_66.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_66_SPEC>;
 #[doc = "Register `stg_syscfg_66` writer"]
 pub type W = crate::W<STG_SYSCFG_66_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_543_512` reader - u0_plda_pcie_k_phyparam_543_512"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_543_512_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_543_512` writer - u0_plda_pcie_k_phyparam_543_512"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_543_512_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_543_512` reader - u0_pcie_k_phyparam_543_512"]
+pub type U0_PCIE_K_PHYPARAM_543_512_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_543_512` writer - u0_pcie_k_phyparam_543_512"]
+pub type U0_PCIE_K_PHYPARAM_543_512_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_543_512"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_543_512"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_543_512(&self) -> U0_PLDA_PCIE_K_PHYPARAM_543_512_R {
-        U0_PLDA_PCIE_K_PHYPARAM_543_512_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_543_512(&self) -> U0_PCIE_K_PHYPARAM_543_512_R {
+        U0_PCIE_K_PHYPARAM_543_512_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_543_512"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_543_512"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_543_512(
+    pub fn u0_pcie_k_phyparam_543_512(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_543_512_W<STG_SYSCFG_66_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_543_512_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_543_512_W<STG_SYSCFG_66_SPEC> {
+        U0_PCIE_K_PHYPARAM_543_512_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_67.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_67.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_67_SPEC>;
 #[doc = "Register `stg_syscfg_67` writer"]
 pub type W = crate::W<STG_SYSCFG_67_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_575_544` reader - u0_plda_pcie_k_phyparam_575_544"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_575_544_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_575_544` writer - u0_plda_pcie_k_phyparam_575_544"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_575_544_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_575_544` reader - u0_pcie_k_phyparam_575_544"]
+pub type U0_PCIE_K_PHYPARAM_575_544_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_575_544` writer - u0_pcie_k_phyparam_575_544"]
+pub type U0_PCIE_K_PHYPARAM_575_544_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_575_544"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_575_544"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_575_544(&self) -> U0_PLDA_PCIE_K_PHYPARAM_575_544_R {
-        U0_PLDA_PCIE_K_PHYPARAM_575_544_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_575_544(&self) -> U0_PCIE_K_PHYPARAM_575_544_R {
+        U0_PCIE_K_PHYPARAM_575_544_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_575_544"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_575_544"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_575_544(
+    pub fn u0_pcie_k_phyparam_575_544(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_575_544_W<STG_SYSCFG_67_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_575_544_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_575_544_W<STG_SYSCFG_67_SPEC> {
+        U0_PCIE_K_PHYPARAM_575_544_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_68.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_68.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_68_SPEC>;
 #[doc = "Register `stg_syscfg_68` writer"]
 pub type W = crate::W<STG_SYSCFG_68_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_607_576` reader - u0_plda_pcie_k_phyparam_607_576"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_607_576_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_607_576` writer - u0_plda_pcie_k_phyparam_607_576"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_607_576_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_607_576` reader - u0_pcie_k_phyparam_607_576"]
+pub type U0_PCIE_K_PHYPARAM_607_576_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_607_576` writer - u0_pcie_k_phyparam_607_576"]
+pub type U0_PCIE_K_PHYPARAM_607_576_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_607_576"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_607_576"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_607_576(&self) -> U0_PLDA_PCIE_K_PHYPARAM_607_576_R {
-        U0_PLDA_PCIE_K_PHYPARAM_607_576_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_607_576(&self) -> U0_PCIE_K_PHYPARAM_607_576_R {
+        U0_PCIE_K_PHYPARAM_607_576_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_607_576"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_607_576"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_607_576(
+    pub fn u0_pcie_k_phyparam_607_576(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_607_576_W<STG_SYSCFG_68_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_607_576_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_607_576_W<STG_SYSCFG_68_SPEC> {
+        U0_PCIE_K_PHYPARAM_607_576_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_69.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_69.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_69_SPEC>;
 #[doc = "Register `stg_syscfg_69` writer"]
 pub type W = crate::W<STG_SYSCFG_69_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_639_608` reader - u0_plda_pcie_k_phyparam_639_608"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_639_608_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_639_608` writer - u0_plda_pcie_k_phyparam_639_608"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_639_608_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_639_608` reader - u0_pcie_k_phyparam_639_608"]
+pub type U0_PCIE_K_PHYPARAM_639_608_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_639_608` writer - u0_pcie_k_phyparam_639_608"]
+pub type U0_PCIE_K_PHYPARAM_639_608_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_639_608"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_639_608"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_639_608(&self) -> U0_PLDA_PCIE_K_PHYPARAM_639_608_R {
-        U0_PLDA_PCIE_K_PHYPARAM_639_608_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_639_608(&self) -> U0_PCIE_K_PHYPARAM_639_608_R {
+        U0_PCIE_K_PHYPARAM_639_608_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_639_608"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_639_608"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_639_608(
+    pub fn u0_pcie_k_phyparam_639_608(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_639_608_W<STG_SYSCFG_69_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_639_608_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_639_608_W<STG_SYSCFG_69_SPEC> {
+        U0_PCIE_K_PHYPARAM_639_608_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_7.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_7.rs
@@ -2,28 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_7_SPEC>;
 #[doc = "Register `stg_syscfg_7` writer"]
 pub type W = crate::W<STG_SYSCFG_7_SPEC>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_exception_vector` reader - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_exception_vector` writer - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_nmi_exception_vector` reader - u0_e2_nmi_exception_vector"]
+pub type U0_E2_NMI_EXCEPTION_VECTOR_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_nmi_exception_vector` writer - u0_e2_nmi_exception_vector"]
+pub type U0_E2_NMI_EXCEPTION_VECTOR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_exception_vector"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_exception_vector(
-        &self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R {
-        U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R::new(self.bits)
+    pub fn u0_e2_nmi_exception_vector(&self) -> U0_E2_NMI_EXCEPTION_VECTOR_R {
+        U0_E2_NMI_EXCEPTION_VECTOR_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_exception_vector"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_exception_vector(
+    pub fn u0_e2_nmi_exception_vector(
         &mut self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W<STG_SYSCFG_7_SPEC> {
-        U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W::new(self, 0)
+    ) -> U0_E2_NMI_EXCEPTION_VECTOR_W<STG_SYSCFG_7_SPEC> {
+        U0_E2_NMI_EXCEPTION_VECTOR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_70.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_70.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_70_SPEC>;
 #[doc = "Register `stg_syscfg_70` writer"]
 pub type W = crate::W<STG_SYSCFG_70_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_671_640` reader - u0_plda_pcie_k_phyparam_671_640"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_671_640_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_671_640` writer - u0_plda_pcie_k_phyparam_671_640"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_671_640_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_671_640` reader - u0_pcie_k_phyparam_671_640"]
+pub type U0_PCIE_K_PHYPARAM_671_640_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_671_640` writer - u0_pcie_k_phyparam_671_640"]
+pub type U0_PCIE_K_PHYPARAM_671_640_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_671_640"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_671_640"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_671_640(&self) -> U0_PLDA_PCIE_K_PHYPARAM_671_640_R {
-        U0_PLDA_PCIE_K_PHYPARAM_671_640_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_671_640(&self) -> U0_PCIE_K_PHYPARAM_671_640_R {
+        U0_PCIE_K_PHYPARAM_671_640_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_671_640"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_671_640"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_671_640(
+    pub fn u0_pcie_k_phyparam_671_640(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_671_640_W<STG_SYSCFG_70_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_671_640_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_671_640_W<STG_SYSCFG_70_SPEC> {
+        U0_PCIE_K_PHYPARAM_671_640_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_71.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_71.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_71_SPEC>;
 #[doc = "Register `stg_syscfg_71` writer"]
 pub type W = crate::W<STG_SYSCFG_71_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_703_672` reader - u0_plda_pcie_k_phyparam_703_672"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_703_672_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_703_672` writer - u0_plda_pcie_k_phyparam_703_672"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_703_672_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_703_672` reader - u0_pcie_k_phyparam_703_672"]
+pub type U0_PCIE_K_PHYPARAM_703_672_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_703_672` writer - u0_pcie_k_phyparam_703_672"]
+pub type U0_PCIE_K_PHYPARAM_703_672_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_703_672"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_703_672"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_703_672(&self) -> U0_PLDA_PCIE_K_PHYPARAM_703_672_R {
-        U0_PLDA_PCIE_K_PHYPARAM_703_672_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_703_672(&self) -> U0_PCIE_K_PHYPARAM_703_672_R {
+        U0_PCIE_K_PHYPARAM_703_672_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_703_672"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_703_672"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_703_672(
+    pub fn u0_pcie_k_phyparam_703_672(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_703_672_W<STG_SYSCFG_71_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_703_672_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_703_672_W<STG_SYSCFG_71_SPEC> {
+        U0_PCIE_K_PHYPARAM_703_672_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_72.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_72.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_72_SPEC>;
 #[doc = "Register `stg_syscfg_72` writer"]
 pub type W = crate::W<STG_SYSCFG_72_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_735_704` reader - u0_plda_pcie_k_phyparam_735_704"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_735_704_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_735_704` writer - u0_plda_pcie_k_phyparam_735_704"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_735_704_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_735_704` reader - u0_pcie_k_phyparam_735_704"]
+pub type U0_PCIE_K_PHYPARAM_735_704_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_735_704` writer - u0_pcie_k_phyparam_735_704"]
+pub type U0_PCIE_K_PHYPARAM_735_704_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_735_704"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_735_704"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_735_704(&self) -> U0_PLDA_PCIE_K_PHYPARAM_735_704_R {
-        U0_PLDA_PCIE_K_PHYPARAM_735_704_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_735_704(&self) -> U0_PCIE_K_PHYPARAM_735_704_R {
+        U0_PCIE_K_PHYPARAM_735_704_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_735_704"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_735_704"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_735_704(
+    pub fn u0_pcie_k_phyparam_735_704(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_735_704_W<STG_SYSCFG_72_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_735_704_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_735_704_W<STG_SYSCFG_72_SPEC> {
+        U0_PCIE_K_PHYPARAM_735_704_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_73.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_73.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_73_SPEC>;
 #[doc = "Register `stg_syscfg_73` writer"]
 pub type W = crate::W<STG_SYSCFG_73_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_767_736` reader - u0_plda_pcie_k_phyparam_767_736"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_767_736_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_767_736` writer - u0_plda_pcie_k_phyparam_767_736"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_767_736_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_767_736` reader - u0_pcie_k_phyparam_767_736"]
+pub type U0_PCIE_K_PHYPARAM_767_736_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_767_736` writer - u0_pcie_k_phyparam_767_736"]
+pub type U0_PCIE_K_PHYPARAM_767_736_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_767_736"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_767_736"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_767_736(&self) -> U0_PLDA_PCIE_K_PHYPARAM_767_736_R {
-        U0_PLDA_PCIE_K_PHYPARAM_767_736_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_767_736(&self) -> U0_PCIE_K_PHYPARAM_767_736_R {
+        U0_PCIE_K_PHYPARAM_767_736_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_767_736"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_767_736"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_767_736(
+    pub fn u0_pcie_k_phyparam_767_736(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_767_736_W<STG_SYSCFG_73_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_767_736_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_767_736_W<STG_SYSCFG_73_SPEC> {
+        U0_PCIE_K_PHYPARAM_767_736_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_74.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_74.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_74_SPEC>;
 #[doc = "Register `stg_syscfg_74` writer"]
 pub type W = crate::W<STG_SYSCFG_74_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_799_768` reader - u0_plda_pcie_k_phyparam_799_768"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_799_768_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_799_768` writer - u0_plda_pcie_k_phyparam_799_768"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_799_768_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_799_768` reader - u0_pcie_k_phyparam_799_768"]
+pub type U0_PCIE_K_PHYPARAM_799_768_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_799_768` writer - u0_pcie_k_phyparam_799_768"]
+pub type U0_PCIE_K_PHYPARAM_799_768_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_799_768"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_799_768"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_799_768(&self) -> U0_PLDA_PCIE_K_PHYPARAM_799_768_R {
-        U0_PLDA_PCIE_K_PHYPARAM_799_768_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_799_768(&self) -> U0_PCIE_K_PHYPARAM_799_768_R {
+        U0_PCIE_K_PHYPARAM_799_768_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_799_768"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_799_768"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_799_768(
+    pub fn u0_pcie_k_phyparam_799_768(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_799_768_W<STG_SYSCFG_74_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_799_768_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_799_768_W<STG_SYSCFG_74_SPEC> {
+        U0_PCIE_K_PHYPARAM_799_768_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_75.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_75.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_75_SPEC>;
 #[doc = "Register `stg_syscfg_75` writer"]
 pub type W = crate::W<STG_SYSCFG_75_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_831_800` reader - u0_plda_pcie_k_phyparam_831_800"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_831_800_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_831_800` writer - u0_plda_pcie_k_phyparam_831_800"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_831_800_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_831_800` reader - u0_pcie_k_phyparam_831_800"]
+pub type U0_PCIE_K_PHYPARAM_831_800_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_831_800` writer - u0_pcie_k_phyparam_831_800"]
+pub type U0_PCIE_K_PHYPARAM_831_800_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_831_800"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_831_800"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_831_800(&self) -> U0_PLDA_PCIE_K_PHYPARAM_831_800_R {
-        U0_PLDA_PCIE_K_PHYPARAM_831_800_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_831_800(&self) -> U0_PCIE_K_PHYPARAM_831_800_R {
+        U0_PCIE_K_PHYPARAM_831_800_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_831_800"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_831_800"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_831_800(
+    pub fn u0_pcie_k_phyparam_831_800(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_831_800_W<STG_SYSCFG_75_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_831_800_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_831_800_W<STG_SYSCFG_75_SPEC> {
+        U0_PCIE_K_PHYPARAM_831_800_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_76.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_76.rs
@@ -2,62 +2,62 @@
 pub type R = crate::R<STG_SYSCFG_76_SPEC>;
 #[doc = "Register `stg_syscfg_76` writer"]
 pub type W = crate::W<STG_SYSCFG_76_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_839_832` reader - u0_plda_pcie_k_phyparam_839_832"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_k_phyparam_839_832` writer - u0_plda_pcie_k_phyparam_839_832"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_plda_pcie_k_rp_nep` reader - u0_plda_pcie_k_rp_nep"]
-pub type U0_PLDA_PCIE_K_RP_NEP_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_k_rp_nep` writer - u0_plda_pcie_k_rp_nep"]
-pub type U0_PLDA_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_l1sub_entack` reader - u0_plda_pcie_l1sub_entack"]
-pub type U0_PLDA_PCIE_L1SUB_ENTACK_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_l1sub_entreq` reader - u0_plda_pcie_l1sub_entreq"]
-pub type U0_PLDA_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_l1sub_entreq` writer - u0_plda_pcie_l1sub_entreq"]
-pub type U0_PLDA_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_k_phyparam_839_832` reader - u0_pcie_k_phyparam_839_832"]
+pub type U0_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_k_phyparam_839_832` writer - u0_pcie_k_phyparam_839_832"]
+pub type U0_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_k_rp_nep` reader - u0_pcie_k_rp_nep"]
+pub type U0_PCIE_K_RP_NEP_R = crate::BitReader;
+#[doc = "Field `u0_pcie_k_rp_nep` writer - u0_pcie_k_rp_nep"]
+pub type U0_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_l1sub_entack` reader - u0_pcie_l1sub_entack"]
+pub type U0_PCIE_L1SUB_ENTACK_R = crate::BitReader;
+#[doc = "Field `u0_pcie_l1sub_entreq` reader - u0_pcie_l1sub_entreq"]
+pub type U0_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
+#[doc = "Field `u0_pcie_l1sub_entreq` writer - u0_pcie_l1sub_entreq"]
+pub type U0_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u0_pcie_k_phyparam_839_832"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_839_832(&self) -> U0_PLDA_PCIE_K_PHYPARAM_839_832_R {
-        U0_PLDA_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_k_phyparam_839_832(&self) -> U0_PCIE_K_PHYPARAM_839_832_R {
+        U0_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u0_pcie_k_rp_nep"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_rp_nep(&self) -> U0_PLDA_PCIE_K_RP_NEP_R {
-        U0_PLDA_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_pcie_k_rp_nep(&self) -> U0_PCIE_K_RP_NEP_R {
+        U0_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_l1sub_entack"]
+    #[doc = "Bit 9 - u0_pcie_l1sub_entack"]
     #[inline(always)]
-    pub fn u0_plda_pcie_l1sub_entack(&self) -> U0_PLDA_PCIE_L1SUB_ENTACK_R {
-        U0_PLDA_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_pcie_l1sub_entack(&self) -> U0_PCIE_L1SUB_ENTACK_R {
+        U0_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u0_pcie_l1sub_entreq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_l1sub_entreq(&self) -> U0_PLDA_PCIE_L1SUB_ENTREQ_R {
-        U0_PLDA_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_pcie_l1sub_entreq(&self) -> U0_PCIE_L1SUB_ENTREQ_R {
+        U0_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u0_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u0_pcie_k_phyparam_839_832"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_839_832(
+    pub fn u0_pcie_k_phyparam_839_832(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u0_pcie_k_rp_nep"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_rp_nep(&mut self) -> U0_PLDA_PCIE_K_RP_NEP_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_K_RP_NEP_W::new(self, 8)
+    pub fn u0_pcie_k_rp_nep(&mut self) -> U0_PCIE_K_RP_NEP_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_K_RP_NEP_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u0_pcie_l1sub_entreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_l1sub_entreq(&mut self) -> U0_PLDA_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_L1SUB_ENTREQ_W::new(self, 10)
+    pub fn u0_pcie_l1sub_entreq(&mut self) -> U0_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_L1SUB_ENTREQ_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_77.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_77.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_77_SPEC>;
 #[doc = "Register `stg_syscfg_77` writer"]
 pub type W = crate::W<STG_SYSCFG_77_SPEC>;
-#[doc = "Field `u0_plda_pcie_local_interrupt_in` reader - u0_plda_pcie_local_interrupt_in"]
-pub type U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_local_interrupt_in` writer - u0_plda_pcie_local_interrupt_in"]
-pub type U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_local_interrupt_in` reader - u0_pcie_local_interrupt_in"]
+pub type U0_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_local_interrupt_in` writer - u0_pcie_local_interrupt_in"]
+pub type U0_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u0_pcie_local_interrupt_in"]
     #[inline(always)]
-    pub fn u0_plda_pcie_local_interrupt_in(&self) -> U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R {
-        U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
+    pub fn u0_pcie_local_interrupt_in(&self) -> U0_PCIE_LOCAL_INTERRUPT_IN_R {
+        U0_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u0_pcie_local_interrupt_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_local_interrupt_in(
+    pub fn u0_pcie_local_interrupt_in(
         &mut self,
-    ) -> U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_77_SPEC> {
-        U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
+    ) -> U0_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_77_SPEC> {
+        U0_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_78.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_78.rs
@@ -2,108 +2,100 @@
 pub type R = crate::R<STG_SYSCFG_78_SPEC>;
 #[doc = "Register `stg_syscfg_78` writer"]
 pub type W = crate::W<STG_SYSCFG_78_SPEC>;
-#[doc = "Field `u0_plda_pcie_mperstn` reader - u0_plda_pcie_mperstn"]
-pub type U0_PLDA_PCIE_MPERSTN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_mperstn` writer - u0_plda_pcie_mperstn"]
-pub type U0_PLDA_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_ebuf_mode` reader - u0_plda_pcie_pcie_ebuf_mode"]
-pub type U0_PLDA_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_ebuf_mode` writer - u0_plda_pcie_pcie_ebuf_mode"]
-pub type U0_PLDA_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_phy_test_cfg` reader - u0_plda_pcie_pcie_phy_test_cfg"]
-pub type U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pcie_phy_test_cfg` writer - u0_plda_pcie_pcie_phy_test_cfg"]
-pub type U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
-#[doc = "Field `u0_plda_pcie_pcie_rx_eq_training` reader - u0_plda_pcie_pcie_rx_eq_training"]
-pub type U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_rx_eq_training` writer - u0_plda_pcie_pcie_rx_eq_training"]
-pub type U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_rxterm_en` reader - u0_plda_pcie_pcie_rxterm_en"]
-pub type U0_PLDA_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_rxterm_en` writer - u0_plda_pcie_pcie_rxterm_en"]
-pub type U0_PLDA_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_tx_onezeros` reader - u0_plda_pcie_pcie_tx_onezeros"]
-pub type U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_tx_onezeros` writer - u0_plda_pcie_pcie_tx_onezeros"]
-pub type U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_mperstn` reader - u0_pcie_mperstn"]
+pub type U0_PCIE_MPERSTN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_mperstn` writer - u0_pcie_mperstn"]
+pub type U0_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_ebuf_mode` reader - u0_pcie_pcie_ebuf_mode"]
+pub type U0_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_ebuf_mode` writer - u0_pcie_pcie_ebuf_mode"]
+pub type U0_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_phy_test_cfg` reader - u0_pcie_pcie_phy_test_cfg"]
+pub type U0_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pcie_phy_test_cfg` writer - u0_pcie_pcie_phy_test_cfg"]
+pub type U0_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
+#[doc = "Field `u0_pcie_pcie_rx_eq_training` reader - u0_pcie_pcie_rx_eq_training"]
+pub type U0_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_rx_eq_training` writer - u0_pcie_pcie_rx_eq_training"]
+pub type U0_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_rxterm_en` reader - u0_pcie_pcie_rxterm_en"]
+pub type U0_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_rxterm_en` writer - u0_pcie_pcie_rxterm_en"]
+pub type U0_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_tx_onezeros` reader - u0_pcie_pcie_tx_onezeros"]
+pub type U0_PCIE_PCIE_TX_ONEZEROS_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_tx_onezeros` writer - u0_pcie_pcie_tx_onezeros"]
+pub type U0_PCIE_PCIE_TX_ONEZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u0_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u0_pcie_mperstn"]
     #[inline(always)]
-    pub fn u0_plda_pcie_mperstn(&self) -> U0_PLDA_PCIE_MPERSTN_R {
-        U0_PLDA_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
+    pub fn u0_pcie_mperstn(&self) -> U0_PCIE_MPERSTN_R {
+        U0_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u0_pcie_pcie_ebuf_mode"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_ebuf_mode(&self) -> U0_PLDA_PCIE_PCIE_EBUF_MODE_R {
-        U0_PLDA_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pcie_pcie_ebuf_mode(&self) -> U0_PCIE_PCIE_EBUF_MODE_R {
+        U0_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:24 - u0_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u0_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_phy_test_cfg(&self) -> U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R {
-        U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
+    pub fn u0_pcie_pcie_phy_test_cfg(&self) -> U0_PCIE_PCIE_PHY_TEST_CFG_R {
+        U0_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
     }
-    #[doc = "Bit 25 - u0_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u0_pcie_pcie_rx_eq_training"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_rx_eq_training(&self) -> U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R {
-        U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_pcie_pcie_rx_eq_training(&self) -> U0_PCIE_PCIE_RX_EQ_TRAINING_R {
+        U0_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u0_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u0_pcie_pcie_rxterm_en"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_rxterm_en(&self) -> U0_PLDA_PCIE_PCIE_RXTERM_EN_R {
-        U0_PLDA_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_pcie_pcie_rxterm_en(&self) -> U0_PCIE_PCIE_RXTERM_EN_R {
+        U0_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_plda_pcie_pcie_tx_onezeros"]
+    #[doc = "Bit 27 - u0_pcie_pcie_tx_onezeros"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_tx_onezeros(&self) -> U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R {
-        U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_pcie_pcie_tx_onezeros(&self) -> U0_PCIE_PCIE_TX_ONEZEROS_R {
+        U0_PCIE_PCIE_TX_ONEZEROS_R::new(((self.bits >> 27) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u0_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u0_pcie_mperstn"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_mperstn(&mut self) -> U0_PLDA_PCIE_MPERSTN_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_MPERSTN_W::new(self, 0)
+    pub fn u0_pcie_mperstn(&mut self) -> U0_PCIE_MPERSTN_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_MPERSTN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u0_pcie_pcie_ebuf_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_ebuf_mode(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
+    pub fn u0_pcie_pcie_ebuf_mode(&mut self) -> U0_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
     }
-    #[doc = "Bits 2:24 - u0_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u0_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_phy_test_cfg(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
+    pub fn u0_pcie_pcie_phy_test_cfg(&mut self) -> U0_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
     }
-    #[doc = "Bit 25 - u0_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u0_pcie_pcie_rx_eq_training"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_rx_eq_training(
+    pub fn u0_pcie_pcie_rx_eq_training(
         &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
+    ) -> U0_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
     }
-    #[doc = "Bit 26 - u0_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u0_pcie_pcie_rxterm_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_rxterm_en(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
+    pub fn u0_pcie_pcie_rxterm_en(&mut self) -> U0_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
     }
-    #[doc = "Bit 27 - u0_plda_pcie_pcie_tx_onezeros"]
+    #[doc = "Bit 27 - u0_pcie_pcie_tx_onezeros"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_tx_onezeros(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W::new(self, 27)
+    pub fn u0_pcie_pcie_tx_onezeros(&mut self) -> U0_PCIE_PCIE_TX_ONEZEROS_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_TX_ONEZEROS_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_79.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_79.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_79_SPEC>;
 #[doc = "Register `stg_syscfg_79` writer"]
 pub type W = crate::W<STG_SYSCFG_79_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf0_offset` reader - u0_plda_pcie_pf0_offset"]
-pub type U0_PLDA_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf0_offset` writer - u0_plda_pcie_pf0_offset"]
-pub type U0_PLDA_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf0_offset` reader - u0_pcie_pf0_offset"]
+pub type U0_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf0_offset` writer - u0_pcie_pf0_offset"]
+pub type U0_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf0_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf0_offset(&self) -> U0_PLDA_PCIE_PF0_OFFSET_R {
-        U0_PLDA_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf0_offset(&self) -> U0_PCIE_PF0_OFFSET_R {
+        U0_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf0_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf0_offset(&mut self) -> U0_PLDA_PCIE_PF0_OFFSET_W<STG_SYSCFG_79_SPEC> {
-        U0_PLDA_PCIE_PF0_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf0_offset(&mut self) -> U0_PCIE_PF0_OFFSET_W<STG_SYSCFG_79_SPEC> {
+        U0_PCIE_PF0_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_8.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_8.rs
@@ -2,28 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_8_SPEC>;
 #[doc = "Register `stg_syscfg_8` writer"]
 pub type W = crate::W<STG_SYSCFG_8_SPEC>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_interrupt_vector` reader - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_interrupt_vector` writer - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_nmi_interrupt_vector` reader - u0_e2_nmi_interrupt_vector"]
+pub type U0_E2_NMI_INTERRUPT_VECTOR_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_nmi_interrupt_vector` writer - u0_e2_nmi_interrupt_vector"]
+pub type U0_E2_NMI_INTERRUPT_VECTOR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_interrupt_vector"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_interrupt_vector(
-        &self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R {
-        U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R::new(self.bits)
+    pub fn u0_e2_nmi_interrupt_vector(&self) -> U0_E2_NMI_INTERRUPT_VECTOR_R {
+        U0_E2_NMI_INTERRUPT_VECTOR_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_interrupt_vector"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_interrupt_vector(
+    pub fn u0_e2_nmi_interrupt_vector(
         &mut self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W<STG_SYSCFG_8_SPEC> {
-        U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W::new(self, 0)
+    ) -> U0_E2_NMI_INTERRUPT_VECTOR_W<STG_SYSCFG_8_SPEC> {
+        U0_E2_NMI_INTERRUPT_VECTOR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_80.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_80.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_80_SPEC>;
 #[doc = "Register `stg_syscfg_80` writer"]
 pub type W = crate::W<STG_SYSCFG_80_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf1_offset` reader - u0_plda_pcie_pf1_offset"]
-pub type U0_PLDA_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf1_offset` writer - u0_plda_pcie_pf1_offset"]
-pub type U0_PLDA_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf1_offset` reader - u0_pcie_pf1_offset"]
+pub type U0_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf1_offset` writer - u0_pcie_pf1_offset"]
+pub type U0_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf1_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf1_offset(&self) -> U0_PLDA_PCIE_PF1_OFFSET_R {
-        U0_PLDA_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf1_offset(&self) -> U0_PCIE_PF1_OFFSET_R {
+        U0_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf1_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf1_offset(&mut self) -> U0_PLDA_PCIE_PF1_OFFSET_W<STG_SYSCFG_80_SPEC> {
-        U0_PLDA_PCIE_PF1_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf1_offset(&mut self) -> U0_PCIE_PF1_OFFSET_W<STG_SYSCFG_80_SPEC> {
+        U0_PCIE_PF1_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_81.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_81.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_81_SPEC>;
 #[doc = "Register `stg_syscfg_81` writer"]
 pub type W = crate::W<STG_SYSCFG_81_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf2_offset` reader - u0_plda_pcie_pf2_offset"]
-pub type U0_PLDA_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf2_offset` writer - u0_plda_pcie_pf2_offset"]
-pub type U0_PLDA_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf2_offset` reader - u0_pcie_pf2_offset"]
+pub type U0_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf2_offset` writer - u0_pcie_pf2_offset"]
+pub type U0_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf2_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf2_offset(&self) -> U0_PLDA_PCIE_PF2_OFFSET_R {
-        U0_PLDA_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf2_offset(&self) -> U0_PCIE_PF2_OFFSET_R {
+        U0_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf2_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf2_offset(&mut self) -> U0_PLDA_PCIE_PF2_OFFSET_W<STG_SYSCFG_81_SPEC> {
-        U0_PLDA_PCIE_PF2_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf2_offset(&mut self) -> U0_PCIE_PF2_OFFSET_W<STG_SYSCFG_81_SPEC> {
+        U0_PCIE_PF2_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_82.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_82.rs
@@ -2,76 +2,74 @@
 pub type R = crate::R<STG_SYSCFG_82_SPEC>;
 #[doc = "Register `stg_syscfg_82` writer"]
 pub type W = crate::W<STG_SYSCFG_82_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf3_offset` reader - u0_plda_pcie_pf3_offset"]
-pub type U0_PLDA_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf3_offset` writer - u0_plda_pcie_pf3_offset"]
-pub type U0_PLDA_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
-#[doc = "Field `u0_plda_pcie_phy_mode` reader - u0_plda_pcie_phy_mode"]
-pub type U0_PLDA_PCIE_PHY_MODE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_phy_mode` writer - u0_plda_pcie_phy_mode"]
-pub type U0_PLDA_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_pl_clkrem_allow` reader - u0_plda_pcie_pl_clkrem_allow"]
-pub type U0_PLDA_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_clkrem_allow` writer - u0_plda_pcie_pl_clkrem_allow"]
-pub type U0_PLDA_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pl_clkreq_oen` reader - u0_plda_pcie_pl_clkreq_oen"]
-pub type U0_PLDA_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_equ_phase` reader - u0_plda_pcie_pl_equ_phase"]
-pub type U0_PLDA_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_pl_ltssm` reader - u0_plda_pcie_pl_ltssm"]
-pub type U0_PLDA_PCIE_PL_LTSSM_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pf3_offset` reader - u0_pcie_pf3_offset"]
+pub type U0_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf3_offset` writer - u0_pcie_pf3_offset"]
+pub type U0_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_phy_mode` reader - u0_pcie_phy_mode"]
+pub type U0_PCIE_PHY_MODE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_phy_mode` writer - u0_pcie_phy_mode"]
+pub type U0_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_pl_clkrem_allow` reader - u0_pcie_pl_clkrem_allow"]
+pub type U0_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_clkrem_allow` writer - u0_pcie_pl_clkrem_allow"]
+pub type U0_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pl_clkreq_oen` reader - u0_pcie_pl_clkreq_oen"]
+pub type U0_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_equ_phase` reader - u0_pcie_pl_equ_phase"]
+pub type U0_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pl_ltssm` reader - u0_pcie_pl_ltssm"]
+pub type U0_PCIE_PL_LTSSM_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf3_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf3_offset(&self) -> U0_PLDA_PCIE_PF3_OFFSET_R {
-        U0_PLDA_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf3_offset(&self) -> U0_PCIE_PF3_OFFSET_R {
+        U0_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u0_pcie_phy_mode"]
     #[inline(always)]
-    pub fn u0_plda_pcie_phy_mode(&self) -> U0_PLDA_PCIE_PHY_MODE_R {
-        U0_PLDA_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u0_pcie_phy_mode(&self) -> U0_PCIE_PHY_MODE_R {
+        U0_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u0_pcie_pl_clkrem_allow"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_clkrem_allow(&self) -> U0_PLDA_PCIE_PL_CLKREM_ALLOW_R {
-        U0_PLDA_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_pcie_pl_clkrem_allow(&self) -> U0_PCIE_PL_CLKREM_ALLOW_R {
+        U0_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_plda_pcie_pl_clkreq_oen"]
+    #[doc = "Bit 23 - u0_pcie_pl_clkreq_oen"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_clkreq_oen(&self) -> U0_PLDA_PCIE_PL_CLKREQ_OEN_R {
-        U0_PLDA_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_pcie_pl_clkreq_oen(&self) -> U0_PCIE_PL_CLKREQ_OEN_R {
+        U0_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bits 24:25 - u0_plda_pcie_pl_equ_phase"]
+    #[doc = "Bits 24:25 - u0_pcie_pl_equ_phase"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_equ_phase(&self) -> U0_PLDA_PCIE_PL_EQU_PHASE_R {
-        U0_PLDA_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
+    pub fn u0_pcie_pl_equ_phase(&self) -> U0_PCIE_PL_EQU_PHASE_R {
+        U0_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
     }
-    #[doc = "Bits 26:30 - u0_plda_pcie_pl_ltssm"]
+    #[doc = "Bits 26:30 - u0_pcie_pl_ltssm"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_ltssm(&self) -> U0_PLDA_PCIE_PL_LTSSM_R {
-        U0_PLDA_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn u0_pcie_pl_ltssm(&self) -> U0_PCIE_PL_LTSSM_R {
+        U0_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf3_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf3_offset(&mut self) -> U0_PLDA_PCIE_PF3_OFFSET_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PF3_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf3_offset(&mut self) -> U0_PCIE_PF3_OFFSET_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PF3_OFFSET_W::new(self, 0)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u0_pcie_phy_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_phy_mode(&mut self) -> U0_PLDA_PCIE_PHY_MODE_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PHY_MODE_W::new(self, 20)
+    pub fn u0_pcie_phy_mode(&mut self) -> U0_PCIE_PHY_MODE_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PHY_MODE_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u0_pcie_pl_clkrem_allow"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pl_clkrem_allow(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
+    pub fn u0_pcie_pl_clkrem_allow(&mut self) -> U0_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_83.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_83.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_83_SPEC>;
 #[doc = "Register `stg_syscfg_83` writer"]
 pub type W = crate::W<STG_SYSCFG_83_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_pclk_rate` reader - u0_plda_pcie_pl_pclk_rate"]
-pub type U0_PLDA_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pl_pclk_rate` reader - u0_pcie_pl_pclk_rate"]
+pub type U0_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:4 - u0_plda_pcie_pl_pclk_rate"]
+    #[doc = "Bits 0:4 - u0_pcie_pl_pclk_rate"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_pclk_rate(&self) -> U0_PLDA_PCIE_PL_PCLK_RATE_R {
-        U0_PLDA_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
+    pub fn u0_pcie_pl_pclk_rate(&self) -> U0_PCIE_PL_PCLK_RATE_R {
+        U0_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_84.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_84.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_84_SPEC>;
 #[doc = "Register `stg_syscfg_84` writer"]
 pub type W = crate::W<STG_SYSCFG_84_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_in_31_0` reader - u0_plda_pcie_pl_sideband_in_31_0"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_in_31_0` reader - u0_pcie_pl_sideband_in_31_0"]
+pub type U0_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_in_31_0(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_in_31_0(&self) -> U0_PCIE_PL_SIDEBAND_IN_31_0_R {
+        U0_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_85.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_85.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_85_SPEC>;
 #[doc = "Register `stg_syscfg_85` writer"]
 pub type W = crate::W<STG_SYSCFG_85_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_in_63_32` reader - u0_plda_pcie_pl_sideband_in_63_32"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_in_63_32` reader - u0_pcie_pl_sideband_in_63_32"]
+pub type U0_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_in_63_32(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_in_63_32(&self) -> U0_PCIE_PL_SIDEBAND_IN_63_32_R {
+        U0_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_86.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_86.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_86_SPEC>;
 #[doc = "Register `stg_syscfg_86` writer"]
 pub type W = crate::W<STG_SYSCFG_86_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_out_31_0` reader - u0_plda_pcie_pl_sideband_out_31_0"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_out_31_0` reader - u0_pcie_pl_sideband_out_31_0"]
+pub type U0_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_out_31_0(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_out_31_0(&self) -> U0_PCIE_PL_SIDEBAND_OUT_31_0_R {
+        U0_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_87.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_87.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_87_SPEC>;
 #[doc = "Register `stg_syscfg_87` writer"]
 pub type W = crate::W<STG_SYSCFG_87_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_out_63_32` reader - u0_plda_pcie_pl_sideband_out_63_32"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_out_63_32` reader - u0_pcie_pl_sideband_out_63_32"]
+pub type U0_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_out_63_32(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_out_63_32(&self) -> U0_PCIE_PL_SIDEBAND_OUT_63_32_R {
+        U0_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_88.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_88.rs
@@ -2,37 +2,37 @@
 pub type R = crate::R<STG_SYSCFG_88_SPEC>;
 #[doc = "Register `stg_syscfg_88` writer"]
 pub type W = crate::W<STG_SYSCFG_88_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_wake_in` reader - u0_plda_pcie_pl_wake_in"]
-pub type U0_PLDA_PCIE_PL_WAKE_IN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_wake_in` writer - u0_plda_pcie_pl_wake_in"]
-pub type U0_PLDA_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pl_wake_oen` reader - u0_plda_pcie_pl_wake_oen"]
-pub type U0_PLDA_PCIE_PL_WAKE_OEN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_rx_standby_0` reader - u0_plda_pcie_rx_standby_0"]
-pub type U0_PLDA_PCIE_RX_STANDBY_0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_wake_in` reader - u0_pcie_pl_wake_in"]
+pub type U0_PCIE_PL_WAKE_IN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_wake_in` writer - u0_pcie_pl_wake_in"]
+pub type U0_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pl_wake_oen` reader - u0_pcie_pl_wake_oen"]
+pub type U0_PCIE_PL_WAKE_OEN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_rx_standby_0` reader - u0_pcie_rx_standby_0"]
+pub type U0_PCIE_RX_STANDBY_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u0_pcie_pl_wake_in"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_wake_in(&self) -> U0_PLDA_PCIE_PL_WAKE_IN_R {
-        U0_PLDA_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
+    pub fn u0_pcie_pl_wake_in(&self) -> U0_PCIE_PL_WAKE_IN_R {
+        U0_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pl_wake_oen"]
+    #[doc = "Bit 1 - u0_pcie_pl_wake_oen"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_wake_oen(&self) -> U0_PLDA_PCIE_PL_WAKE_OEN_R {
-        U0_PLDA_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pcie_pl_wake_oen(&self) -> U0_PCIE_PL_WAKE_OEN_R {
+        U0_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_plda_pcie_rx_standby_0"]
+    #[doc = "Bit 2 - u0_pcie_rx_standby_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_rx_standby_0(&self) -> U0_PLDA_PCIE_RX_STANDBY_0_R {
-        U0_PLDA_PCIE_RX_STANDBY_0_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pcie_rx_standby_0(&self) -> U0_PCIE_RX_STANDBY_0_R {
+        U0_PCIE_RX_STANDBY_0_R::new(((self.bits >> 2) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u0_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u0_pcie_pl_wake_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pl_wake_in(&mut self) -> U0_PLDA_PCIE_PL_WAKE_IN_W<STG_SYSCFG_88_SPEC> {
-        U0_PLDA_PCIE_PL_WAKE_IN_W::new(self, 0)
+    pub fn u0_pcie_pl_wake_in(&mut self) -> U0_PCIE_PL_WAKE_IN_W<STG_SYSCFG_88_SPEC> {
+        U0_PCIE_PL_WAKE_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_89.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_89.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_89_SPEC>;
 #[doc = "Register `stg_syscfg_89` writer"]
 pub type W = crate::W<STG_SYSCFG_89_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_in_31_0` reader - u0_plda_pcie_test_in_31_0"]
-pub type U0_PLDA_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_test_in_31_0` writer - u0_plda_pcie_test_in_31_0"]
-pub type U0_PLDA_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_test_in_31_0` reader - u0_pcie_test_in_31_0"]
+pub type U0_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_in_31_0` writer - u0_pcie_test_in_31_0"]
+pub type U0_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_in_31_0(&self) -> U0_PLDA_PCIE_TEST_IN_31_0_R {
-        U0_PLDA_PCIE_TEST_IN_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_in_31_0(&self) -> U0_PCIE_TEST_IN_31_0_R {
+        U0_PCIE_TEST_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_in_31_0(&mut self) -> U0_PLDA_PCIE_TEST_IN_31_0_W<STG_SYSCFG_89_SPEC> {
-        U0_PLDA_PCIE_TEST_IN_31_0_W::new(self, 0)
+    pub fn u0_pcie_test_in_31_0(&mut self) -> U0_PCIE_TEST_IN_31_0_W<STG_SYSCFG_89_SPEC> {
+        U0_PCIE_TEST_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_9.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_9.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_9_SPEC>;
 #[doc = "Register `stg_syscfg_9` writer"]
 pub type W = crate::W<STG_SYSCFG_9_SPEC>;
-#[doc = "Field `u0_e2_sft7110_reset_vector_0` reader - u0_e2_sft7110_reset_vector_0"]
-pub type U0_E2_SFT7110_RESET_VECTOR_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_reset_vector_0` writer - u0_e2_sft7110_reset_vector_0"]
-pub type U0_E2_SFT7110_RESET_VECTOR_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_reset_vector_0` reader - u0_e2_reset_vector_0"]
+pub type U0_E2_RESET_VECTOR_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_reset_vector_0` writer - u0_e2_reset_vector_0"]
+pub type U0_E2_RESET_VECTOR_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_reset_vector_0"]
+    #[doc = "Bits 0:31 - u0_e2_reset_vector_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_reset_vector_0(&self) -> U0_E2_SFT7110_RESET_VECTOR_0_R {
-        U0_E2_SFT7110_RESET_VECTOR_0_R::new(self.bits)
+    pub fn u0_e2_reset_vector_0(&self) -> U0_E2_RESET_VECTOR_0_R {
+        U0_E2_RESET_VECTOR_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_reset_vector_0"]
+    #[doc = "Bits 0:31 - u0_e2_reset_vector_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_reset_vector_0(
-        &mut self,
-    ) -> U0_E2_SFT7110_RESET_VECTOR_0_W<STG_SYSCFG_9_SPEC> {
-        U0_E2_SFT7110_RESET_VECTOR_0_W::new(self, 0)
+    pub fn u0_e2_reset_vector_0(&mut self) -> U0_E2_RESET_VECTOR_0_W<STG_SYSCFG_9_SPEC> {
+        U0_E2_RESET_VECTOR_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_90.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_90.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_90_SPEC>;
 #[doc = "Register `stg_syscfg_90` writer"]
 pub type W = crate::W<STG_SYSCFG_90_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_in_63_32` reader - u0_plda_pcie_test_in_63_32"]
-pub type U0_PLDA_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_test_in_63_32` writer - u0_plda_pcie_test_in_63_32"]
-pub type U0_PLDA_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_test_in_63_32` reader - u0_pcie_test_in_63_32"]
+pub type U0_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_in_63_32` writer - u0_pcie_test_in_63_32"]
+pub type U0_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_in_63_32(&self) -> U0_PLDA_PCIE_TEST_IN_63_32_R {
-        U0_PLDA_PCIE_TEST_IN_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_in_63_32(&self) -> U0_PCIE_TEST_IN_63_32_R {
+        U0_PCIE_TEST_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_in_63_32(
-        &mut self,
-    ) -> U0_PLDA_PCIE_TEST_IN_63_32_W<STG_SYSCFG_90_SPEC> {
-        U0_PLDA_PCIE_TEST_IN_63_32_W::new(self, 0)
+    pub fn u0_pcie_test_in_63_32(&mut self) -> U0_PCIE_TEST_IN_63_32_W<STG_SYSCFG_90_SPEC> {
+        U0_PCIE_TEST_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_91.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_91.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_91_SPEC>;
 #[doc = "Register `stg_syscfg_91` writer"]
 pub type W = crate::W<STG_SYSCFG_91_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_31_0` reader - u0_plda_pcie_test_out_bridge_31_0"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_31_0` reader - u0_pcie_test_out_bridge_31_0"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_31_0(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_31_0(&self) -> U0_PCIE_TEST_OUT_BRIDGE_31_0_R {
+        U0_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_92.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_92.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_92_SPEC>;
 #[doc = "Register `stg_syscfg_92` writer"]
 pub type W = crate::W<STG_SYSCFG_92_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_63_32` reader - u0_plda_pcie_test_out_bridge_63_32"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_63_32` reader - u0_pcie_test_out_bridge_63_32"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_63_32(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_63_32(&self) -> U0_PCIE_TEST_OUT_BRIDGE_63_32_R {
+        U0_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_93.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_93.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_93_SPEC>;
 #[doc = "Register `stg_syscfg_93` writer"]
 pub type W = crate::W<STG_SYSCFG_93_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_95_64` reader - u0_plda_pcie_test_out_bridge_95_64"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_95_64` reader - u0_pcie_test_out_bridge_95_64"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_95_64(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_95_64(&self) -> U0_PCIE_TEST_OUT_BRIDGE_95_64_R {
+        U0_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_94.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_94.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_94_SPEC>;
 #[doc = "Register `stg_syscfg_94` writer"]
 pub type W = crate::W<STG_SYSCFG_94_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_127_96` reader - u0_plda_pcie_test_out_bridge_127_96"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_127_96` reader - u0_pcie_test_out_bridge_127_96"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_127_96(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_127_96(&self) -> U0_PCIE_TEST_OUT_BRIDGE_127_96_R {
+        U0_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_95.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_95.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_95_SPEC>;
 #[doc = "Register `stg_syscfg_95` writer"]
 pub type W = crate::W<STG_SYSCFG_95_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_159_128` reader - u0_plda_pcie_test_out_bridge_159_128"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_159_128` reader - u0_pcie_test_out_bridge_159_128"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_159_128(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_159_128(&self) -> U0_PCIE_TEST_OUT_BRIDGE_159_128_R {
+        U0_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_96.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_96.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_96_SPEC>;
 #[doc = "Register `stg_syscfg_96` writer"]
 pub type W = crate::W<STG_SYSCFG_96_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_191_160` reader - u0_plda_pcie_test_out_bridge_191_160"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_191_160` reader - u0_pcie_test_out_bridge_191_160"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_191_160(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_191_160(&self) -> U0_PCIE_TEST_OUT_BRIDGE_191_160_R {
+        U0_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_97.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_97.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_97_SPEC>;
 #[doc = "Register `stg_syscfg_97` writer"]
 pub type W = crate::W<STG_SYSCFG_97_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_223_192` reader - u0_plda_pcie_test_out_bridge_223_192"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_223_192` reader - u0_pcie_test_out_bridge_223_192"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_223_192(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_223_192(&self) -> U0_PCIE_TEST_OUT_BRIDGE_223_192_R {
+        U0_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_98.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_98.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_98_SPEC>;
 #[doc = "Register `stg_syscfg_98` writer"]
 pub type W = crate::W<STG_SYSCFG_98_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_255_224` reader - u0_plda_pcie_test_out_bridge_255_224"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_255_224` reader - u0_pcie_test_out_bridge_255_224"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_255_224(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_255_224(&self) -> U0_PCIE_TEST_OUT_BRIDGE_255_224_R {
+        U0_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_99.rs
+++ b/jh7110-vf2-12a-pac/src/stg_syscon/stg_syscfg_99.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_99_SPEC>;
 #[doc = "Register `stg_syscfg_99` writer"]
 pub type W = crate::W<STG_SYSCFG_99_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_287_256` reader - u0_plda_pcie_test_out_bridge_287_256"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_287_256` reader - u0_pcie_test_out_bridge_287_256"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_287_256(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_287_256(&self) -> U0_PCIE_TEST_OUT_BRIDGE_287_256_R {
+        U0_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -12216,134 +12216,134 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_en</name>
-              <description>u0_cdn_usb_adp_en</description>
+              <name>u0_usb_adp_en</name>
+              <description>u0_usb_adp_en</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_probe_ana</name>
-              <description>u0_cdn_usb_adp_probe_ana</description>
+              <name>u0_usb_adp_probe_ana</name>
+              <description>u0_usb_adp_probe_ana</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_probe_en</name>
-              <description>u0_cdn_usb_adp_probe_en</description>
+              <name>u0_usb_adp_probe_en</name>
+              <description>u0_usb_adp_probe_en</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sense_ana</name>
-              <description>u0_cdn_usb_adp_sense_ana</description>
+              <name>u0_usb_adp_sense_ana</name>
+              <description>u0_usb_adp_sense_ana</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sense_en</name>
-              <description>u0_cdn_usb_adp_sense_en</description>
+              <name>u0_usb_adp_sense_en</name>
+              <description>u0_usb_adp_sense_en</description>
               <bitRange>[12:12]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_sink_current_en</name>
-              <description>u0_cdn_usb_adp_sink_current_en</description>
+              <name>u0_usb_adp_sink_current_en</name>
+              <description>u0_usb_adp_sink_current_en</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_adp_source_current_en</name>
-              <description>u0_cdn_usb_adp_source_current_en</description>
+              <name>u0_usb_adp_source_current_en</name>
+              <description>u0_usb_adp_source_current_en</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_bc_en</name>
-              <description>u0_cdn_usb_bc_en</description>
+              <name>u0_usb_bc_en</name>
+              <description>u0_usb_bc_en</description>
               <bitRange>[15:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_chrg_vbus</name>
-              <description>u0_cdn_usb_chrg_vbus</description>
+              <name>u0_usb_chrg_vbus</name>
+              <description>u0_usb_chrg_vbus</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dcd_comp_sts</name>
-              <description>u0_cdn_usb_dcd_comp_sts</description>
+              <name>u0_usb_dcd_comp_sts</name>
+              <description>u0_usb_dcd_comp_sts</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dischrg_vbus</name>
-              <description>u0_cdn_usb_dischrg_vbus</description>
+              <name>u0_usb_dischrg_vbus</name>
+              <description>u0_usb_dischrg_vbus</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vdat_ref_comp_en</name>
-              <description>u0_cdn_usb_dm_vdat_ref_comp_en</description>
+              <name>u0_usb_dm_vdat_ref_comp_en</name>
+              <description>u0_usb_dm_vdat_ref_comp_en</description>
               <bitRange>[19:19]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vdat_ref_comp_sts</name>
-              <description>u0_cdn_usb_dm_vdat_ref_comp_sts</description>
+              <name>u0_usb_dm_vdat_ref_comp_sts</name>
+              <description>u0_usb_dm_vdat_ref_comp_sts</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vlgc_comp_en</name>
-              <description>u0_cdn_usb_dm_vlgc_comp_en</description>
+              <name>u0_usb_dm_vlgc_comp_en</name>
+              <description>u0_usb_dm_vlgc_comp_en</description>
               <bitRange>[21:21]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dm_vlgc_comp_sts</name>
-              <description>u0_cdn_usb_dm_vlgc_comp_sts</description>
+              <name>u0_usb_dm_vlgc_comp_sts</name>
+              <description>u0_usb_dm_vlgc_comp_sts</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dp_vdat_ref_comp_en</name>
-              <description>u0_cdn_usb_dp_vdat_ref_comp_en</description>
+              <name>u0_usb_dp_vdat_ref_comp_en</name>
+              <description>u0_usb_dp_vdat_ref_comp_en</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_dp_vdat_ref_comp_sts</name>
-              <description>u0_cdn_usb_dp_vdat_ref_comp_sts</description>
+              <name>u0_usb_dp_vdat_ref_comp_sts</name>
+              <description>u0_usb_dp_vdat_ref_comp_sts</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_host_system_err</name>
-              <description>u0_cdn_usb_host_system_err</description>
+              <name>u0_usb_host_system_err</name>
+              <description>u0_usb_host_system_err</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_hsystem_err_ext</name>
-              <description>u0_cdn_usb_hsystem_err_ext</description>
+              <name>u0_usb_hsystem_err_ext</name>
+              <description>u0_usb_hsystem_err_ext</description>
               <bitRange>[26:26]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idm_sink_en</name>
-              <description>u0_cdn_usb_idm_sink_en</description>
+              <name>u0_usb_idm_sink_en</name>
+              <description>u0_usb_idm_sink_en</description>
               <bitRange>[27:27]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idp_sink_en</name>
-              <description>u0_cdn_usb_idp_sink_en</description>
+              <name>u0_usb_idp_sink_en</name>
+              <description>u0_usb_idp_sink_en</description>
               <bitRange>[28:28]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_idp_src_en</name>
-              <description>u0_cdn_usb_idp_src_en</description>
+              <name>u0_usb_idp_src_en</name>
+              <description>u0_usb_idp_src_en</description>
               <bitRange>[29:29]</bitRange>
               <access>read-only</access>
             </field>
@@ -12357,68 +12357,68 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_lowest_belt</name>
+              <name>u0_usb_lowest_belt</name>
               <description>LTM interface to software</description>
               <bitRange>[11:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_ltm_host_req</name>
+              <name>u0_usb_ltm_host_req</name>
               <description>LTM interface to software</description>
               <bitRange>[12:12]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_ltm_host_req_halt</name>
+              <name>u0_usb_ltm_host_req_halt</name>
               <description>LTM interface to software</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mdctrl_clk_sel</name>
-              <description>u0_cdn_usb_mdctrl_clk_sel</description>
+              <name>u0_usb_mdctrl_clk_sel</name>
+              <description>u0_usb_mdctrl_clk_sel</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mdctrl_clk_status</name>
-              <description>u0_cdn_usb_mdctrl_clk_status</description>
+              <name>u0_usb_mdctrl_clk_status</name>
+              <description>u0_usb_mdctrl_clk_status</description>
               <bitRange>[15:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_mode_strap</name>
+              <name>u0_usb_mode_strap</name>
               <description>Can onlly be changed when pwrup_rst_n is low</description>
               <bitRange>[18:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_otg_suspendm</name>
-              <description>u0_cdn_usb_otg_suspendm</description>
+              <name>u0_usb_otg_suspendm</name>
+              <description>u0_usb_otg_suspendm</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_otg_suspendm_byps</name>
-              <description>u0_cdn_usb_otg_suspendm_byps</description>
+              <name>u0_usb_otg_suspendm_byps</name>
+              <description>u0_usb_otg_suspendm_byps</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_phy_bvalid</name>
-              <description>u0_cdn_usb_phy_bvalid</description>
+              <name>u0_usb_phy_bvalid</name>
+              <description>u0_usb_phy_bvalid</description>
               <bitRange>[21:21]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_pll_en</name>
-              <description>u0_cdn_usb_pll_en</description>
+              <name>u0_usb_pll_en</name>
+              <description>u0_usb_pll_en</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_refclk_mode</name>
-              <description>u0_cdn_usb_refclk_mode</description>
+              <name>u0_usb_refclk_mode</name>
+              <description>u0_usb_refclk_mode</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
@@ -12441,32 +12441,32 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_float_comp_en</name>
-              <description>u0_cdn_usb_rid_float_comp_en</description>
+              <name>u0_usb_rid_float_comp_en</name>
+              <description>u0_usb_rid_float_comp_en</description>
               <bitRange>[27:27]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_float_comp_sts</name>
-              <description>u0_cdn_usb_rid_float_comp_sts</description>
+              <name>u0_usb_rid_float_comp_sts</name>
+              <description>u0_usb_rid_float_comp_sts</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_gnd_comp_sts</name>
-              <description>u0_cdn_usb_rid_gnd_comp_sts</description>
+              <name>u0_usb_rid_gnd_comp_sts</name>
+              <description>u0_usb_rid_gnd_comp_sts</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rid_nonfloat_comp_en</name>
-              <description>u0_cdn_usb_rid_nonfloat_comp_en</description>
+              <name>u0_usb_rid_nonfloat_comp_en</name>
+              <description>u0_usb_rid_nonfloat_comp_en</description>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rx_dm</name>
-              <description>u0_cdn_usb_rx_dm</description>
+              <name>u0_usb_rx_dm</name>
+              <description>u0_usb_rx_dm</description>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
             </field>
@@ -12480,182 +12480,182 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_rx_dp</name>
-              <description>u0_cdn_usb_rx_dp</description>
+              <name>u0_usb_rx_dp</name>
+              <description>u0_usb_rx_dp</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_rx_rcv</name>
-              <description>u0_cdn_usb_rx_rcv</description>
+              <name>u0_usb_rx_rcv</name>
+              <description>u0_usb_rx_rcv</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_self_test</name>
+              <name>u0_usb_self_test</name>
               <description>For software bist_test</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sessend</name>
-              <description>u0_cdn_usb_sessend</description>
+              <name>u0_usb_sessend</name>
+              <description>u0_usb_sessend</description>
               <bitRange>[3:3]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sessvalid</name>
-              <description>u0_cdn_usb_sessvalid</description>
+              <name>u0_usb_sessvalid</name>
+              <description>u0_usb_sessvalid</description>
               <bitRange>[4:4]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_sof</name>
-              <description>u0_cdn_usb_sof</description>
+              <name>u0_usb_sof</name>
+              <description>u0_usb_sof</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_test_bist</name>
+              <name>u0_usb_test_bist</name>
               <description>For software bist_test</description>
               <bitRange>[6:6]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_ack</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_ack</description>
+              <name>u0_usb_usbdev_main_power_off_ack</name>
+              <description>u0_usb_usbdev_main_power_off_ack</description>
               <bitRange>[7:7]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_ready</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_ready</description>
+              <name>u0_usb_usbdev_main_power_off_ready</name>
+              <description>u0_usb_usbdev_main_power_off_ready</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_off_req</name>
-              <description>u0_cdn_usb_usbdev_main_power_off_req</description>
+              <name>u0_usb_usbdev_main_power_off_req</name>
+              <description>u0_usb_usbdev_main_power_off_req</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_ready</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_ready</description>
+              <name>u0_usb_usbdev_main_power_on_ready</name>
+              <description>u0_usb_usbdev_main_power_on_ready</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_req</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_req</description>
+              <name>u0_usb_usbdev_main_power_on_req</name>
+              <description>u0_usb_usbdev_main_power_on_req</description>
               <bitRange>[11:11]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_main_power_on_valid</name>
-              <description>u0_cdn_usb_usbdev_main_power_on_valid</description>
+              <name>u0_usb_usbdev_main_power_on_valid</name>
+              <description>u0_usb_usbdev_main_power_on_valid</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_ack</name>
-              <description>u0_cdn_usb_usbdev_power_off_ack</description>
+              <name>u0_usb_usbdev_power_off_ack</name>
+              <description>u0_usb_usbdev_power_off_ack</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_ready</name>
-              <description>u0_cdn_usb_usbdev_power_off_ready</description>
+              <name>u0_usb_usbdev_power_off_ready</name>
+              <description>u0_usb_usbdev_power_off_ready</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_off_req</name>
-              <description>u0_cdn_usb_usbdev_power_off_req</description>
+              <name>u0_usb_usbdev_power_off_req</name>
+              <description>u0_usb_usbdev_power_off_req</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_ready</name>
-              <description>u0_cdn_usb_usbdev_power_on_ready</description>
+              <name>u0_usb_usbdev_power_on_ready</name>
+              <description>u0_usb_usbdev_power_on_ready</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_req</name>
-              <description>u0_cdn_usb_usbdev_power_on_req</description>
+              <name>u0_usb_usbdev_power_on_req</name>
+              <description>u0_usb_usbdev_power_on_req</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_usbdev_power_on_valid</name>
-              <description>u0_cdn_usb_usbdev_power_on_valid</description>
+              <name>u0_usb_usbdev_power_on_valid</name>
+              <description>u0_usb_usbdev_power_on_valid</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_dmpulldown_sit</name>
-              <description>u0_cdn_usb_utmi_dmpulldown_sit</description>
+              <name>u0_usb_utmi_dmpulldown_sit</name>
+              <description>u0_usb_utmi_dmpulldown_sit</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_dppulldown_sit</name>
-              <description>u0_cdn_usb_utmi_dppulldown_sit</description>
+              <name>u0_usb_utmi_dppulldown_sit</name>
+              <description>u0_usb_utmi_dppulldown_sit</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_fslsserialmode_sit</name>
-              <description>u0_cdn_usb_utmi_fslsserialmode_sit</description>
+              <name>u0_usb_utmi_fslsserialmode_sit</name>
+              <description>u0_usb_utmi_fslsserialmode_sit</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_hostdisconnect_sit</name>
-              <description>u0_cdn_usb_utmi_hostdisconnect_sit</description>
+              <name>u0_usb_utmi_hostdisconnect_sit</name>
+              <description>u0_usb_utmi_hostdisconnect_sit</description>
               <bitRange>[22:22]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_iddig_sit</name>
-              <description>u0_cdn_usb_utmi_iddig_sit</description>
+              <name>u0_usb_utmi_iddig_sit</name>
+              <description>u0_usb_utmi_iddig_sit</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_idpullup_sit</name>
-              <description>u0_cdn_usb_utmi_idpullup_sit</description>
+              <name>u0_usb_utmi_idpullup_sit</name>
+              <description>u0_usb_utmi_idpullup_sit</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_linestate_sit</name>
-              <description>u0_cdn_usb_utmi_linestate_sit</description>
+              <name>u0_usb_utmi_linestate_sit</name>
+              <description>u0_usb_utmi_linestate_sit</description>
               <bitRange>[26:25]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_opmode_sit</name>
-              <description>u0_cdn_usb_utmi_opmode_sit</description>
+              <name>u0_usb_utmi_opmode_sit</name>
+              <description>u0_usb_utmi_opmode_sit</description>
               <bitRange>[28:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxactive_sit</name>
-              <description>u0_cdn_usb_utmi_rxactive_sit</description>
+              <name>u0_usb_utmi_rxactive_sit</name>
+              <description>u0_usb_utmi_rxactive_sit</description>
               <bitRange>[29:29]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxerror_sit</name>
-              <description>u0_cdn_usb_utmi_rxerror_sit</description>
+              <name>u0_usb_utmi_rxerror_sit</name>
+              <description>u0_usb_utmi_rxerror_sit</description>
               <bitRange>[30:30]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_rxvalid_sit</name>
-              <description>u0_cdn_usb_utmi_rxvalid_sit</description>
+              <name>u0_usb_utmi_rxvalid_sit</name>
+              <description>u0_usb_utmi_rxvalid_sit</description>
               <bitRange>[31:31]</bitRange>
               <access>read-only</access>
             </field>
@@ -12669,104 +12669,104 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_utmi_rxvalidh_sit</name>
-              <description>u0_cdn_usb_utmi_rxvalidh_sit</description>
+              <name>u0_usb_utmi_rxvalidh_sit</name>
+              <description>u0_usb_utmi_rxvalidh_sit</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_sessvld</name>
-              <description>u0_cdn_usb_utmi_sessvld</description>
+              <name>u0_usb_utmi_sessvld</name>
+              <description>u0_usb_utmi_sessvld</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_termselect_sit</name>
-              <description>u0_cdn_usb_utmi_termselect_sit</description>
+              <name>u0_usb_utmi_termselect_sit</name>
+              <description>u0_usb_utmi_termselect_sit</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_dat_sit</name>
-              <description>u0_cdn_usb_utmi_tx_dat_sit</description>
+              <name>u0_usb_utmi_tx_dat_sit</name>
+              <description>u0_usb_utmi_tx_dat_sit</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_enable_n_sit</name>
-              <description>u0_cdn_usb_utmi_tx_enable_n_sit</description>
+              <name>u0_usb_utmi_tx_enable_n_sit</name>
+              <description>u0_usb_utmi_tx_enable_n_sit</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_tx_se0_sit</name>
-              <description>u0_cdn_usb_utmi_tx_se0_sit</description>
+              <name>u0_usb_utmi_tx_se0_sit</name>
+              <description>u0_usb_utmi_tx_se0_sit</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txbitstuffenable_sit</name>
-              <description>u0_cdn_usb_utmi_txbitstuffenable_sit</description>
+              <name>u0_usb_utmi_txbitstuffenable_sit</name>
+              <description>u0_usb_utmi_txbitstuffenable_sit</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txready_sit</name>
-              <description>u0_cdn_usb_utmi_txready_sit</description>
+              <name>u0_usb_utmi_txready_sit</name>
+              <description>u0_usb_utmi_txready_sit</description>
               <bitRange>[7:7]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txvalid_sit</name>
-              <description>u0_cdn_usb_utmi_txvalid_sit</description>
+              <name>u0_usb_utmi_txvalid_sit</name>
+              <description>u0_usb_utmi_txvalid_sit</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_txvalidh_sit</name>
-              <description>u0_cdn_usb_utmi_txvalidh_sit</description>
+              <name>u0_usb_utmi_txvalidh_sit</name>
+              <description>u0_usb_utmi_txvalidh_sit</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vbusvalid_sit</name>
-              <description>u0_cdn_usb_utmi_vbusvalid_sit</description>
+              <name>u0_usb_utmi_vbusvalid_sit</name>
+              <description>u0_usb_utmi_vbusvalid_sit</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_xcvrselect_sit</name>
-              <description>u0_cdn_usb_utmi_xcvrselect_sit</description>
+              <name>u0_usb_utmi_xcvrselect_sit</name>
+              <description>u0_usb_utmi_xcvrselect_sit</description>
               <bitRange>[12:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vdm_src_en</name>
-              <description>u0_cdn_usb_utmi_vdm_src_en</description>
+              <name>u0_usb_utmi_vdm_src_en</name>
+              <description>u0_usb_utmi_vdm_src_en</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_utmi_vdp_src_en</name>
-              <description>u0_cdn_usb_utmi_vdp_src_en</description>
+              <name>u0_usb_utmi_vdp_src_en</name>
+              <description>u0_usb_utmi_vdp_src_en</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_wakeup</name>
-              <description>u0_cdn_usb_wakeup</description>
+              <name>u0_usb_wakeup</name>
+              <description>u0_usb_wakeup</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhc_d0_ack</name>
-              <description>u0_cdn_usb_xhc_d0_ack</description>
+              <name>u0_usb_xhc_d0_ack</name>
+              <description>u0_usb_xhc_d0_ack</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhc_d0_req</name>
-              <description>u0_cdn_usb_xhc_d0_req</description>
+              <name>u0_usb_xhc_d0_req</name>
+              <description>u0_usb_xhc_d0_req</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -12780,8 +12780,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_bus</name>
-              <description>u0_cdn_usb_xhci_debug_bus</description>
+              <name>u0_usb_xhci_debug_bus</name>
+              <description>u0_usb_xhci_debug_bus</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -12795,8 +12795,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_link_state</name>
-              <description>u0_cdn_usb_xhci_debug_link_state</description>
+              <name>u0_usb_xhci_debug_link_state</name>
+              <description>u0_usb_xhci_debug_link_state</description>
               <bitRange>[30:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -12810,92 +12810,92 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_cdn_usb_xhci_debug_sel</name>
-              <description>u0_cdn_usb_xhci_debug_sel</description>
+              <name>u0_usb_xhci_debug_sel</name>
+              <description>u0_usb_xhci_debug_sel</description>
               <bitRange>[4:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_off_ack</name>
-              <description>u0_cdn_usb_xhci_main_power_off_ack</description>
+              <name>u0_usb_xhci_main_power_off_ack</name>
+              <description>u0_usb_xhci_main_power_off_ack</description>
               <bitRange>[5:5]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_off_req</name>
-              <description>u0_cdn_usb_xhci_main_power_off_req</description>
+              <name>u0_usb_xhci_main_power_off_req</name>
+              <description>u0_usb_xhci_main_power_off_req</description>
               <bitRange>[6:6]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_ready</name>
-              <description>u0_cdn_usb_xhci_main_power_on_ready</description>
+              <name>u0_usb_xhci_main_power_on_ready</name>
+              <description>u0_usb_xhci_main_power_on_ready</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_req</name>
-              <description>u0_cdn_usb_xhci_main_power_on_req</description>
+              <name>u0_usb_xhci_main_power_on_req</name>
+              <description>u0_usb_xhci_main_power_on_req</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_main_power_on_valid</name>
-              <description>u0_cdn_usb_xhci_main_power_on_valid</description>
+              <name>u0_usb_xhci_main_power_on_valid</name>
+              <description>u0_usb_xhci_main_power_on_valid</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_ack</name>
-              <description>u0_cdn_usb_xhci_power_off_ack</description>
+              <name>u0_usb_xhci_power_off_ack</name>
+              <description>u0_usb_xhci_power_off_ack</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_ready</name>
-              <description>u0_cdn_usb_xhci_power_off_ready</description>
+              <name>u0_usb_xhci_power_off_ready</name>
+              <description>u0_usb_xhci_power_off_ready</description>
               <bitRange>[11:11]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_off_req</name>
-              <description>u0_cdn_usb_xhci_power_off_req</description>
+              <name>u0_usb_xhci_power_off_req</name>
+              <description>u0_usb_xhci_power_off_req</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_ready</name>
-              <description>u0_cdn_usb_xhci_power_on_ready</description>
+              <name>u0_usb_xhci_power_on_ready</name>
+              <description>u0_usb_xhci_power_on_ready</description>
               <bitRange>[13:13]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_req</name>
-              <description>u0_cdn_usb_xhci_power_on_req</description>
+              <name>u0_usb_xhci_power_on_req</name>
+              <description>u0_usb_xhci_power_on_req</description>
               <bitRange>[14:14]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_cdn_usb_xhci_power_on_valid</name>
-              <description>u0_cdn_usb_xhci_power_on_valid</description>
+              <name>u0_usb_xhci_power_on_valid</name>
+              <description>u0_usb_xhci_power_on_valid</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_cease_from_tile_0</name>
-              <description>u0_e2_sft7110_cease_from_tile_0</description>
+              <name>u0_e2_cease_from_tile_0</name>
+              <description>u0_e2_cease_from_tile_0</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_debug_from_tile_0</name>
-              <description>u0_e2_sft7110_debug_from_tile_0</description>
+              <name>u0_e2_debug_from_tile_0</name>
+              <description>u0_e2_debug_from_tile_0</description>
               <bitRange>[17:17]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_e2_sft7110_halt_from_tile_0</name>
-              <description>u0_e2_sft7110_halt_from_tile_0</description>
+              <name>u0_e2_halt_from_tile_0</name>
+              <description>u0_e2_halt_from_tile_0</description>
               <bitRange>[18:18]</bitRange>
               <access>read-only</access>
             </field>
@@ -12909,8 +12909,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_nmi_0_rnmi_exception_vector</name>
-              <description>u0_e2_sft7110_nmi_0_rnmi_exception_vector</description>
+              <name>u0_e2_nmi_exception_vector</name>
+              <description>u0_e2_nmi_exception_vector</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12924,8 +12924,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_nmi_0_rnmi_interrupt_vector</name>
-              <description>u0_e2_sft7110_nmi_0_rnmi_interrupt_vector</description>
+              <name>u0_e2_nmi_interrupt_vector</name>
+              <description>u0_e2_nmi_interrupt_vector</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12939,8 +12939,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_reset_vector_0</name>
-              <description>u0_e2_sft7110_reset_vector_0</description>
+              <name>u0_e2_reset_vector_0</name>
+              <description>u0_e2_reset_vector_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -12954,8 +12954,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_e2_sft7110_wfi_from_tile_0</name>
-              <description>u0_e2_sft7110_wfi_from_tile_0</description>
+              <name>u0_e2_wfi_from_tile_0</name>
+              <description>u0_e2_wfi_from_tile_0</description>
               <bitRange>[0:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13209,8 +13209,8 @@
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_align_detect</name>
-              <description>u0_plda_pcie_align_detect</description>
+              <name>u0_pcie_align_detect</name>
+              <description>u0_pcie_align_detect</description>
               <bitRange>[16:16]</bitRange>
               <access>read-only</access>
             </field>
@@ -13224,8 +13224,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_mst0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_mst0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13239,8 +13239,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_mst0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_mst0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13254,8 +13254,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_mst0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_mst0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13269,8 +13269,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_mst0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_mst0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13284,8 +13284,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_mst0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_mst0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13299,8 +13299,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_mst0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_mst0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13314,8 +13314,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_mst0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_mst0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13329,8 +13329,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_mst0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_mst0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13344,20 +13344,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_arfunc</description>
+              <name>u0_pcie_axi4_mst0_arfunc</name>
+              <description>u0_pcie_axi4_mst0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arregion</name>
-              <description>u0_plda_pcie_axi4_mst0_arregion</description>
+              <name>u0_pcie_axi4_mst0_arregion</name>
+              <description>u0_pcie_axi4_mst0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-only</access>
             </field>
@@ -13371,8 +13371,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aruser_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aruser_31_0</description>
+              <name>u0_pcie_axi4_mst0_aruser_31_0</name>
+              <description>u0_pcie_axi4_mst0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13386,8 +13386,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aruser_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aruser_63_32</description>
+              <name>u0_pcie_axi4_mst0_aruser_63_32</name>
+              <description>u0_pcie_axi4_mst0_aruser_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13401,14 +13401,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_awfunc</description>
+              <name>u0_pcie_axi4_mst0_awfunc</name>
+              <description>u0_pcie_axi4_mst0_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awregion</name>
-              <description>u0_plda_pcie_axi4_mst0_awregion</description>
+              <name>u0_pcie_axi4_mst0_awregion</name>
+              <description>u0_pcie_axi4_mst0_awregion</description>
               <bitRange>[18:15]</bitRange>
               <access>read-only</access>
             </field>
@@ -13422,8 +13422,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_a2user_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_a2user_31_0</description>
+              <name>u0_pcie_axi4_mst0_a2user_31_0</name>
+              <description>u0_pcie_axi4_mst0_a2user_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13437,14 +13437,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_awuser_42_32</name>
-              <description>u0_plda_pcie_axi4_mst0_awuser_42_32</description>
+              <name>u0_pcie_axi4_mst0_awuser_42_32</name>
+              <description>u0_pcie_axi4_mst0_awuser_42_32</description>
               <bitRange>[10:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_rderr</name>
-              <description>u0_plda_pcie_axi4_mst0_rderr</description>
+              <name>u0_pcie_axi4_mst0_rderr</name>
+              <description>u0_pcie_axi4_mst0_rderr</description>
               <bitRange>[18:11]</bitRange>
               <access>read-write</access>
             </field>
@@ -13458,8 +13458,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_ruser</name>
-              <description>u0_plda_pcie_axi4_mst0_ruser</description>
+              <name>u0_pcie_axi4_mst0_ruser</name>
+              <description>u0_pcie_axi4_mst0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13473,8 +13473,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_wderr</name>
-              <description>u0_plda_pcie_axi4_mst0_wderr</description>
+              <name>u0_pcie_axi4_mst0_wderr</name>
+              <description>u0_pcie_axi4_mst0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13488,8 +13488,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_slv0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_slv0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13503,8 +13503,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_slv0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_slv0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13518,8 +13518,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_slv0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_slv0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13533,8 +13533,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_slv0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_slv0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13548,8 +13548,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_slv0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_slv0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13563,8 +13563,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_slv0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_slv0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13578,8 +13578,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_slv0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_slv0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13593,8 +13593,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_slv0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_slv0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13608,20 +13608,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_slv0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_slv0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_slv0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_arfunc</name>
-              <description>u0_plda_pcie_axi4_slv0_arfunc</description>
+              <name>u0_pcie_axi4_slv0_arfunc</name>
+              <description>u0_pcie_axi4_slv0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_arregion</name>
-              <description>u0_plda_pcie_axi4_slv0_arregion</description>
+              <name>u0_pcie_axi4_slv0_arregion</name>
+              <description>u0_pcie_axi4_slv0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -13635,8 +13635,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aruser_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_aruser_31_0</description>
+              <name>u0_pcie_axi4_slv0_aruser_31_0</name>
+              <description>u0_pcie_axi4_slv0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13650,20 +13650,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_aruser_40_32</name>
-              <description>u0_plda_pcie_axi4_slv0_aruser_40_32</description>
+              <name>u0_pcie_axi4_slv0_aruser_40_32</name>
+              <description>u0_pcie_axi4_slv0_aruser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awfunc</name>
-              <description>u0_plda_pcie_axi4_slv0_awfunc</description>
+              <name>u0_pcie_axi4_slv0_awfunc</name>
+              <description>u0_pcie_axi4_slv0_awfunc</description>
               <bitRange>[23:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awregion</name>
-              <description>u0_plda_pcie_axi4_slv0_awregion</description>
+              <name>u0_pcie_axi4_slv0_awregion</name>
+              <description>u0_pcie_axi4_slv0_awregion</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
@@ -13677,8 +13677,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awuser_31_0</name>
-              <description>u0_plda_pcie_axi4_slv0_awuser_31_0</description>
+              <name>u0_pcie_axi4_slv0_awuser_31_0</name>
+              <description>u0_pcie_axi4_slv0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13692,14 +13692,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_awuser_40_32</name>
-              <description>u0_plda_pcie_axi4_slv0_awuser_40_32</description>
+              <name>u0_pcie_axi4_slv0_awuser_40_32</name>
+              <description>u0_pcie_axi4_slv0_awuser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_rderr</name>
-              <description>u0_plda_pcie_axi4_slv0_rderr</description>
+              <name>u0_pcie_axi4_slv0_rderr</name>
+              <description>u0_pcie_axi4_slv0_rderr</description>
               <bitRange>[16:9]</bitRange>
               <access>read-only</access>
             </field>
@@ -13713,8 +13713,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_ruser</name>
-              <description>u0_plda_pcie_axi4_slv0_ruser</description>
+              <name>u0_pcie_axi4_slv0_ruser</name>
+              <description>u0_pcie_axi4_slv0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -13728,14 +13728,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slv0_wderr</name>
-              <description>u0_plda_pcie_axi4_slv0_wderr</description>
+              <name>u0_pcie_axi4_slv0_wderr</name>
+              <description>u0_pcie_axi4_slv0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_slvl_arfunc</name>
-              <description>u0_plda_pcie_axi4_slvl_arfunc</description>
+              <name>u0_pcie_axi4_slvl_arfunc</name>
+              <description>u0_pcie_axi4_slvl_arfunc</description>
               <bitRange>[22:8]</bitRange>
               <access>read-only</access>
             </field>
@@ -13749,38 +13749,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_slvl_awfunc</name>
-              <description>u0_plda_pcie_axi4_slvl_awfunc</description>
+              <name>u0_pcie_axi4_slvl_awfunc</name>
+              <description>u0_pcie_axi4_slvl_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_bus_width_o</name>
-              <description>u0_plda_pcie_bus_width_o</description>
+              <name>u0_pcie_bus_width_o</name>
+              <description>u0_pcie_bus_width_o</description>
               <bitRange>[16:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_bypass_codec</name>
-              <description>u0_plda_pcie_bypass_codec</description>
+              <name>u0_pcie_bypass_codec</name>
+              <description>u0_pcie_bypass_codec</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_ckref_src</name>
-              <description>u0_plda_pcie_ckref_src</description>
+              <name>u0_pcie_ckref_src</name>
+              <description>u0_pcie_ckref_src</description>
               <bitRange>[19:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_clk_sel</name>
-              <description>u0_plda_pcie_clk_sel</description>
+              <name>u0_pcie_clk_sel</name>
+              <description>u0_pcie_clk_sel</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_clkreq</name>
-              <description>u0_plda_pcie_clkreq</description>
+              <name>u0_pcie_clkreq</name>
+              <description>u0_pcie_clkreq</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
@@ -13794,8 +13794,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_31_0</name>
-              <description>u0_plda_pcie_k_phyparam_31_0</description>
+              <name>u0_pcie_k_phyparam_31_0</name>
+              <description>u0_pcie_k_phyparam_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13809,8 +13809,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_63_32</name>
-              <description>u0_plda_pcie_k_phyparam_63_32</description>
+              <name>u0_pcie_k_phyparam_63_32</name>
+              <description>u0_pcie_k_phyparam_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13824,8 +13824,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_95_64</name>
-              <description>u0_plda_pcie_k_phyparam_95_64</description>
+              <name>u0_pcie_k_phyparam_95_64</name>
+              <description>u0_pcie_k_phyparam_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13839,8 +13839,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_127_96</name>
-              <description>u0_plda_pcie_k_phyparam_127_96</description>
+              <name>u0_pcie_k_phyparam_127_96</name>
+              <description>u0_pcie_k_phyparam_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13854,8 +13854,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_159_128</name>
-              <description>u0_plda_pcie_k_phyparam_159_128</description>
+              <name>u0_pcie_k_phyparam_159_128</name>
+              <description>u0_pcie_k_phyparam_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13869,8 +13869,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_191_160</name>
-              <description>u0_plda_pcie_k_phyparam_191_160</description>
+              <name>u0_pcie_k_phyparam_191_160</name>
+              <description>u0_pcie_k_phyparam_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13884,8 +13884,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_223_192</name>
-              <description>u0_plda_pcie_k_phyparam_223_192</description>
+              <name>u0_pcie_k_phyparam_223_192</name>
+              <description>u0_pcie_k_phyparam_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13899,8 +13899,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_255_224</name>
-              <description>u0_plda_pcie_k_phyparam_255_224</description>
+              <name>u0_pcie_k_phyparam_255_224</name>
+              <description>u0_pcie_k_phyparam_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13914,8 +13914,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_287_256</name>
-              <description>u0_plda_pcie_k_phyparam_287_256</description>
+              <name>u0_pcie_k_phyparam_287_256</name>
+              <description>u0_pcie_k_phyparam_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13929,8 +13929,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_319_288</name>
-              <description>u0_plda_pcie_k_phyparam_319_288</description>
+              <name>u0_pcie_k_phyparam_319_288</name>
+              <description>u0_pcie_k_phyparam_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13944,8 +13944,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_351_320</name>
-              <description>u0_plda_pcie_k_phyparam_351_320</description>
+              <name>u0_pcie_k_phyparam_351_320</name>
+              <description>u0_pcie_k_phyparam_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13959,8 +13959,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_383_352</name>
-              <description>u0_plda_pcie_k_phyparam_383_352</description>
+              <name>u0_pcie_k_phyparam_383_352</name>
+              <description>u0_pcie_k_phyparam_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13974,8 +13974,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_415_384</name>
-              <description>u0_plda_pcie_k_phyparam_415_384</description>
+              <name>u0_pcie_k_phyparam_415_384</name>
+              <description>u0_pcie_k_phyparam_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -13989,8 +13989,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_447_416</name>
-              <description>u0_plda_pcie_k_phyparam_447_416</description>
+              <name>u0_pcie_k_phyparam_447_416</name>
+              <description>u0_pcie_k_phyparam_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14004,8 +14004,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_479_448</name>
-              <description>u0_plda_pcie_k_phyparam_479_448</description>
+              <name>u0_pcie_k_phyparam_479_448</name>
+              <description>u0_pcie_k_phyparam_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14019,8 +14019,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_511_480</name>
-              <description>u0_plda_pcie_k_phyparam_511_480</description>
+              <name>u0_pcie_k_phyparam_511_480</name>
+              <description>u0_pcie_k_phyparam_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14034,8 +14034,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_543_512</name>
-              <description>u0_plda_pcie_k_phyparam_543_512</description>
+              <name>u0_pcie_k_phyparam_543_512</name>
+              <description>u0_pcie_k_phyparam_543_512</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14049,8 +14049,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_575_544</name>
-              <description>u0_plda_pcie_k_phyparam_575_544</description>
+              <name>u0_pcie_k_phyparam_575_544</name>
+              <description>u0_pcie_k_phyparam_575_544</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14064,8 +14064,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_607_576</name>
-              <description>u0_plda_pcie_k_phyparam_607_576</description>
+              <name>u0_pcie_k_phyparam_607_576</name>
+              <description>u0_pcie_k_phyparam_607_576</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14079,8 +14079,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_639_608</name>
-              <description>u0_plda_pcie_k_phyparam_639_608</description>
+              <name>u0_pcie_k_phyparam_639_608</name>
+              <description>u0_pcie_k_phyparam_639_608</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14094,8 +14094,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_671_640</name>
-              <description>u0_plda_pcie_k_phyparam_671_640</description>
+              <name>u0_pcie_k_phyparam_671_640</name>
+              <description>u0_pcie_k_phyparam_671_640</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14109,8 +14109,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_703_672</name>
-              <description>u0_plda_pcie_k_phyparam_703_672</description>
+              <name>u0_pcie_k_phyparam_703_672</name>
+              <description>u0_pcie_k_phyparam_703_672</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14124,8 +14124,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_735_704</name>
-              <description>u0_plda_pcie_k_phyparam_735_704</description>
+              <name>u0_pcie_k_phyparam_735_704</name>
+              <description>u0_pcie_k_phyparam_735_704</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14139,8 +14139,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_767_736</name>
-              <description>u0_plda_pcie_k_phyparam_767_736</description>
+              <name>u0_pcie_k_phyparam_767_736</name>
+              <description>u0_pcie_k_phyparam_767_736</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14154,8 +14154,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_799_768</name>
-              <description>u0_plda_pcie_k_phyparam_799_768</description>
+              <name>u0_pcie_k_phyparam_799_768</name>
+              <description>u0_pcie_k_phyparam_799_768</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14169,8 +14169,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_831_800</name>
-              <description>u0_plda_pcie_k_phyparam_831_800</description>
+              <name>u0_pcie_k_phyparam_831_800</name>
+              <description>u0_pcie_k_phyparam_831_800</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14184,26 +14184,26 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_k_phyparam_839_832</name>
-              <description>u0_plda_pcie_k_phyparam_839_832</description>
+              <name>u0_pcie_k_phyparam_839_832</name>
+              <description>u0_pcie_k_phyparam_839_832</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_k_rp_nep</name>
-              <description>u0_plda_pcie_k_rp_nep</description>
+              <name>u0_pcie_k_rp_nep</name>
+              <description>u0_pcie_k_rp_nep</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_l1sub_entack</name>
-              <description>u0_plda_pcie_l1sub_entack</description>
+              <name>u0_pcie_l1sub_entack</name>
+              <description>u0_pcie_l1sub_entack</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_l1sub_entreq</name>
-              <description>u0_plda_pcie_l1sub_entreq</description>
+              <name>u0_pcie_l1sub_entreq</name>
+              <description>u0_pcie_l1sub_entreq</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
@@ -14217,8 +14217,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_local_interrupt_in</name>
-              <description>u0_plda_pcie_local_interrupt_in</description>
+              <name>u0_pcie_local_interrupt_in</name>
+              <description>u0_pcie_local_interrupt_in</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14232,38 +14232,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_mperstn</name>
-              <description>u0_plda_pcie_mperstn</description>
+              <name>u0_pcie_mperstn</name>
+              <description>u0_pcie_mperstn</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_ebuf_mode</name>
-              <description>u0_plda_pcie_pcie_ebuf_mode</description>
+              <name>u0_pcie_pcie_ebuf_mode</name>
+              <description>u0_pcie_pcie_ebuf_mode</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_phy_test_cfg</name>
-              <description>u0_plda_pcie_pcie_phy_test_cfg</description>
+              <name>u0_pcie_pcie_phy_test_cfg</name>
+              <description>u0_pcie_pcie_phy_test_cfg</description>
               <bitRange>[24:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_rx_eq_training</name>
-              <description>u0_plda_pcie_pcie_rx_eq_training</description>
+              <name>u0_pcie_pcie_rx_eq_training</name>
+              <description>u0_pcie_pcie_rx_eq_training</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_rxterm_en</name>
-              <description>u0_plda_pcie_pcie_rxterm_en</description>
+              <name>u0_pcie_pcie_rxterm_en</name>
+              <description>u0_pcie_pcie_rxterm_en</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pcie_tx_onezeros</name>
-              <description>u0_plda_pcie_pcie_tx_onezeros</description>
+              <name>u0_pcie_pcie_tx_onezeros</name>
+              <description>u0_pcie_pcie_tx_onezeros</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -14277,8 +14277,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf0_offset</name>
-              <description>u0_plda_pcie_pf0_offset</description>
+              <name>u0_pcie_pf0_offset</name>
+              <description>u0_pcie_pf0_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14292,8 +14292,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf1_offset</name>
-              <description>u0_plda_pcie_pf1_offset</description>
+              <name>u0_pcie_pf1_offset</name>
+              <description>u0_pcie_pf1_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14307,8 +14307,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf2_offset</name>
-              <description>u0_plda_pcie_pf2_offset</description>
+              <name>u0_pcie_pf2_offset</name>
+              <description>u0_pcie_pf2_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14322,38 +14322,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pf3_offset</name>
-              <description>u0_plda_pcie_pf3_offset</description>
+              <name>u0_pcie_pf3_offset</name>
+              <description>u0_pcie_pf3_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_phy_mode</name>
-              <description>u0_plda_pcie_phy_mode</description>
+              <name>u0_pcie_phy_mode</name>
+              <description>u0_pcie_phy_mode</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_clkrem_allow</name>
-              <description>u0_plda_pcie_pl_clkrem_allow</description>
+              <name>u0_pcie_pl_clkrem_allow</name>
+              <description>u0_pcie_pl_clkrem_allow</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_clkreq_oen</name>
-              <description>u0_plda_pcie_pl_clkreq_oen</description>
+              <name>u0_pcie_pl_clkreq_oen</name>
+              <description>u0_pcie_pl_clkreq_oen</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_equ_phase</name>
-              <description>u0_plda_pcie_pl_equ_phase</description>
+              <name>u0_pcie_pl_equ_phase</name>
+              <description>u0_pcie_pl_equ_phase</description>
               <bitRange>[25:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_ltssm</name>
-              <description>u0_plda_pcie_pl_ltssm</description>
+              <name>u0_pcie_pl_ltssm</name>
+              <description>u0_pcie_pl_ltssm</description>
               <bitRange>[30:26]</bitRange>
               <access>read-only</access>
             </field>
@@ -14367,8 +14367,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_pclk_rate</name>
-              <description>u0_plda_pcie_pl_pclk_rate</description>
+              <name>u0_pcie_pl_pclk_rate</name>
+              <description>u0_pcie_pl_pclk_rate</description>
               <bitRange>[4:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14382,8 +14382,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_in_31_0</name>
-              <description>u0_plda_pcie_pl_sideband_in_31_0</description>
+              <name>u0_pcie_pl_sideband_in_31_0</name>
+              <description>u0_pcie_pl_sideband_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14397,8 +14397,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_in_63_32</name>
-              <description>u0_plda_pcie_pl_sideband_in_63_32</description>
+              <name>u0_pcie_pl_sideband_in_63_32</name>
+              <description>u0_pcie_pl_sideband_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14412,8 +14412,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_out_31_0</name>
-              <description>u0_plda_pcie_pl_sideband_out_31_0</description>
+              <name>u0_pcie_pl_sideband_out_31_0</name>
+              <description>u0_pcie_pl_sideband_out_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14427,8 +14427,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_sideband_out_63_32</name>
-              <description>u0_plda_pcie_pl_sideband_out_63_32</description>
+              <name>u0_pcie_pl_sideband_out_63_32</name>
+              <description>u0_pcie_pl_sideband_out_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14442,20 +14442,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_pl_wake_in</name>
-              <description>u0_plda_pcie_pl_wake_in</description>
+              <name>u0_pcie_pl_wake_in</name>
+              <description>u0_pcie_pl_wake_in</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_pl_wake_oen</name>
-              <description>u0_plda_pcie_pl_wake_oen</description>
+              <name>u0_pcie_pl_wake_oen</name>
+              <description>u0_pcie_pl_wake_oen</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_rx_standby_0</name>
-              <description>u0_plda_pcie_rx_standby_0</description>
+              <name>u0_pcie_rx_standby_0</name>
+              <description>u0_pcie_rx_standby_0</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
@@ -14469,8 +14469,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_in_31_0</name>
-              <description>u0_plda_pcie_test_in_31_0</description>
+              <name>u0_pcie_test_in_31_0</name>
+              <description>u0_pcie_test_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14484,8 +14484,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_in_63_32</name>
-              <description>u0_plda_pcie_test_in_63_32</description>
+              <name>u0_pcie_test_in_63_32</name>
+              <description>u0_pcie_test_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -14499,8 +14499,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_31_0</name>
-              <description>u0_plda_pcie_test_out_bridge_31_0</description>
+              <name>u0_pcie_test_out_bridge_31_0</name>
+              <description>u0_pcie_test_out_bridge_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14514,8 +14514,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_63_32</name>
-              <description>u0_plda_pcie_test_out_bridge_63_32</description>
+              <name>u0_pcie_test_out_bridge_63_32</name>
+              <description>u0_pcie_test_out_bridge_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14529,8 +14529,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_95_64</name>
-              <description>u0_plda_pcie_test_out_bridge_95_64</description>
+              <name>u0_pcie_test_out_bridge_95_64</name>
+              <description>u0_pcie_test_out_bridge_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14544,8 +14544,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_127_96</name>
-              <description>u0_plda_pcie_test_out_bridge_127_96</description>
+              <name>u0_pcie_test_out_bridge_127_96</name>
+              <description>u0_pcie_test_out_bridge_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14559,8 +14559,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_159_128</name>
-              <description>u0_plda_pcie_test_out_bridge_159_128</description>
+              <name>u0_pcie_test_out_bridge_159_128</name>
+              <description>u0_pcie_test_out_bridge_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14574,8 +14574,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_191_160</name>
-              <description>u0_plda_pcie_test_out_bridge_191_160</description>
+              <name>u0_pcie_test_out_bridge_191_160</name>
+              <description>u0_pcie_test_out_bridge_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14589,8 +14589,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_223_192</name>
-              <description>u0_plda_pcie_test_out_bridge_223_192</description>
+              <name>u0_pcie_test_out_bridge_223_192</name>
+              <description>u0_pcie_test_out_bridge_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14604,8 +14604,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_255_224</name>
-              <description>u0_plda_pcie_test_out_bridge_255_224</description>
+              <name>u0_pcie_test_out_bridge_255_224</name>
+              <description>u0_pcie_test_out_bridge_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14619,8 +14619,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_287_256</name>
-              <description>u0_plda_pcie_test_out_bridge_287_256</description>
+              <name>u0_pcie_test_out_bridge_287_256</name>
+              <description>u0_pcie_test_out_bridge_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14634,8 +14634,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_319_288</name>
-              <description>u0_plda_pcie_test_out_bridge_319_288</description>
+              <name>u0_pcie_test_out_bridge_319_288</name>
+              <description>u0_pcie_test_out_bridge_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14649,8 +14649,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_351_320</name>
-              <description>u0_plda_pcie_test_out_bridge_351_320</description>
+              <name>u0_pcie_test_out_bridge_351_320</name>
+              <description>u0_pcie_test_out_bridge_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14664,8 +14664,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_383_352</name>
-              <description>u0_plda_pcie_test_out_bridge_383_352</description>
+              <name>u0_pcie_test_out_bridge_383_352</name>
+              <description>u0_pcie_test_out_bridge_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14679,8 +14679,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_415_384</name>
-              <description>u0_plda_pcie_test_out_bridge_415_384</description>
+              <name>u0_pcie_test_out_bridge_415_384</name>
+              <description>u0_pcie_test_out_bridge_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14694,8 +14694,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_447_416</name>
-              <description>u0_plda_pcie_test_out_bridge_447_416</description>
+              <name>u0_pcie_test_out_bridge_447_416</name>
+              <description>u0_pcie_test_out_bridge_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14709,8 +14709,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_479_448</name>
-              <description>u0_plda_pcie_test_out_bridge_479_448</description>
+              <name>u0_pcie_test_out_bridge_479_448</name>
+              <description>u0_pcie_test_out_bridge_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14724,8 +14724,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_bridge_511_480</name>
-              <description>u0_plda_pcie_test_out_bridge_511_480</description>
+              <name>u0_pcie_test_out_bridge_511_480</name>
+              <description>u0_pcie_test_out_bridge_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14739,8 +14739,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_31_0</name>
-              <description>u0_plda_pcie_test_out_pcie_31_0</description>
+              <name>u0_pcie_test_out_pcie_31_0</name>
+              <description>u0_pcie_test_out_pcie_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14754,8 +14754,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_63_32</name>
-              <description>u0_plda_pcie_test_out_pcie_63_32</description>
+              <name>u0_pcie_test_out_pcie_63_32</name>
+              <description>u0_pcie_test_out_pcie_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14769,8 +14769,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_95_64</name>
-              <description>u0_plda_pcie_test_out_pcie_95_64</description>
+              <name>u0_pcie_test_out_pcie_95_64</name>
+              <description>u0_pcie_test_out_pcie_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14784,8 +14784,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_127_96</name>
-              <description>u0_plda_pcie_test_out_pcie_127_96</description>
+              <name>u0_pcie_test_out_pcie_127_96</name>
+              <description>u0_pcie_test_out_pcie_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14799,8 +14799,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_159_128</name>
-              <description>u0_plda_pcie_test_out_pcie_159_128</description>
+              <name>u0_pcie_test_out_pcie_159_128</name>
+              <description>u0_pcie_test_out_pcie_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14814,8 +14814,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_191_160</name>
-              <description>u0_plda_pcie_test_out_pcie_191_160</description>
+              <name>u0_pcie_test_out_pcie_191_160</name>
+              <description>u0_pcie_test_out_pcie_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14829,8 +14829,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_223_192</name>
-              <description>u0_plda_pcie_test_out_pcie_223_192</description>
+              <name>u0_pcie_test_out_pcie_223_192</name>
+              <description>u0_pcie_test_out_pcie_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14844,8 +14844,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_255_224</name>
-              <description>u0_plda_pcie_test_out_pcie_255_224</description>
+              <name>u0_pcie_test_out_pcie_255_224</name>
+              <description>u0_pcie_test_out_pcie_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14859,8 +14859,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_287_256</name>
-              <description>u0_plda_pcie_test_out_pcie_287_256</description>
+              <name>u0_pcie_test_out_pcie_287_256</name>
+              <description>u0_pcie_test_out_pcie_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14874,8 +14874,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_319_288</name>
-              <description>u0_plda_pcie_test_out_pcie_319_288</description>
+              <name>u0_pcie_test_out_pcie_319_288</name>
+              <description>u0_pcie_test_out_pcie_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14889,8 +14889,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_351_320</name>
-              <description>u0_plda_pcie_test_out_pcie_351_320</description>
+              <name>u0_pcie_test_out_pcie_351_320</name>
+              <description>u0_pcie_test_out_pcie_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14904,8 +14904,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_383_352</name>
-              <description>u0_plda_pcie_test_out_pcie_383_352</description>
+              <name>u0_pcie_test_out_pcie_383_352</name>
+              <description>u0_pcie_test_out_pcie_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14919,8 +14919,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_415_384</name>
-              <description>u0_plda_pcie_test_out_pcie_415_384</description>
+              <name>u0_pcie_test_out_pcie_415_384</name>
+              <description>u0_pcie_test_out_pcie_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14934,8 +14934,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_447_416</name>
-              <description>u0_plda_pcie_test_out_pcie_447_416</description>
+              <name>u0_pcie_test_out_pcie_447_416</name>
+              <description>u0_pcie_test_out_pcie_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14949,8 +14949,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_479_448</name>
-              <description>u0_plda_pcie_test_out_pcie_479_448</description>
+              <name>u0_pcie_test_out_pcie_479_448</name>
+              <description>u0_pcie_test_out_pcie_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14964,8 +14964,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_out_pcie_511_480</name>
-              <description>u0_plda_pcie_test_out_pcie_511_480</description>
+              <name>u0_pcie_test_out_pcie_511_480</name>
+              <description>u0_pcie_test_out_pcie_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -14979,14 +14979,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_test_sel</name>
-              <description>u0_plda_pcie_test_sel</description>
+              <name>u0_pcie_test_sel</name>
+              <description>u0_pcie_test_sel</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_tl_clock_freq</name>
-              <description>u0_plda_pcie_tl_clock_freq</description>
+              <name>u0_pcie_tl_clock_freq</name>
+              <description>u0_pcie_tl_clock_freq</description>
               <bitRange>[25:4]</bitRange>
               <access>read-write</access>
             </field>
@@ -15000,14 +15000,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_tl_ctrl_hotplug</name>
-              <description>u0_plda_pcie_tl_ctrl_hotplug</description>
+              <name>u0_pcie_tl_ctrl_hotplug</name>
+              <description>u0_pcie_tl_ctrl_hotplug</description>
               <bitRange>[15:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_tl_report_hotplug</name>
-              <description>u0_plda_pcie_tl_report_hotplug</description>
+              <name>u0_pcie_tl_report_hotplug</name>
+              <description>u0_pcie_tl_report_hotplug</description>
               <bitRange>[31:16]</bitRange>
               <access>read-write</access>
             </field>
@@ -15021,50 +15021,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_tx_pattern</name>
-              <description>u0_plda_pcie_tx_pattern</description>
+              <name>u0_pcie_tx_pattern</name>
+              <description>u0_pcie_tx_pattern</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_bus_width</name>
-              <description>u0_plda_pcie_usb3_bus_width</description>
+              <name>u0_pcie_usb3_bus_width</name>
+              <description>u0_pcie_usb3_bus_width</description>
               <bitRange>[3:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_phy_enable</name>
-              <description>u0_plda_pcie_usb3_phy_enable</description>
+              <name>u0_pcie_usb3_phy_enable</name>
+              <description>u0_pcie_usb3_phy_enable</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_rate</name>
-              <description>u0_plda_pcie_usb3_rate</description>
+              <name>u0_pcie_usb3_rate</name>
+              <description>u0_pcie_usb3_rate</description>
               <bitRange>[6:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_usb3_rx_standby</name>
-              <description>u0_plda_pcie_usb3_rx_standby</description>
+              <name>u0_pcie_usb3_rx_standby</name>
+              <description>u0_pcie_usb3_rx_standby</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwdecerr</name>
-              <description>u0_plda_pcie_xwdecerr</description>
+              <name>u0_pcie_xwdecerr</name>
+              <description>u0_pcie_xwdecerr</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwerrclr</name>
-              <description>u0_plda_pcie_xwerrclr</description>
+              <name>u0_pcie_xwerrclr</name>
+              <description>u0_pcie_xwerrclr</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u0_plda_pcie_xwslverr</name>
-              <description>u0_plda_pcie_xwslverr</description>
+              <name>u0_pcie_xwslverr</name>
+              <description>u0_pcie_xwslverr</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>
@@ -15132,8 +15132,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_31_0</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_31_0</description>
+              <name>u0_pcie_axi4_mst0_aratomop_31_0</name>
+              <description>u0_pcie_axi4_mst0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15147,8 +15147,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_63_32</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_63_32</description>
+              <name>u0_pcie_axi4_mst0_aratomop_63_32</name>
+              <description>u0_pcie_axi4_mst0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15162,8 +15162,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_95_64</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_95_64</description>
+              <name>u0_pcie_axi4_mst0_aratomop_95_64</name>
+              <description>u0_pcie_axi4_mst0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15177,8 +15177,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_127_96</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_127_96</description>
+              <name>u0_pcie_axi4_mst0_aratomop_127_96</name>
+              <description>u0_pcie_axi4_mst0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15192,8 +15192,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_159_128</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_159_128</description>
+              <name>u0_pcie_axi4_mst0_aratomop_159_128</name>
+              <description>u0_pcie_axi4_mst0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15207,8 +15207,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_191_160</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_191_160</description>
+              <name>u0_pcie_axi4_mst0_aratomop_191_160</name>
+              <description>u0_pcie_axi4_mst0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15222,8 +15222,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_223_192</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_223_192</description>
+              <name>u0_pcie_axi4_mst0_aratomop_223_192</name>
+              <description>u0_pcie_axi4_mst0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15237,8 +15237,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_255_224</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_255_224</description>
+              <name>u0_pcie_axi4_mst0_aratomop_255_224</name>
+              <description>u0_pcie_axi4_mst0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15252,20 +15252,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u0_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u0_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u0_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arfunc</name>
-              <description>u0_plda_pcie_axi4_mst0_arfunc</description>
+              <name>u0_pcie_axi4_mst0_arfunc</name>
+              <description>u0_pcie_axi4_mst0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u0_plda_pcie_axi4_mst0_arregion</name>
-              <description>u0_plda_pcie_axi4_mst0_arregion</description>
+              <name>u0_pcie_axi4_mst0_arregion</name>
+              <description>u0_pcie_axi4_mst0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-only</access>
             </field>
@@ -15279,8 +15279,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aruser_31_0</name>
-              <description>u1_plda_pcie_axi4_mst0_aruser_31_0</description>
+              <name>u1_pcie_axi4_mst0_aruser_31_0</name>
+              <description>u1_pcie_axi4_mst0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15294,8 +15294,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aruser_52_32</name>
-              <description>u1_plda_pcie_axi4_mst0_aruser_52_32</description>
+              <name>u1_pcie_axi4_mst0_aruser_52_32</name>
+              <description>u1_pcie_axi4_mst0_aruser_52_32</description>
               <bitRange>[20:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15309,14 +15309,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awfunc</name>
-              <description>u1_plda_pcie_axi4_mst0_awfunc</description>
+              <name>u1_pcie_axi4_mst0_awfunc</name>
+              <description>u1_pcie_axi4_mst0_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awregion</name>
-              <description>u1_plda_pcie_axi4_mst0_awregion</description>
+              <name>u1_pcie_axi4_mst0_awregion</name>
+              <description>u1_pcie_axi4_mst0_awregion</description>
               <bitRange>[18:15]</bitRange>
               <access>read-only</access>
             </field>
@@ -15330,8 +15330,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awuser_31_0</name>
-              <description>u1_plda_pcie_axi4_mst0_awuser_31_0</description>
+              <name>u1_pcie_axi4_mst0_awuser_31_0</name>
+              <description>u1_pcie_axi4_mst0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15345,14 +15345,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_awuser_42_32</name>
-              <description>u1_plda_pcie_axi4_mst0_awuser_42_32</description>
+              <name>u1_pcie_axi4_mst0_awuser_42_32</name>
+              <description>u1_pcie_axi4_mst0_awuser_42_32</description>
               <bitRange>[10:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_rderr</name>
-              <description>u1_plda_pcie_axi4_mst0_rderr</description>
+              <name>u1_pcie_axi4_mst0_rderr</name>
+              <description>u1_pcie_axi4_mst0_rderr</description>
               <bitRange>[18:11]</bitRange>
               <access>read-write</access>
             </field>
@@ -15366,8 +15366,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_ruser</name>
-              <description>u1_plda_pcie_axi4_mst0_ruser</description>
+              <name>u1_pcie_axi4_mst0_ruser</name>
+              <description>u1_pcie_axi4_mst0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15381,8 +15381,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_wderr</name>
-              <description>u1_plda_pcie_axi4_mst0_wderr</description>
+              <name>u1_pcie_axi4_mst0_wderr</name>
+              <description>u1_pcie_axi4_mst0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15396,8 +15396,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_31_0</description>
+              <name>u1_pcie_axi4_slv0_aratomop_31_0</name>
+              <description>u1_pcie_axi4_slv0_aratomop_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15411,8 +15411,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_63_32</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_63_32</description>
+              <name>u1_pcie_axi4_slv0_aratomop_63_32</name>
+              <description>u1_pcie_axi4_slv0_aratomop_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15426,8 +15426,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_95_64</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_95_64</description>
+              <name>u1_pcie_axi4_slv0_aratomop_95_64</name>
+              <description>u1_pcie_axi4_slv0_aratomop_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15441,8 +15441,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_127_96</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_127_96</description>
+              <name>u1_pcie_axi4_slv0_aratomop_127_96</name>
+              <description>u1_pcie_axi4_slv0_aratomop_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15456,8 +15456,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_159_128</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_159_128</description>
+              <name>u1_pcie_axi4_slv0_aratomop_159_128</name>
+              <description>u1_pcie_axi4_slv0_aratomop_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15471,8 +15471,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_191_160</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_191_160</description>
+              <name>u1_pcie_axi4_slv0_aratomop_191_160</name>
+              <description>u1_pcie_axi4_slv0_aratomop_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15486,8 +15486,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_223_192</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_223_192</description>
+              <name>u1_pcie_axi4_slv0_aratomop_223_192</name>
+              <description>u1_pcie_axi4_slv0_aratomop_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15501,8 +15501,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aratomop_255_224</name>
-              <description>u1_plda_pcie_axi4_slv0_aratomop_255_224</description>
+              <name>u1_pcie_axi4_slv0_aratomop_255_224</name>
+              <description>u1_pcie_axi4_slv0_aratomop_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15516,20 +15516,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_mst0_aratomop_257_256</name>
-              <description>u1_plda_pcie_axi4_mst0_aratomop_257_256</description>
+              <name>u1_pcie_axi4_mst0_aratomop_257_256</name>
+              <description>u1_pcie_axi4_mst0_aratomop_257_256</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_arfunc</name>
-              <description>u1_plda_pcie_axi4_slv0_arfunc</description>
+              <name>u1_pcie_axi4_slv0_arfunc</name>
+              <description>u1_pcie_axi4_slv0_arfunc</description>
               <bitRange>[16:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_arregion</name>
-              <description>u1_plda_pcie_axi4_slv0_arregion</description>
+              <name>u1_pcie_axi4_slv0_arregion</name>
+              <description>u1_pcie_axi4_slv0_arregion</description>
               <bitRange>[20:17]</bitRange>
               <access>read-write</access>
             </field>
@@ -15543,8 +15543,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aruser_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_aruser_31_0</description>
+              <name>u1_pcie_axi4_slv0_aruser_31_0</name>
+              <description>u1_pcie_axi4_slv0_aruser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15558,20 +15558,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_aruser_40_32</name>
-              <description>u1_plda_pcie_axi4_slv0_aruser_40_32</description>
+              <name>u1_pcie_axi4_slv0_aruser_40_32</name>
+              <description>u1_pcie_axi4_slv0_aruser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awfunc</name>
-              <description>u1_plda_pcie_axi4_slv0_awfunc</description>
+              <name>u1_pcie_axi4_slv0_awfunc</name>
+              <description>u1_pcie_axi4_slv0_awfunc</description>
               <bitRange>[23:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awregion</name>
-              <description>u1_plda_pcie_axi4_slv0_awregion</description>
+              <name>u1_pcie_axi4_slv0_awregion</name>
+              <description>u1_pcie_axi4_slv0_awregion</description>
               <bitRange>[27:24]</bitRange>
               <access>read-write</access>
             </field>
@@ -15585,8 +15585,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awuser_31_0</name>
-              <description>u1_plda_pcie_axi4_slv0_awuser_31_0</description>
+              <name>u1_pcie_axi4_slv0_awuser_31_0</name>
+              <description>u1_pcie_axi4_slv0_awuser_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -15600,14 +15600,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_awuser_40_32</name>
-              <description>u1_plda_pcie_axi4_slv0_awuser_40_32</description>
+              <name>u1_pcie_axi4_slv0_awuser_40_32</name>
+              <description>u1_pcie_axi4_slv0_awuser_40_32</description>
               <bitRange>[8:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_rderr</name>
-              <description>u1_plda_pcie_axi4_slv0_rderr</description>
+              <name>u1_pcie_axi4_slv0_rderr</name>
+              <description>u1_pcie_axi4_slv0_rderr</description>
               <bitRange>[16:9]</bitRange>
               <access>read-only</access>
             </field>
@@ -15621,8 +15621,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_ruser</name>
-              <description>u1_plda_pcie_axi4_slv0_ruser</description>
+              <name>u1_pcie_axi4_slv0_ruser</name>
+              <description>u1_pcie_axi4_slv0_ruser</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -15636,14 +15636,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slv0_wderr</name>
-              <description>u1_plda_pcie_axi4_slv0_wderr</description>
+              <name>u1_pcie_axi4_slv0_wderr</name>
+              <description>u1_pcie_axi4_slv0_wderr</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_axi4_slvl_arfunc</name>
-              <description>u1_plda_pcie_axi4_slvl_arfunc</description>
+              <name>u1_pcie_axi4_slvl_arfunc</name>
+              <description>u1_pcie_axi4_slvl_arfunc</description>
               <bitRange>[22:8]</bitRange>
               <access>read-write</access>
             </field>
@@ -15657,38 +15657,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_axi4_slvl_awfunc</name>
-              <description>u1_plda_pcie_axi4_slvl_awfunc</description>
+              <name>u1_pcie_axi4_slvl_awfunc</name>
+              <description>u1_pcie_axi4_slvl_awfunc</description>
               <bitRange>[14:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_bus_width_o</name>
-              <description>u1_plda_pcie_bus_width_o</description>
+              <name>u1_pcie_bus_width_o</name>
+              <description>u1_pcie_bus_width_o</description>
               <bitRange>[16:15]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_bypass_codec</name>
-              <description>u1_plda_pcie_bypass_codec</description>
+              <name>u1_pcie_bypass_codec</name>
+              <description>u1_pcie_bypass_codec</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_ckref_src</name>
-              <description>u1_plda_pcie_ckref_src</description>
+              <name>u1_pcie_ckref_src</name>
+              <description>u1_pcie_ckref_src</description>
               <bitRange>[19:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_clk_sel</name>
-              <description>u1_plda_pcie_clk_sel</description>
+              <name>u1_pcie_clk_sel</name>
+              <description>u1_pcie_clk_sel</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_clkreq</name>
-              <description>u1_plda_pcie_clkreq</description>
+              <name>u1_pcie_clkreq</name>
+              <description>u1_pcie_clkreq</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
@@ -16092,26 +16092,26 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_k_phyparam_839_832</name>
-              <description>u1_plda_pcie_k_phyparam_839_832</description>
+              <name>u1_pcie_k_phyparam_839_832</name>
+              <description>u1_pcie_k_phyparam_839_832</description>
               <bitRange>[7:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_k_rp_nep</name>
-              <description>u1_plda_pcie_k_rp_nep</description>
+              <name>u1_pcie_k_rp_nep</name>
+              <description>u1_pcie_k_rp_nep</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_l1sub_entack</name>
-              <description>u1_plda_pcie_l1sub_entack</description>
+              <name>u1_pcie_l1sub_entack</name>
+              <description>u1_pcie_l1sub_entack</description>
               <bitRange>[9:9]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_l1sub_entreq</name>
-              <description>u1_plda_pcie_l1sub_entreq</description>
+              <name>u1_pcie_l1sub_entreq</name>
+              <description>u1_pcie_l1sub_entreq</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
@@ -16125,8 +16125,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_local_interrupt_in</name>
-              <description>u1_plda_pcie_local_interrupt_in</description>
+              <name>u1_pcie_local_interrupt_in</name>
+              <description>u1_pcie_local_interrupt_in</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16140,38 +16140,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_mperstn</name>
-              <description>u1_plda_pcie_mperstn</description>
+              <name>u1_pcie_mperstn</name>
+              <description>u1_pcie_mperstn</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_ebuf_mode</name>
-              <description>u1_plda_pcie_pcie_ebuf_mode</description>
+              <name>u1_pcie_pcie_ebuf_mode</name>
+              <description>u1_pcie_pcie_ebuf_mode</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_phy_test_cfg</name>
-              <description>u1_plda_pcie_pcie_phy_test_cfg</description>
+              <name>u1_pcie_pcie_phy_test_cfg</name>
+              <description>u1_pcie_pcie_phy_test_cfg</description>
               <bitRange>[24:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_rx_eq_training</name>
-              <description>u1_plda_pcie_pcie_rx_eq_training</description>
+              <name>u1_pcie_pcie_rx_eq_training</name>
+              <description>u1_pcie_pcie_rx_eq_training</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_rxterm_en</name>
-              <description>u1_plda_pcie_pcie_rxterm_en</description>
+              <name>u1_pcie_pcie_rxterm_en</name>
+              <description>u1_pcie_pcie_rxterm_en</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pcie_tx_oneszeros</name>
-              <description>u1_plda_pcie_pcie_tx_oneszeros</description>
+              <name>u1_pcie_pcie_tx_oneszeros</name>
+              <description>u1_pcie_pcie_tx_oneszeros</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
@@ -16185,8 +16185,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf0_offset</name>
-              <description>u1_plda_pcie_pf0_offset</description>
+              <name>u1_pcie_pf0_offset</name>
+              <description>u1_pcie_pf0_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16200,8 +16200,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf1_offset</name>
-              <description>u1_plda_pcie_pf1_offset</description>
+              <name>u1_pcie_pf1_offset</name>
+              <description>u1_pcie_pf1_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16215,8 +16215,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf2_offset</name>
-              <description>u1_plda_pcie_pf2_offset</description>
+              <name>u1_pcie_pf2_offset</name>
+              <description>u1_pcie_pf2_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16230,38 +16230,38 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pf3_offset</name>
-              <description>u1_plda_pcie_pf3_offset</description>
+              <name>u1_pcie_pf3_offset</name>
+              <description>u1_pcie_pf3_offset</description>
               <bitRange>[19:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_phy_mode</name>
-              <description>u1_plda_pcie_phy_mode</description>
+              <name>u1_pcie_phy_mode</name>
+              <description>u1_pcie_phy_mode</description>
               <bitRange>[21:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_clkrem_allow</name>
-              <description>u1_plda_pcie_pl_clkrem_allow</description>
+              <name>u1_pcie_pl_clkrem_allow</name>
+              <description>u1_pcie_pl_clkrem_allow</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_clkreq_oen</name>
-              <description>u1_plda_pcie_pl_clkreq_oen</description>
+              <name>u1_pcie_pl_clkreq_oen</name>
+              <description>u1_pcie_pl_clkreq_oen</description>
               <bitRange>[23:23]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_equ_phase</name>
-              <description>u1_plda_pcie_pl_equ_phase</description>
+              <name>u1_pcie_pl_equ_phase</name>
+              <description>u1_pcie_pl_equ_phase</description>
               <bitRange>[25:24]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_ltssm</name>
-              <description>u1_plda_pcie_pl_ltssm</description>
+              <name>u1_pcie_pl_ltssm</name>
+              <description>u1_pcie_pl_ltssm</description>
               <bitRange>[30:26]</bitRange>
               <access>read-only</access>
             </field>
@@ -16275,8 +16275,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_pclk_rate</name>
-              <description>u1_plda_pcie_pl_pclk_rate</description>
+              <name>u1_pcie_pl_pclk_rate</name>
+              <description>u1_pcie_pl_pclk_rate</description>
               <bitRange>[4:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16290,8 +16290,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_in_31_0</name>
-              <description>u1_plda_pcie_pl_sideband_in_31_0</description>
+              <name>u1_pcie_pl_sideband_in_31_0</name>
+              <description>u1_pcie_pl_sideband_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16305,8 +16305,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_in_63_32</name>
-              <description>u1_plda_pcie_pl_sideband_in_63_32</description>
+              <name>u1_pcie_pl_sideband_in_63_32</name>
+              <description>u1_pcie_pl_sideband_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16320,8 +16320,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_out_31_0</name>
-              <description>u1_plda_pcie_pl_sideband_out_31_0</description>
+              <name>u1_pcie_pl_sideband_out_31_0</name>
+              <description>u1_pcie_pl_sideband_out_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16335,8 +16335,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_sideband_out_63_32</name>
-              <description>u1_plda_pcie_pl_sideband_out_63_32</description>
+              <name>u1_pcie_pl_sideband_out_63_32</name>
+              <description>u1_pcie_pl_sideband_out_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16350,20 +16350,20 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_pl_wake_in</name>
-              <description>u1_plda_pcie_pl_wake_in</description>
+              <name>u1_pcie_pl_wake_in</name>
+              <description>u1_pcie_pl_wake_in</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_pl_wake_oen</name>
-              <description>u1_plda_pcie_pl_wake_oen</description>
+              <name>u1_pcie_pl_wake_oen</name>
+              <description>u1_pcie_pl_wake_oen</description>
               <bitRange>[1:1]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_rx_standby_o</name>
-              <description>u1_plda_pcie_rx_standby_o</description>
+              <name>u1_pcie_rx_standby_o</name>
+              <description>u1_pcie_rx_standby_o</description>
               <bitRange>[2:2]</bitRange>
               <access>read-only</access>
             </field>
@@ -16377,8 +16377,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_in_31_0</name>
-              <description>u1_plda_pcie_test_in_31_0</description>
+              <name>u1_pcie_test_in_31_0</name>
+              <description>u1_pcie_test_in_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16392,8 +16392,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_in_63_32</name>
-              <description>u1_plda_pcie_test_in_63_32</description>
+              <name>u1_pcie_test_in_63_32</name>
+              <description>u1_pcie_test_in_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16407,8 +16407,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_31_0</name>
-              <description>u1_plda_pcie_test_out_bridge_31_0</description>
+              <name>u1_pcie_test_out_bridge_31_0</name>
+              <description>u1_pcie_test_out_bridge_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16422,8 +16422,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_63_32</name>
-              <description>u1_plda_pcie_test_out_bridge_63_32</description>
+              <name>u1_pcie_test_out_bridge_63_32</name>
+              <description>u1_pcie_test_out_bridge_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16437,8 +16437,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_95_64</name>
-              <description>u1_plda_pcie_test_out_bridge_95_64</description>
+              <name>u1_pcie_test_out_bridge_95_64</name>
+              <description>u1_pcie_test_out_bridge_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16452,8 +16452,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_127_96</name>
-              <description>u1_plda_pcie_test_out_bridge_127_96</description>
+              <name>u1_pcie_test_out_bridge_127_96</name>
+              <description>u1_pcie_test_out_bridge_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16467,8 +16467,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_159_128</name>
-              <description>u1_plda_pcie_test_out_bridge_159_128</description>
+              <name>u1_pcie_test_out_bridge_159_128</name>
+              <description>u1_pcie_test_out_bridge_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16482,8 +16482,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_191_160</name>
-              <description>u1_plda_pcie_test_out_bridge_191_160</description>
+              <name>u1_pcie_test_out_bridge_191_160</name>
+              <description>u1_pcie_test_out_bridge_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16497,8 +16497,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_223_192</name>
-              <description>u1_plda_pcie_test_out_bridge_223_192</description>
+              <name>u1_pcie_test_out_bridge_223_192</name>
+              <description>u1_pcie_test_out_bridge_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16512,8 +16512,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_255_224</name>
-              <description>u1_plda_pcie_test_out_bridge_255_224</description>
+              <name>u1_pcie_test_out_bridge_255_224</name>
+              <description>u1_pcie_test_out_bridge_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16527,8 +16527,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_287_256</name>
-              <description>u1_plda_pcie_test_out_bridge_287_256</description>
+              <name>u1_pcie_test_out_bridge_287_256</name>
+              <description>u1_pcie_test_out_bridge_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16542,8 +16542,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_319_288</name>
-              <description>u1_plda_pcie_test_out_bridge_319_288</description>
+              <name>u1_pcie_test_out_bridge_319_288</name>
+              <description>u1_pcie_test_out_bridge_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16557,8 +16557,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_351_320</name>
-              <description>u1_plda_pcie_test_out_bridge_351_320</description>
+              <name>u1_pcie_test_out_bridge_351_320</name>
+              <description>u1_pcie_test_out_bridge_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16572,8 +16572,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_383_352</name>
-              <description>u1_plda_pcie_test_out_bridge_383_352</description>
+              <name>u1_pcie_test_out_bridge_383_352</name>
+              <description>u1_pcie_test_out_bridge_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16587,8 +16587,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_415_384</name>
-              <description>u1_plda_pcie_test_out_bridge_415_384</description>
+              <name>u1_pcie_test_out_bridge_415_384</name>
+              <description>u1_pcie_test_out_bridge_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16602,8 +16602,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_447_416</name>
-              <description>u1_plda_pcie_test_out_bridge_447_416</description>
+              <name>u1_pcie_test_out_bridge_447_416</name>
+              <description>u1_pcie_test_out_bridge_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16617,8 +16617,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_479_448</name>
-              <description>u1_plda_pcie_test_out_bridge_479_448</description>
+              <name>u1_pcie_test_out_bridge_479_448</name>
+              <description>u1_pcie_test_out_bridge_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16632,8 +16632,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_bridge_511_480</name>
-              <description>u1_plda_pcie_test_out_bridge_511_480</description>
+              <name>u1_pcie_test_out_bridge_511_480</name>
+              <description>u1_pcie_test_out_bridge_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-write</access>
             </field>
@@ -16647,8 +16647,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_31_0</name>
-              <description>u1_plda_pcie_test_out_pcie_31_0</description>
+              <name>u1_pcie_test_out_pcie_31_0</name>
+              <description>u1_pcie_test_out_pcie_31_0</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16662,8 +16662,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_63_32</name>
-              <description>u1_plda_pcie_test_out_pcie_63_32</description>
+              <name>u1_pcie_test_out_pcie_63_32</name>
+              <description>u1_pcie_test_out_pcie_63_32</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16677,8 +16677,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_95_64</name>
-              <description>u1_plda_pcie_test_out_pcie_95_64</description>
+              <name>u1_pcie_test_out_pcie_95_64</name>
+              <description>u1_pcie_test_out_pcie_95_64</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16692,8 +16692,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_127_96</name>
-              <description>u1_plda_pcie_test_out_pcie_127_96</description>
+              <name>u1_pcie_test_out_pcie_127_96</name>
+              <description>u1_pcie_test_out_pcie_127_96</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16707,8 +16707,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_159_128</name>
-              <description>u1_plda_pcie_test_out_pcie_159_128</description>
+              <name>u1_pcie_test_out_pcie_159_128</name>
+              <description>u1_pcie_test_out_pcie_159_128</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16722,8 +16722,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_191_160</name>
-              <description>u1_plda_pcie_test_out_pcie_191_160</description>
+              <name>u1_pcie_test_out_pcie_191_160</name>
+              <description>u1_pcie_test_out_pcie_191_160</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16737,8 +16737,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_223_192</name>
-              <description>u1_plda_pcie_test_out_pcie_223_192</description>
+              <name>u1_pcie_test_out_pcie_223_192</name>
+              <description>u1_pcie_test_out_pcie_223_192</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16752,8 +16752,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_255_224</name>
-              <description>u1_plda_pcie_test_out_pcie_255_224</description>
+              <name>u1_pcie_test_out_pcie_255_224</name>
+              <description>u1_pcie_test_out_pcie_255_224</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16767,8 +16767,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_287_256</name>
-              <description>u1_plda_pcie_test_out_pcie_287_256</description>
+              <name>u1_pcie_test_out_pcie_287_256</name>
+              <description>u1_pcie_test_out_pcie_287_256</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16782,8 +16782,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_319_288</name>
-              <description>u1_plda_pcie_test_out_pcie_319_288</description>
+              <name>u1_pcie_test_out_pcie_319_288</name>
+              <description>u1_pcie_test_out_pcie_319_288</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16797,8 +16797,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_351_320</name>
-              <description>u1_plda_pcie_test_out_pcie_351_320</description>
+              <name>u1_pcie_test_out_pcie_351_320</name>
+              <description>u1_pcie_test_out_pcie_351_320</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16812,8 +16812,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_383_352</name>
-              <description>u1_plda_pcie_test_out_pcie_383_352</description>
+              <name>u1_pcie_test_out_pcie_383_352</name>
+              <description>u1_pcie_test_out_pcie_383_352</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16827,8 +16827,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_415_384</name>
-              <description>u1_plda_pcie_test_out_pcie_415_384</description>
+              <name>u1_pcie_test_out_pcie_415_384</name>
+              <description>u1_pcie_test_out_pcie_415_384</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16842,8 +16842,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_447_416</name>
-              <description>u1_plda_pcie_test_out_pcie_447_416</description>
+              <name>u1_pcie_test_out_pcie_447_416</name>
+              <description>u1_pcie_test_out_pcie_447_416</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16857,8 +16857,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_479_448</name>
-              <description>u1_plda_pcie_test_out_pcie_479_448</description>
+              <name>u1_pcie_test_out_pcie_479_448</name>
+              <description>u1_pcie_test_out_pcie_479_448</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16872,8 +16872,8 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_out_pcie_511_480</name>
-              <description>u1_plda_pcie_test_out_pcie_511_480</description>
+              <name>u1_pcie_test_out_pcie_511_480</name>
+              <description>u1_pcie_test_out_pcie_511_480</description>
               <bitRange>[31:0]</bitRange>
               <access>read-only</access>
             </field>
@@ -16887,14 +16887,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_test_sel</name>
-              <description>u1_plda_pcie_test_sel</description>
+              <name>u1_pcie_test_sel</name>
+              <description>u1_pcie_test_sel</description>
               <bitRange>[3:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_tl_clock_freq</name>
-              <description>u1_plda_pcie_tl_clock_freq</description>
+              <name>u1_pcie_tl_clock_freq</name>
+              <description>u1_pcie_tl_clock_freq</description>
               <bitRange>[25:4]</bitRange>
               <access>read-write</access>
             </field>
@@ -16908,14 +16908,14 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_tl_ctrl_hotplug</name>
-              <description>u1_plda_pcie_tl_ctrl_hotplug</description>
+              <name>u1_pcie_tl_ctrl_hotplug</name>
+              <description>u1_pcie_tl_ctrl_hotplug</description>
               <bitRange>[15:0]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_tl_report_hotplug</name>
-              <description>u1_plda_pcie_tl_report_hotplug</description>
+              <name>u1_pcie_tl_report_hotplug</name>
+              <description>u1_pcie_tl_report_hotplug</description>
               <bitRange>[31:16]</bitRange>
               <access>read-write</access>
             </field>
@@ -16929,50 +16929,50 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>u1_plda_pcie_tx_pattern</name>
-              <description>u1_plda_pcie_tx_pattern</description>
+              <name>u1_pcie_tx_pattern</name>
+              <description>u1_pcie_tx_pattern</description>
               <bitRange>[1:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_bus_width</name>
-              <description>u1_plda_pcie_usb3_bus_width</description>
+              <name>u1_pcie_usb3_bus_width</name>
+              <description>u1_pcie_usb3_bus_width</description>
               <bitRange>[3:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_phy_enable</name>
-              <description>u1_plda_pcie_usb3_phy_enable</description>
+              <name>u1_pcie_usb3_phy_enable</name>
+              <description>u1_pcie_usb3_phy_enable</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_rate</name>
-              <description>u1_plda_pcie_usb3_rate</description>
+              <name>u1_pcie_usb3_rate</name>
+              <description>u1_pcie_usb3_rate</description>
               <bitRange>[6:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_usb3_rx_standby</name>
-              <description>u1_plda_pcie_usb3_rx_standby</description>
+              <name>u1_pcie_usb3_rx_standby</name>
+              <description>u1_pcie_usb3_rx_standby</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwdecerr</name>
-              <description>u1_plda_pcie_xwdecerr</description>
+              <name>u1_pcie_xwdecerr</name>
+              <description>u1_pcie_xwdecerr</description>
               <bitRange>[8:8]</bitRange>
               <access>read-only</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwerrclr</name>
-              <description>u1_plda_pcie_xwerrclr</description>
+              <name>u1_pcie_xwerrclr</name>
+              <description>u1_pcie_xwerrclr</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>u1_plda_pcie_xwslverr</name>
-              <description>u1_plda_pcie_xwslverr</description>
+              <name>u1_pcie_xwslverr</name>
+              <description>u1_pcie_xwslverr</description>
               <bitRange>[10:10]</bitRange>
               <access>read-only</access>
             </field>

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_0.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_0.rs
@@ -10,68 +10,68 @@ pub type SCFG_HPROT_SD_0_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 pub type SCFG_HPROT_SD_1_R = crate::FieldReader;
 #[doc = "Field `scfg_hprot_sd_1` writer - scfg_hprot_sd_1"]
 pub type SCFG_HPROT_SD_1_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u0_cdn_usb_adp_en` reader - u0_cdn_usb_adp_en"]
-pub type U0_CDN_USB_ADP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_probe_ana` reader - u0_cdn_usb_adp_probe_ana"]
-pub type U0_CDN_USB_ADP_PROBE_ANA_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_probe_ana` writer - u0_cdn_usb_adp_probe_ana"]
-pub type U0_CDN_USB_ADP_PROBE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_adp_probe_en` reader - u0_cdn_usb_adp_probe_en"]
-pub type U0_CDN_USB_ADP_PROBE_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sense_ana` reader - u0_cdn_usb_adp_sense_ana"]
-pub type U0_CDN_USB_ADP_SENSE_ANA_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sense_ana` writer - u0_cdn_usb_adp_sense_ana"]
-pub type U0_CDN_USB_ADP_SENSE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_adp_sense_en` reader - u0_cdn_usb_adp_sense_en"]
-pub type U0_CDN_USB_ADP_SENSE_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_sink_current_en` reader - u0_cdn_usb_adp_sink_current_en"]
-pub type U0_CDN_USB_ADP_SINK_CURRENT_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_adp_source_current_en` reader - u0_cdn_usb_adp_source_current_en"]
-pub type U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_bc_en` reader - u0_cdn_usb_bc_en"]
-pub type U0_CDN_USB_BC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_chrg_vbus` reader - u0_cdn_usb_chrg_vbus"]
-pub type U0_CDN_USB_CHRG_VBUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_chrg_vbus` writer - u0_cdn_usb_chrg_vbus"]
-pub type U0_CDN_USB_CHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dcd_comp_sts` reader - u0_cdn_usb_dcd_comp_sts"]
-pub type U0_CDN_USB_DCD_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dcd_comp_sts` writer - u0_cdn_usb_dcd_comp_sts"]
-pub type U0_CDN_USB_DCD_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dischrg_vbus` reader - u0_cdn_usb_dischrg_vbus"]
-pub type U0_CDN_USB_DISCHRG_VBUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dischrg_vbus` writer - u0_cdn_usb_dischrg_vbus"]
-pub type U0_CDN_USB_DISCHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_en` reader - u0_cdn_usb_dm_vdat_ref_comp_en"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_sts` reader - u0_cdn_usb_dm_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vdat_ref_comp_sts` writer - u0_cdn_usb_dm_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DM_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_en` reader - u0_cdn_usb_dm_vlgc_comp_en"]
-pub type U0_CDN_USB_DM_VLGC_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_sts` reader - u0_cdn_usb_dm_vlgc_comp_sts"]
-pub type U0_CDN_USB_DM_VLGC_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dm_vlgc_comp_sts` writer - u0_cdn_usb_dm_vlgc_comp_sts"]
-pub type U0_CDN_USB_DM_VLGC_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_en` reader - u0_cdn_usb_dp_vdat_ref_comp_en"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_sts` reader - u0_cdn_usb_dp_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_dp_vdat_ref_comp_sts` writer - u0_cdn_usb_dp_vdat_ref_comp_sts"]
-pub type U0_CDN_USB_DP_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_host_system_err` reader - u0_cdn_usb_host_system_err"]
-pub type U0_CDN_USB_HOST_SYSTEM_ERR_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_host_system_err` writer - u0_cdn_usb_host_system_err"]
-pub type U0_CDN_USB_HOST_SYSTEM_ERR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_hsystem_err_ext` reader - u0_cdn_usb_hsystem_err_ext"]
-pub type U0_CDN_USB_HSYSTEM_ERR_EXT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idm_sink_en` reader - u0_cdn_usb_idm_sink_en"]
-pub type U0_CDN_USB_IDM_SINK_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idp_sink_en` reader - u0_cdn_usb_idp_sink_en"]
-pub type U0_CDN_USB_IDP_SINK_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_idp_src_en` reader - u0_cdn_usb_idp_src_en"]
-pub type U0_CDN_USB_IDP_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_en` reader - u0_usb_adp_en"]
+pub type U0_USB_ADP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_probe_ana` reader - u0_usb_adp_probe_ana"]
+pub type U0_USB_ADP_PROBE_ANA_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_probe_ana` writer - u0_usb_adp_probe_ana"]
+pub type U0_USB_ADP_PROBE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_adp_probe_en` reader - u0_usb_adp_probe_en"]
+pub type U0_USB_ADP_PROBE_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sense_ana` reader - u0_usb_adp_sense_ana"]
+pub type U0_USB_ADP_SENSE_ANA_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sense_ana` writer - u0_usb_adp_sense_ana"]
+pub type U0_USB_ADP_SENSE_ANA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_adp_sense_en` reader - u0_usb_adp_sense_en"]
+pub type U0_USB_ADP_SENSE_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_sink_current_en` reader - u0_usb_adp_sink_current_en"]
+pub type U0_USB_ADP_SINK_CURRENT_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_adp_source_current_en` reader - u0_usb_adp_source_current_en"]
+pub type U0_USB_ADP_SOURCE_CURRENT_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_bc_en` reader - u0_usb_bc_en"]
+pub type U0_USB_BC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_chrg_vbus` reader - u0_usb_chrg_vbus"]
+pub type U0_USB_CHRG_VBUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_chrg_vbus` writer - u0_usb_chrg_vbus"]
+pub type U0_USB_CHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dcd_comp_sts` reader - u0_usb_dcd_comp_sts"]
+pub type U0_USB_DCD_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dcd_comp_sts` writer - u0_usb_dcd_comp_sts"]
+pub type U0_USB_DCD_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dischrg_vbus` reader - u0_usb_dischrg_vbus"]
+pub type U0_USB_DISCHRG_VBUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dischrg_vbus` writer - u0_usb_dischrg_vbus"]
+pub type U0_USB_DISCHRG_VBUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_en` reader - u0_usb_dm_vdat_ref_comp_en"]
+pub type U0_USB_DM_VDAT_REF_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_sts` reader - u0_usb_dm_vdat_ref_comp_sts"]
+pub type U0_USB_DM_VDAT_REF_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vdat_ref_comp_sts` writer - u0_usb_dm_vdat_ref_comp_sts"]
+pub type U0_USB_DM_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dm_vlgc_comp_en` reader - u0_usb_dm_vlgc_comp_en"]
+pub type U0_USB_DM_VLGC_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vlgc_comp_sts` reader - u0_usb_dm_vlgc_comp_sts"]
+pub type U0_USB_DM_VLGC_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dm_vlgc_comp_sts` writer - u0_usb_dm_vlgc_comp_sts"]
+pub type U0_USB_DM_VLGC_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_en` reader - u0_usb_dp_vdat_ref_comp_en"]
+pub type U0_USB_DP_VDAT_REF_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_sts` reader - u0_usb_dp_vdat_ref_comp_sts"]
+pub type U0_USB_DP_VDAT_REF_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_dp_vdat_ref_comp_sts` writer - u0_usb_dp_vdat_ref_comp_sts"]
+pub type U0_USB_DP_VDAT_REF_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_host_system_err` reader - u0_usb_host_system_err"]
+pub type U0_USB_HOST_SYSTEM_ERR_R = crate::BitReader;
+#[doc = "Field `u0_usb_host_system_err` writer - u0_usb_host_system_err"]
+pub type U0_USB_HOST_SYSTEM_ERR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_hsystem_err_ext` reader - u0_usb_hsystem_err_ext"]
+pub type U0_USB_HSYSTEM_ERR_EXT_R = crate::BitReader;
+#[doc = "Field `u0_usb_idm_sink_en` reader - u0_usb_idm_sink_en"]
+pub type U0_USB_IDM_SINK_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_idp_sink_en` reader - u0_usb_idp_sink_en"]
+pub type U0_USB_IDP_SINK_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_idp_src_en` reader - u0_usb_idp_src_en"]
+pub type U0_USB_IDP_SRC_EN_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:3 - scfg_hprot_sd_0"]
     #[inline(always)]
@@ -83,115 +83,115 @@ impl R {
     pub fn scfg_hprot_sd_1(&self) -> SCFG_HPROT_SD_1_R {
         SCFG_HPROT_SD_1_R::new(((self.bits >> 4) & 0x0f) as u8)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_adp_en"]
+    #[doc = "Bit 8 - u0_usb_adp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_en(&self) -> U0_CDN_USB_ADP_EN_R {
-        U0_CDN_USB_ADP_EN_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_adp_en(&self) -> U0_USB_ADP_EN_R {
+        U0_USB_ADP_EN_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_adp_probe_ana"]
+    #[doc = "Bit 9 - u0_usb_adp_probe_ana"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_probe_ana(&self) -> U0_CDN_USB_ADP_PROBE_ANA_R {
-        U0_CDN_USB_ADP_PROBE_ANA_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_adp_probe_ana(&self) -> U0_USB_ADP_PROBE_ANA_R {
+        U0_USB_ADP_PROBE_ANA_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_adp_probe_en"]
+    #[doc = "Bit 10 - u0_usb_adp_probe_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_probe_en(&self) -> U0_CDN_USB_ADP_PROBE_EN_R {
-        U0_CDN_USB_ADP_PROBE_EN_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_adp_probe_en(&self) -> U0_USB_ADP_PROBE_EN_R {
+        U0_USB_ADP_PROBE_EN_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_adp_sense_ana"]
+    #[doc = "Bit 11 - u0_usb_adp_sense_ana"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sense_ana(&self) -> U0_CDN_USB_ADP_SENSE_ANA_R {
-        U0_CDN_USB_ADP_SENSE_ANA_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_adp_sense_ana(&self) -> U0_USB_ADP_SENSE_ANA_R {
+        U0_USB_ADP_SENSE_ANA_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_adp_sense_en"]
+    #[doc = "Bit 12 - u0_usb_adp_sense_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sense_en(&self) -> U0_CDN_USB_ADP_SENSE_EN_R {
-        U0_CDN_USB_ADP_SENSE_EN_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_adp_sense_en(&self) -> U0_USB_ADP_SENSE_EN_R {
+        U0_USB_ADP_SENSE_EN_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_adp_sink_current_en"]
+    #[doc = "Bit 13 - u0_usb_adp_sink_current_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_sink_current_en(&self) -> U0_CDN_USB_ADP_SINK_CURRENT_EN_R {
-        U0_CDN_USB_ADP_SINK_CURRENT_EN_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_adp_sink_current_en(&self) -> U0_USB_ADP_SINK_CURRENT_EN_R {
+        U0_USB_ADP_SINK_CURRENT_EN_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_adp_source_current_en"]
+    #[doc = "Bit 14 - u0_usb_adp_source_current_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_adp_source_current_en(&self) -> U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R {
-        U0_CDN_USB_ADP_SOURCE_CURRENT_EN_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_adp_source_current_en(&self) -> U0_USB_ADP_SOURCE_CURRENT_EN_R {
+        U0_USB_ADP_SOURCE_CURRENT_EN_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_bc_en"]
+    #[doc = "Bit 15 - u0_usb_bc_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_bc_en(&self) -> U0_CDN_USB_BC_EN_R {
-        U0_CDN_USB_BC_EN_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_bc_en(&self) -> U0_USB_BC_EN_R {
+        U0_USB_BC_EN_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_chrg_vbus"]
+    #[doc = "Bit 16 - u0_usb_chrg_vbus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_chrg_vbus(&self) -> U0_CDN_USB_CHRG_VBUS_R {
-        U0_CDN_USB_CHRG_VBUS_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_chrg_vbus(&self) -> U0_USB_CHRG_VBUS_R {
+        U0_USB_CHRG_VBUS_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_dcd_comp_sts"]
+    #[doc = "Bit 17 - u0_usb_dcd_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dcd_comp_sts(&self) -> U0_CDN_USB_DCD_COMP_STS_R {
-        U0_CDN_USB_DCD_COMP_STS_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_dcd_comp_sts(&self) -> U0_USB_DCD_COMP_STS_R {
+        U0_USB_DCD_COMP_STS_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_dischrg_vbus"]
+    #[doc = "Bit 18 - u0_usb_dischrg_vbus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dischrg_vbus(&self) -> U0_CDN_USB_DISCHRG_VBUS_R {
-        U0_CDN_USB_DISCHRG_VBUS_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_usb_dischrg_vbus(&self) -> U0_USB_DISCHRG_VBUS_R {
+        U0_USB_DISCHRG_VBUS_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_dm_vdat_ref_comp_en"]
+    #[doc = "Bit 19 - u0_usb_dm_vdat_ref_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_en(&self) -> U0_CDN_USB_DM_VDAT_REF_COMP_EN_R {
-        U0_CDN_USB_DM_VDAT_REF_COMP_EN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_dm_vdat_ref_comp_en(&self) -> U0_USB_DM_VDAT_REF_COMP_EN_R {
+        U0_USB_DM_VDAT_REF_COMP_EN_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_dm_vdat_ref_comp_sts"]
+    #[doc = "Bit 20 - u0_usb_dm_vdat_ref_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_sts(&self) -> U0_CDN_USB_DM_VDAT_REF_COMP_STS_R {
-        U0_CDN_USB_DM_VDAT_REF_COMP_STS_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_dm_vdat_ref_comp_sts(&self) -> U0_USB_DM_VDAT_REF_COMP_STS_R {
+        U0_USB_DM_VDAT_REF_COMP_STS_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_dm_vlgc_comp_en"]
+    #[doc = "Bit 21 - u0_usb_dm_vlgc_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vlgc_comp_en(&self) -> U0_CDN_USB_DM_VLGC_COMP_EN_R {
-        U0_CDN_USB_DM_VLGC_COMP_EN_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_dm_vlgc_comp_en(&self) -> U0_USB_DM_VLGC_COMP_EN_R {
+        U0_USB_DM_VLGC_COMP_EN_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_dm_vlgc_comp_sts"]
+    #[doc = "Bit 22 - u0_usb_dm_vlgc_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dm_vlgc_comp_sts(&self) -> U0_CDN_USB_DM_VLGC_COMP_STS_R {
-        U0_CDN_USB_DM_VLGC_COMP_STS_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_dm_vlgc_comp_sts(&self) -> U0_USB_DM_VLGC_COMP_STS_R {
+        U0_USB_DM_VLGC_COMP_STS_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_dp_vdat_ref_comp_en"]
+    #[doc = "Bit 23 - u0_usb_dp_vdat_ref_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_en(&self) -> U0_CDN_USB_DP_VDAT_REF_COMP_EN_R {
-        U0_CDN_USB_DP_VDAT_REF_COMP_EN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_dp_vdat_ref_comp_en(&self) -> U0_USB_DP_VDAT_REF_COMP_EN_R {
+        U0_USB_DP_VDAT_REF_COMP_EN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_dp_vdat_ref_comp_sts"]
+    #[doc = "Bit 24 - u0_usb_dp_vdat_ref_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_sts(&self) -> U0_CDN_USB_DP_VDAT_REF_COMP_STS_R {
-        U0_CDN_USB_DP_VDAT_REF_COMP_STS_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_usb_dp_vdat_ref_comp_sts(&self) -> U0_USB_DP_VDAT_REF_COMP_STS_R {
+        U0_USB_DP_VDAT_REF_COMP_STS_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bit 25 - u0_cdn_usb_host_system_err"]
+    #[doc = "Bit 25 - u0_usb_host_system_err"]
     #[inline(always)]
-    pub fn u0_cdn_usb_host_system_err(&self) -> U0_CDN_USB_HOST_SYSTEM_ERR_R {
-        U0_CDN_USB_HOST_SYSTEM_ERR_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_usb_host_system_err(&self) -> U0_USB_HOST_SYSTEM_ERR_R {
+        U0_USB_HOST_SYSTEM_ERR_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u0_cdn_usb_hsystem_err_ext"]
+    #[doc = "Bit 26 - u0_usb_hsystem_err_ext"]
     #[inline(always)]
-    pub fn u0_cdn_usb_hsystem_err_ext(&self) -> U0_CDN_USB_HSYSTEM_ERR_EXT_R {
-        U0_CDN_USB_HSYSTEM_ERR_EXT_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_usb_hsystem_err_ext(&self) -> U0_USB_HSYSTEM_ERR_EXT_R {
+        U0_USB_HSYSTEM_ERR_EXT_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_cdn_usb_idm_sink_en"]
+    #[doc = "Bit 27 - u0_usb_idm_sink_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idm_sink_en(&self) -> U0_CDN_USB_IDM_SINK_EN_R {
-        U0_CDN_USB_IDM_SINK_EN_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_usb_idm_sink_en(&self) -> U0_USB_IDM_SINK_EN_R {
+        U0_USB_IDM_SINK_EN_R::new(((self.bits >> 27) & 1) != 0)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_idp_sink_en"]
+    #[doc = "Bit 28 - u0_usb_idp_sink_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idp_sink_en(&self) -> U0_CDN_USB_IDP_SINK_EN_R {
-        U0_CDN_USB_IDP_SINK_EN_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_usb_idp_sink_en(&self) -> U0_USB_IDP_SINK_EN_R {
+        U0_USB_IDP_SINK_EN_R::new(((self.bits >> 28) & 1) != 0)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_idp_src_en"]
+    #[doc = "Bit 29 - u0_usb_idp_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_idp_src_en(&self) -> U0_CDN_USB_IDP_SRC_EN_R {
-        U0_CDN_USB_IDP_SRC_EN_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_idp_src_en(&self) -> U0_USB_IDP_SRC_EN_R {
+        U0_USB_IDP_SRC_EN_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
@@ -207,67 +207,63 @@ impl W {
     pub fn scfg_hprot_sd_1(&mut self) -> SCFG_HPROT_SD_1_W<STG_SYSCFG_0_SPEC> {
         SCFG_HPROT_SD_1_W::new(self, 4)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_adp_probe_ana"]
+    #[doc = "Bit 9 - u0_usb_adp_probe_ana"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_adp_probe_ana(&mut self) -> U0_CDN_USB_ADP_PROBE_ANA_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_ADP_PROBE_ANA_W::new(self, 9)
+    pub fn u0_usb_adp_probe_ana(&mut self) -> U0_USB_ADP_PROBE_ANA_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_ADP_PROBE_ANA_W::new(self, 9)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_adp_sense_ana"]
+    #[doc = "Bit 11 - u0_usb_adp_sense_ana"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_adp_sense_ana(&mut self) -> U0_CDN_USB_ADP_SENSE_ANA_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_ADP_SENSE_ANA_W::new(self, 11)
+    pub fn u0_usb_adp_sense_ana(&mut self) -> U0_USB_ADP_SENSE_ANA_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_ADP_SENSE_ANA_W::new(self, 11)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_chrg_vbus"]
+    #[doc = "Bit 16 - u0_usb_chrg_vbus"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_chrg_vbus(&mut self) -> U0_CDN_USB_CHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_CHRG_VBUS_W::new(self, 16)
+    pub fn u0_usb_chrg_vbus(&mut self) -> U0_USB_CHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_CHRG_VBUS_W::new(self, 16)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_dcd_comp_sts"]
+    #[doc = "Bit 17 - u0_usb_dcd_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dcd_comp_sts(&mut self) -> U0_CDN_USB_DCD_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DCD_COMP_STS_W::new(self, 17)
+    pub fn u0_usb_dcd_comp_sts(&mut self) -> U0_USB_DCD_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DCD_COMP_STS_W::new(self, 17)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_dischrg_vbus"]
+    #[doc = "Bit 18 - u0_usb_dischrg_vbus"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dischrg_vbus(&mut self) -> U0_CDN_USB_DISCHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DISCHRG_VBUS_W::new(self, 18)
+    pub fn u0_usb_dischrg_vbus(&mut self) -> U0_USB_DISCHRG_VBUS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DISCHRG_VBUS_W::new(self, 18)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_dm_vdat_ref_comp_sts"]
+    #[doc = "Bit 20 - u0_usb_dm_vdat_ref_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dm_vdat_ref_comp_sts(
+    pub fn u0_usb_dm_vdat_ref_comp_sts(
         &mut self,
-    ) -> U0_CDN_USB_DM_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DM_VDAT_REF_COMP_STS_W::new(self, 20)
+    ) -> U0_USB_DM_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DM_VDAT_REF_COMP_STS_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_dm_vlgc_comp_sts"]
+    #[doc = "Bit 22 - u0_usb_dm_vlgc_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dm_vlgc_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_DM_VLGC_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DM_VLGC_COMP_STS_W::new(self, 22)
+    pub fn u0_usb_dm_vlgc_comp_sts(&mut self) -> U0_USB_DM_VLGC_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DM_VLGC_COMP_STS_W::new(self, 22)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_dp_vdat_ref_comp_sts"]
+    #[doc = "Bit 24 - u0_usb_dp_vdat_ref_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_dp_vdat_ref_comp_sts(
+    pub fn u0_usb_dp_vdat_ref_comp_sts(
         &mut self,
-    ) -> U0_CDN_USB_DP_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_DP_VDAT_REF_COMP_STS_W::new(self, 24)
+    ) -> U0_USB_DP_VDAT_REF_COMP_STS_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_DP_VDAT_REF_COMP_STS_W::new(self, 24)
     }
-    #[doc = "Bit 25 - u0_cdn_usb_host_system_err"]
+    #[doc = "Bit 25 - u0_usb_host_system_err"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_host_system_err(
-        &mut self,
-    ) -> U0_CDN_USB_HOST_SYSTEM_ERR_W<STG_SYSCFG_0_SPEC> {
-        U0_CDN_USB_HOST_SYSTEM_ERR_W::new(self, 25)
+    pub fn u0_usb_host_system_err(&mut self) -> U0_USB_HOST_SYSTEM_ERR_W<STG_SYSCFG_0_SPEC> {
+        U0_USB_HOST_SYSTEM_ERR_W::new(self, 25)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_1.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_1.rs
@@ -2,42 +2,42 @@
 pub type R = crate::R<STG_SYSCFG_1_SPEC>;
 #[doc = "Register `stg_syscfg_1` writer"]
 pub type W = crate::W<STG_SYSCFG_1_SPEC>;
-#[doc = "Field `u0_cdn_usb_lowest_belt` reader - LTM interface to software"]
-pub type U0_CDN_USB_LOWEST_BELT_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_cdn_usb_ltm_host_req` reader - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_ltm_host_req_halt` reader - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_HALT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_ltm_host_req_halt` writer - LTM interface to software"]
-pub type U0_CDN_USB_LTM_HOST_REQ_HALT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_sel` reader - u0_cdn_usb_mdctrl_clk_sel"]
-pub type U0_CDN_USB_MDCTRL_CLK_SEL_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_sel` writer - u0_cdn_usb_mdctrl_clk_sel"]
-pub type U0_CDN_USB_MDCTRL_CLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_mdctrl_clk_status` reader - u0_cdn_usb_mdctrl_clk_status"]
-pub type U0_CDN_USB_MDCTRL_CLK_STATUS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_mode_strap` reader - Can onlly be changed when pwrup_rst_n is low"]
-pub type U0_CDN_USB_MODE_STRAP_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_mode_strap` writer - Can onlly be changed when pwrup_rst_n is low"]
-pub type U0_CDN_USB_MODE_STRAP_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
-#[doc = "Field `u0_cdn_usb_otg_suspendm` reader - u0_cdn_usb_otg_suspendm"]
-pub type U0_CDN_USB_OTG_SUSPENDM_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_otg_suspendm` writer - u0_cdn_usb_otg_suspendm"]
-pub type U0_CDN_USB_OTG_SUSPENDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_otg_suspendm_byps` reader - u0_cdn_usb_otg_suspendm_byps"]
-pub type U0_CDN_USB_OTG_SUSPENDM_BYPS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_otg_suspendm_byps` writer - u0_cdn_usb_otg_suspendm_byps"]
-pub type U0_CDN_USB_OTG_SUSPENDM_BYPS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_phy_bvalid` reader - u0_cdn_usb_phy_bvalid"]
-pub type U0_CDN_USB_PHY_BVALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_pll_en` reader - u0_cdn_usb_pll_en"]
-pub type U0_CDN_USB_PLL_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_pll_en` writer - u0_cdn_usb_pll_en"]
-pub type U0_CDN_USB_PLL_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_refclk_mode` reader - u0_cdn_usb_refclk_mode"]
-pub type U0_CDN_USB_REFCLK_MODE_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_refclk_mode` writer - u0_cdn_usb_refclk_mode"]
-pub type U0_CDN_USB_REFCLK_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_lowest_belt` reader - LTM interface to software"]
+pub type U0_USB_LOWEST_BELT_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_usb_ltm_host_req` reader - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_ltm_host_req_halt` reader - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_HALT_R = crate::BitReader;
+#[doc = "Field `u0_usb_ltm_host_req_halt` writer - LTM interface to software"]
+pub type U0_USB_LTM_HOST_REQ_HALT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_mdctrl_clk_sel` reader - u0_usb_mdctrl_clk_sel"]
+pub type U0_USB_MDCTRL_CLK_SEL_R = crate::BitReader;
+#[doc = "Field `u0_usb_mdctrl_clk_sel` writer - u0_usb_mdctrl_clk_sel"]
+pub type U0_USB_MDCTRL_CLK_SEL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_mdctrl_clk_status` reader - u0_usb_mdctrl_clk_status"]
+pub type U0_USB_MDCTRL_CLK_STATUS_R = crate::BitReader;
+#[doc = "Field `u0_usb_mode_strap` reader - Can onlly be changed when pwrup_rst_n is low"]
+pub type U0_USB_MODE_STRAP_R = crate::FieldReader;
+#[doc = "Field `u0_usb_mode_strap` writer - Can onlly be changed when pwrup_rst_n is low"]
+pub type U0_USB_MODE_STRAP_W<'a, REG> = crate::FieldWriter<'a, REG, 3>;
+#[doc = "Field `u0_usb_otg_suspendm` reader - u0_usb_otg_suspendm"]
+pub type U0_USB_OTG_SUSPENDM_R = crate::BitReader;
+#[doc = "Field `u0_usb_otg_suspendm` writer - u0_usb_otg_suspendm"]
+pub type U0_USB_OTG_SUSPENDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_otg_suspendm_byps` reader - u0_usb_otg_suspendm_byps"]
+pub type U0_USB_OTG_SUSPENDM_BYPS_R = crate::BitReader;
+#[doc = "Field `u0_usb_otg_suspendm_byps` writer - u0_usb_otg_suspendm_byps"]
+pub type U0_USB_OTG_SUSPENDM_BYPS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_phy_bvalid` reader - u0_usb_phy_bvalid"]
+pub type U0_USB_PHY_BVALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_pll_en` reader - u0_usb_pll_en"]
+pub type U0_USB_PLL_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_pll_en` writer - u0_usb_pll_en"]
+pub type U0_USB_PLL_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_refclk_mode` reader - u0_usb_refclk_mode"]
+pub type U0_USB_REFCLK_MODE_R = crate::BitReader;
+#[doc = "Field `u0_usb_refclk_mode` writer - u0_usb_refclk_mode"]
+pub type U0_USB_REFCLK_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_0` reader - u0_cdn_usb_rid_comp_sts_0"]
 pub type U0_CDN_USB_RID_COMP_STS_0_R = crate::BitReader;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_0` writer - u0_cdn_usb_rid_comp_sts_0"]
@@ -50,75 +50,75 @@ pub type U0_CDN_USB_RID_COMP_STS_1_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_CDN_USB_RID_COMP_STS_2_R = crate::BitReader;
 #[doc = "Field `u0_cdn_usb_rid_comp_sts_2` writer - u0_cdn_usb_rid_comp_sts_2"]
 pub type U0_CDN_USB_RID_COMP_STS_2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_en` reader - u0_cdn_usb_rid_float_comp_en"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_sts` reader - u0_cdn_usb_rid_float_comp_sts"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_float_comp_sts` writer - u0_cdn_usb_rid_float_comp_sts"]
-pub type U0_CDN_USB_RID_FLOAT_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_gnd_comp_sts` reader - u0_cdn_usb_rid_gnd_comp_sts"]
-pub type U0_CDN_USB_RID_GND_COMP_STS_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rid_gnd_comp_sts` writer - u0_cdn_usb_rid_gnd_comp_sts"]
-pub type U0_CDN_USB_RID_GND_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_rid_nonfloat_comp_en` reader - u0_cdn_usb_rid_nonfloat_comp_en"]
-pub type U0_CDN_USB_RID_NONFLOAT_COMP_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rx_dm` reader - u0_cdn_usb_rx_dm"]
-pub type U0_CDN_USB_RX_DM_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_en` reader - u0_usb_rid_float_comp_en"]
+pub type U0_USB_RID_FLOAT_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_sts` reader - u0_usb_rid_float_comp_sts"]
+pub type U0_USB_RID_FLOAT_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_float_comp_sts` writer - u0_usb_rid_float_comp_sts"]
+pub type U0_USB_RID_FLOAT_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_rid_gnd_comp_sts` reader - u0_usb_rid_gnd_comp_sts"]
+pub type U0_USB_RID_GND_COMP_STS_R = crate::BitReader;
+#[doc = "Field `u0_usb_rid_gnd_comp_sts` writer - u0_usb_rid_gnd_comp_sts"]
+pub type U0_USB_RID_GND_COMP_STS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_rid_nonfloat_comp_en` reader - u0_usb_rid_nonfloat_comp_en"]
+pub type U0_USB_RID_NONFLOAT_COMP_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_dm` reader - u0_usb_rx_dm"]
+pub type U0_USB_RX_DM_R = crate::BitReader;
 impl R {
     #[doc = "Bits 0:11 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_lowest_belt(&self) -> U0_CDN_USB_LOWEST_BELT_R {
-        U0_CDN_USB_LOWEST_BELT_R::new((self.bits & 0x0fff) as u16)
+    pub fn u0_usb_lowest_belt(&self) -> U0_USB_LOWEST_BELT_R {
+        U0_USB_LOWEST_BELT_R::new((self.bits & 0x0fff) as u16)
     }
     #[doc = "Bit 12 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_ltm_host_req(&self) -> U0_CDN_USB_LTM_HOST_REQ_R {
-        U0_CDN_USB_LTM_HOST_REQ_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_ltm_host_req(&self) -> U0_USB_LTM_HOST_REQ_R {
+        U0_USB_LTM_HOST_REQ_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - LTM interface to software"]
     #[inline(always)]
-    pub fn u0_cdn_usb_ltm_host_req_halt(&self) -> U0_CDN_USB_LTM_HOST_REQ_HALT_R {
-        U0_CDN_USB_LTM_HOST_REQ_HALT_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_ltm_host_req_halt(&self) -> U0_USB_LTM_HOST_REQ_HALT_R {
+        U0_USB_LTM_HOST_REQ_HALT_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_mdctrl_clk_sel"]
+    #[doc = "Bit 14 - u0_usb_mdctrl_clk_sel"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mdctrl_clk_sel(&self) -> U0_CDN_USB_MDCTRL_CLK_SEL_R {
-        U0_CDN_USB_MDCTRL_CLK_SEL_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_mdctrl_clk_sel(&self) -> U0_USB_MDCTRL_CLK_SEL_R {
+        U0_USB_MDCTRL_CLK_SEL_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_mdctrl_clk_status"]
+    #[doc = "Bit 15 - u0_usb_mdctrl_clk_status"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mdctrl_clk_status(&self) -> U0_CDN_USB_MDCTRL_CLK_STATUS_R {
-        U0_CDN_USB_MDCTRL_CLK_STATUS_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_mdctrl_clk_status(&self) -> U0_USB_MDCTRL_CLK_STATUS_R {
+        U0_USB_MDCTRL_CLK_STATUS_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bits 16:18 - Can onlly be changed when pwrup_rst_n is low"]
     #[inline(always)]
-    pub fn u0_cdn_usb_mode_strap(&self) -> U0_CDN_USB_MODE_STRAP_R {
-        U0_CDN_USB_MODE_STRAP_R::new(((self.bits >> 16) & 7) as u8)
+    pub fn u0_usb_mode_strap(&self) -> U0_USB_MODE_STRAP_R {
+        U0_USB_MODE_STRAP_R::new(((self.bits >> 16) & 7) as u8)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_otg_suspendm"]
+    #[doc = "Bit 19 - u0_usb_otg_suspendm"]
     #[inline(always)]
-    pub fn u0_cdn_usb_otg_suspendm(&self) -> U0_CDN_USB_OTG_SUSPENDM_R {
-        U0_CDN_USB_OTG_SUSPENDM_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_otg_suspendm(&self) -> U0_USB_OTG_SUSPENDM_R {
+        U0_USB_OTG_SUSPENDM_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_otg_suspendm_byps"]
+    #[doc = "Bit 20 - u0_usb_otg_suspendm_byps"]
     #[inline(always)]
-    pub fn u0_cdn_usb_otg_suspendm_byps(&self) -> U0_CDN_USB_OTG_SUSPENDM_BYPS_R {
-        U0_CDN_USB_OTG_SUSPENDM_BYPS_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_otg_suspendm_byps(&self) -> U0_USB_OTG_SUSPENDM_BYPS_R {
+        U0_USB_OTG_SUSPENDM_BYPS_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_phy_bvalid"]
+    #[doc = "Bit 21 - u0_usb_phy_bvalid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_phy_bvalid(&self) -> U0_CDN_USB_PHY_BVALID_R {
-        U0_CDN_USB_PHY_BVALID_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_phy_bvalid(&self) -> U0_USB_PHY_BVALID_R {
+        U0_USB_PHY_BVALID_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_pll_en"]
+    #[doc = "Bit 22 - u0_usb_pll_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_pll_en(&self) -> U0_CDN_USB_PLL_EN_R {
-        U0_CDN_USB_PLL_EN_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_pll_en(&self) -> U0_USB_PLL_EN_R {
+        U0_USB_PLL_EN_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_refclk_mode"]
+    #[doc = "Bit 23 - u0_usb_refclk_mode"]
     #[inline(always)]
-    pub fn u0_cdn_usb_refclk_mode(&self) -> U0_CDN_USB_REFCLK_MODE_R {
-        U0_CDN_USB_REFCLK_MODE_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_refclk_mode(&self) -> U0_USB_REFCLK_MODE_R {
+        U0_USB_REFCLK_MODE_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - u0_cdn_usb_rid_comp_sts_0"]
     #[inline(always)]
@@ -135,78 +135,74 @@ impl R {
     pub fn u0_cdn_usb_rid_comp_sts_2(&self) -> U0_CDN_USB_RID_COMP_STS_2_R {
         U0_CDN_USB_RID_COMP_STS_2_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_cdn_usb_rid_float_comp_en"]
+    #[doc = "Bit 27 - u0_usb_rid_float_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_float_comp_en(&self) -> U0_CDN_USB_RID_FLOAT_COMP_EN_R {
-        U0_CDN_USB_RID_FLOAT_COMP_EN_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_usb_rid_float_comp_en(&self) -> U0_USB_RID_FLOAT_COMP_EN_R {
+        U0_USB_RID_FLOAT_COMP_EN_R::new(((self.bits >> 27) & 1) != 0)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_rid_float_comp_sts"]
+    #[doc = "Bit 28 - u0_usb_rid_float_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_float_comp_sts(&self) -> U0_CDN_USB_RID_FLOAT_COMP_STS_R {
-        U0_CDN_USB_RID_FLOAT_COMP_STS_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_usb_rid_float_comp_sts(&self) -> U0_USB_RID_FLOAT_COMP_STS_R {
+        U0_USB_RID_FLOAT_COMP_STS_R::new(((self.bits >> 28) & 1) != 0)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_rid_gnd_comp_sts"]
+    #[doc = "Bit 29 - u0_usb_rid_gnd_comp_sts"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_gnd_comp_sts(&self) -> U0_CDN_USB_RID_GND_COMP_STS_R {
-        U0_CDN_USB_RID_GND_COMP_STS_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_rid_gnd_comp_sts(&self) -> U0_USB_RID_GND_COMP_STS_R {
+        U0_USB_RID_GND_COMP_STS_R::new(((self.bits >> 29) & 1) != 0)
     }
-    #[doc = "Bit 30 - u0_cdn_usb_rid_nonfloat_comp_en"]
+    #[doc = "Bit 30 - u0_usb_rid_nonfloat_comp_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rid_nonfloat_comp_en(&self) -> U0_CDN_USB_RID_NONFLOAT_COMP_EN_R {
-        U0_CDN_USB_RID_NONFLOAT_COMP_EN_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_usb_rid_nonfloat_comp_en(&self) -> U0_USB_RID_NONFLOAT_COMP_EN_R {
+        U0_USB_RID_NONFLOAT_COMP_EN_R::new(((self.bits >> 30) & 1) != 0)
     }
-    #[doc = "Bit 31 - u0_cdn_usb_rx_dm"]
+    #[doc = "Bit 31 - u0_usb_rx_dm"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_dm(&self) -> U0_CDN_USB_RX_DM_R {
-        U0_CDN_USB_RX_DM_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_usb_rx_dm(&self) -> U0_USB_RX_DM_R {
+        U0_USB_RX_DM_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 13 - LTM interface to software"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_ltm_host_req_halt(
-        &mut self,
-    ) -> U0_CDN_USB_LTM_HOST_REQ_HALT_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_LTM_HOST_REQ_HALT_W::new(self, 13)
+    pub fn u0_usb_ltm_host_req_halt(&mut self) -> U0_USB_LTM_HOST_REQ_HALT_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_LTM_HOST_REQ_HALT_W::new(self, 13)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_mdctrl_clk_sel"]
+    #[doc = "Bit 14 - u0_usb_mdctrl_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_mdctrl_clk_sel(&mut self) -> U0_CDN_USB_MDCTRL_CLK_SEL_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_MDCTRL_CLK_SEL_W::new(self, 14)
+    pub fn u0_usb_mdctrl_clk_sel(&mut self) -> U0_USB_MDCTRL_CLK_SEL_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_MDCTRL_CLK_SEL_W::new(self, 14)
     }
     #[doc = "Bits 16:18 - Can onlly be changed when pwrup_rst_n is low"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_mode_strap(&mut self) -> U0_CDN_USB_MODE_STRAP_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_MODE_STRAP_W::new(self, 16)
+    pub fn u0_usb_mode_strap(&mut self) -> U0_USB_MODE_STRAP_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_MODE_STRAP_W::new(self, 16)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_otg_suspendm"]
+    #[doc = "Bit 19 - u0_usb_otg_suspendm"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_otg_suspendm(&mut self) -> U0_CDN_USB_OTG_SUSPENDM_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_OTG_SUSPENDM_W::new(self, 19)
+    pub fn u0_usb_otg_suspendm(&mut self) -> U0_USB_OTG_SUSPENDM_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_OTG_SUSPENDM_W::new(self, 19)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_otg_suspendm_byps"]
+    #[doc = "Bit 20 - u0_usb_otg_suspendm_byps"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_otg_suspendm_byps(
-        &mut self,
-    ) -> U0_CDN_USB_OTG_SUSPENDM_BYPS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_OTG_SUSPENDM_BYPS_W::new(self, 20)
+    pub fn u0_usb_otg_suspendm_byps(&mut self) -> U0_USB_OTG_SUSPENDM_BYPS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_OTG_SUSPENDM_BYPS_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_pll_en"]
+    #[doc = "Bit 22 - u0_usb_pll_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_pll_en(&mut self) -> U0_CDN_USB_PLL_EN_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_PLL_EN_W::new(self, 22)
+    pub fn u0_usb_pll_en(&mut self) -> U0_USB_PLL_EN_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_PLL_EN_W::new(self, 22)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_refclk_mode"]
+    #[doc = "Bit 23 - u0_usb_refclk_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_refclk_mode(&mut self) -> U0_CDN_USB_REFCLK_MODE_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_REFCLK_MODE_W::new(self, 23)
+    pub fn u0_usb_refclk_mode(&mut self) -> U0_USB_REFCLK_MODE_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_REFCLK_MODE_W::new(self, 23)
     }
     #[doc = "Bit 24 - u0_cdn_usb_rid_comp_sts_0"]
     #[inline(always)]
@@ -226,21 +222,17 @@ impl W {
     pub fn u0_cdn_usb_rid_comp_sts_2(&mut self) -> U0_CDN_USB_RID_COMP_STS_2_W<STG_SYSCFG_1_SPEC> {
         U0_CDN_USB_RID_COMP_STS_2_W::new(self, 26)
     }
-    #[doc = "Bit 28 - u0_cdn_usb_rid_float_comp_sts"]
+    #[doc = "Bit 28 - u0_usb_rid_float_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_rid_float_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_RID_FLOAT_COMP_STS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_RID_FLOAT_COMP_STS_W::new(self, 28)
+    pub fn u0_usb_rid_float_comp_sts(&mut self) -> U0_USB_RID_FLOAT_COMP_STS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_RID_FLOAT_COMP_STS_W::new(self, 28)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_rid_gnd_comp_sts"]
+    #[doc = "Bit 29 - u0_usb_rid_gnd_comp_sts"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_rid_gnd_comp_sts(
-        &mut self,
-    ) -> U0_CDN_USB_RID_GND_COMP_STS_W<STG_SYSCFG_1_SPEC> {
-        U0_CDN_USB_RID_GND_COMP_STS_W::new(self, 29)
+    pub fn u0_usb_rid_gnd_comp_sts(&mut self) -> U0_USB_RID_GND_COMP_STS_W<STG_SYSCFG_1_SPEC> {
+        U0_USB_RID_GND_COMP_STS_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_10.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_10.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_10_SPEC>;
 #[doc = "Register `stg_syscfg_10` writer"]
 pub type W = crate::W<STG_SYSCFG_10_SPEC>;
-#[doc = "Field `u0_e2_sft7110_wfi_from_tile_0` reader - u0_e2_sft7110_wfi_from_tile_0"]
-pub type U0_E2_SFT7110_WFI_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_wfi_from_tile_0` reader - u0_e2_wfi_from_tile_0"]
+pub type U0_E2_WFI_FROM_TILE_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_e2_sft7110_wfi_from_tile_0"]
+    #[doc = "Bit 0 - u0_e2_wfi_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_wfi_from_tile_0(&self) -> U0_E2_SFT7110_WFI_FROM_TILE_0_R {
-        U0_E2_SFT7110_WFI_FROM_TILE_0_R::new((self.bits & 1) != 0)
+    pub fn u0_e2_wfi_from_tile_0(&self) -> U0_E2_WFI_FROM_TILE_0_R {
+        U0_E2_WFI_FROM_TILE_0_R::new((self.bits & 1) != 0)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_100.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_100.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_100_SPEC>;
 #[doc = "Register `stg_syscfg_100` writer"]
 pub type W = crate::W<STG_SYSCFG_100_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_319_288` reader - u0_plda_pcie_test_out_bridge_319_288"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_319_288` reader - u0_pcie_test_out_bridge_319_288"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_319_288(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_319_288(&self) -> U0_PCIE_TEST_OUT_BRIDGE_319_288_R {
+        U0_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_101.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_101.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_101_SPEC>;
 #[doc = "Register `stg_syscfg_101` writer"]
 pub type W = crate::W<STG_SYSCFG_101_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_351_320` reader - u0_plda_pcie_test_out_bridge_351_320"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_351_320` reader - u0_pcie_test_out_bridge_351_320"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_351_320(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_351_320(&self) -> U0_PCIE_TEST_OUT_BRIDGE_351_320_R {
+        U0_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_102.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_102.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_102_SPEC>;
 #[doc = "Register `stg_syscfg_102` writer"]
 pub type W = crate::W<STG_SYSCFG_102_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_383_352` reader - u0_plda_pcie_test_out_bridge_383_352"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_383_352` reader - u0_pcie_test_out_bridge_383_352"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_383_352(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_383_352(&self) -> U0_PCIE_TEST_OUT_BRIDGE_383_352_R {
+        U0_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_103.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_103.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_103_SPEC>;
 #[doc = "Register `stg_syscfg_103` writer"]
 pub type W = crate::W<STG_SYSCFG_103_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_415_384` reader - u0_plda_pcie_test_out_bridge_415_384"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_415_384` reader - u0_pcie_test_out_bridge_415_384"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_415_384(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_415_384(&self) -> U0_PCIE_TEST_OUT_BRIDGE_415_384_R {
+        U0_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_104.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_104.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_104_SPEC>;
 #[doc = "Register `stg_syscfg_104` writer"]
 pub type W = crate::W<STG_SYSCFG_104_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_447_416` reader - u0_plda_pcie_test_out_bridge_447_416"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_447_416` reader - u0_pcie_test_out_bridge_447_416"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_447_416(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_447_416(&self) -> U0_PCIE_TEST_OUT_BRIDGE_447_416_R {
+        U0_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_105.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_105.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_105_SPEC>;
 #[doc = "Register `stg_syscfg_105` writer"]
 pub type W = crate::W<STG_SYSCFG_105_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_479_448` reader - u0_plda_pcie_test_out_bridge_479_448"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_479_448` reader - u0_pcie_test_out_bridge_479_448"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_479_448(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_479_448(&self) -> U0_PCIE_TEST_OUT_BRIDGE_479_448_R {
+        U0_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_106.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_106.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_106_SPEC>;
 #[doc = "Register `stg_syscfg_106` writer"]
 pub type W = crate::W<STG_SYSCFG_106_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_511_480` reader - u0_plda_pcie_test_out_bridge_511_480"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_511_480` reader - u0_pcie_test_out_bridge_511_480"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_511_480(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_511_480(&self) -> U0_PCIE_TEST_OUT_BRIDGE_511_480_R {
+        U0_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_107.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_107.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_107_SPEC>;
 #[doc = "Register `stg_syscfg_107` writer"]
 pub type W = crate::W<STG_SYSCFG_107_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_31_0` reader - u0_plda_pcie_test_out_pcie_31_0"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_31_0` reader - u0_pcie_test_out_pcie_31_0"]
+pub type U0_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_31_0(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_31_0(&self) -> U0_PCIE_TEST_OUT_PCIE_31_0_R {
+        U0_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_108.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_108.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_108_SPEC>;
 #[doc = "Register `stg_syscfg_108` writer"]
 pub type W = crate::W<STG_SYSCFG_108_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_63_32` reader - u0_plda_pcie_test_out_pcie_63_32"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_63_32` reader - u0_pcie_test_out_pcie_63_32"]
+pub type U0_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_63_32(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_63_32(&self) -> U0_PCIE_TEST_OUT_PCIE_63_32_R {
+        U0_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_109.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_109.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_109_SPEC>;
 #[doc = "Register `stg_syscfg_109` writer"]
 pub type W = crate::W<STG_SYSCFG_109_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_95_64` reader - u0_plda_pcie_test_out_pcie_95_64"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_95_64` reader - u0_pcie_test_out_pcie_95_64"]
+pub type U0_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_95_64(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_95_64(&self) -> U0_PCIE_TEST_OUT_PCIE_95_64_R {
+        U0_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_110.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_110.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_110_SPEC>;
 #[doc = "Register `stg_syscfg_110` writer"]
 pub type W = crate::W<STG_SYSCFG_110_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_127_96` reader - u0_plda_pcie_test_out_pcie_127_96"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_127_96` reader - u0_pcie_test_out_pcie_127_96"]
+pub type U0_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_127_96(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_127_96(&self) -> U0_PCIE_TEST_OUT_PCIE_127_96_R {
+        U0_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_111.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_111.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_111_SPEC>;
 #[doc = "Register `stg_syscfg_111` writer"]
 pub type W = crate::W<STG_SYSCFG_111_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_159_128` reader - u0_plda_pcie_test_out_pcie_159_128"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_159_128` reader - u0_pcie_test_out_pcie_159_128"]
+pub type U0_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_159_128(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_159_128(&self) -> U0_PCIE_TEST_OUT_PCIE_159_128_R {
+        U0_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_112.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_112.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_112_SPEC>;
 #[doc = "Register `stg_syscfg_112` writer"]
 pub type W = crate::W<STG_SYSCFG_112_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_191_160` reader - u0_plda_pcie_test_out_pcie_191_160"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_191_160` reader - u0_pcie_test_out_pcie_191_160"]
+pub type U0_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_191_160(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_191_160(&self) -> U0_PCIE_TEST_OUT_PCIE_191_160_R {
+        U0_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_113.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_113.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_113_SPEC>;
 #[doc = "Register `stg_syscfg_113` writer"]
 pub type W = crate::W<STG_SYSCFG_113_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_223_192` reader - u0_plda_pcie_test_out_pcie_223_192"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_223_192` reader - u0_pcie_test_out_pcie_223_192"]
+pub type U0_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_223_192(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_223_192(&self) -> U0_PCIE_TEST_OUT_PCIE_223_192_R {
+        U0_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_114.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_114.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_114_SPEC>;
 #[doc = "Register `stg_syscfg_114` writer"]
 pub type W = crate::W<STG_SYSCFG_114_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_255_224` reader - u0_plda_pcie_test_out_pcie_255_224"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_255_224` reader - u0_pcie_test_out_pcie_255_224"]
+pub type U0_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_255_224(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_255_224(&self) -> U0_PCIE_TEST_OUT_PCIE_255_224_R {
+        U0_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_115.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_115.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_115_SPEC>;
 #[doc = "Register `stg_syscfg_115` writer"]
 pub type W = crate::W<STG_SYSCFG_115_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_287_256` reader - u0_plda_pcie_test_out_pcie_287_256"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_287_256` reader - u0_pcie_test_out_pcie_287_256"]
+pub type U0_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_287_256(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_287_256(&self) -> U0_PCIE_TEST_OUT_PCIE_287_256_R {
+        U0_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_116.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_116.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_116_SPEC>;
 #[doc = "Register `stg_syscfg_116` writer"]
 pub type W = crate::W<STG_SYSCFG_116_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_319_288` reader - u0_plda_pcie_test_out_pcie_319_288"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_319_288` reader - u0_pcie_test_out_pcie_319_288"]
+pub type U0_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_319_288(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_319_288(&self) -> U0_PCIE_TEST_OUT_PCIE_319_288_R {
+        U0_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_117.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_117.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_117_SPEC>;
 #[doc = "Register `stg_syscfg_117` writer"]
 pub type W = crate::W<STG_SYSCFG_117_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_351_320` reader - u0_plda_pcie_test_out_pcie_351_320"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_351_320` reader - u0_pcie_test_out_pcie_351_320"]
+pub type U0_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_351_320(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_351_320(&self) -> U0_PCIE_TEST_OUT_PCIE_351_320_R {
+        U0_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_118.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_118.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_118_SPEC>;
 #[doc = "Register `stg_syscfg_118` writer"]
 pub type W = crate::W<STG_SYSCFG_118_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_383_352` reader - u0_plda_pcie_test_out_pcie_383_352"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_383_352` reader - u0_pcie_test_out_pcie_383_352"]
+pub type U0_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_383_352(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_383_352(&self) -> U0_PCIE_TEST_OUT_PCIE_383_352_R {
+        U0_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_119.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_119.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_119_SPEC>;
 #[doc = "Register `stg_syscfg_119` writer"]
 pub type W = crate::W<STG_SYSCFG_119_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_415_384` reader - u0_plda_pcie_test_out_pcie_415_384"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_415_384` reader - u0_pcie_test_out_pcie_415_384"]
+pub type U0_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_415_384(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_415_384(&self) -> U0_PCIE_TEST_OUT_PCIE_415_384_R {
+        U0_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_120.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_120.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_120_SPEC>;
 #[doc = "Register `stg_syscfg_120` writer"]
 pub type W = crate::W<STG_SYSCFG_120_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_447_416` reader - u0_plda_pcie_test_out_pcie_447_416"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_447_416` reader - u0_pcie_test_out_pcie_447_416"]
+pub type U0_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_447_416(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_447_416(&self) -> U0_PCIE_TEST_OUT_PCIE_447_416_R {
+        U0_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_121.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_121.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_121_SPEC>;
 #[doc = "Register `stg_syscfg_121` writer"]
 pub type W = crate::W<STG_SYSCFG_121_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_479_448` reader - u0_plda_pcie_test_out_pcie_479_448"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_479_448` reader - u0_pcie_test_out_pcie_479_448"]
+pub type U0_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_479_448(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_479_448(&self) -> U0_PCIE_TEST_OUT_PCIE_479_448_R {
+        U0_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_122.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_122.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_122_SPEC>;
 #[doc = "Register `stg_syscfg_122` writer"]
 pub type W = crate::W<STG_SYSCFG_122_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_pcie_511_480` reader - u0_plda_pcie_test_out_pcie_511_480"]
-pub type U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_pcie_511_480` reader - u0_pcie_test_out_pcie_511_480"]
+pub type U0_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_pcie_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_pcie_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_pcie_511_480(&self) -> U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R {
-        U0_PLDA_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
+    pub fn u0_pcie_test_out_pcie_511_480(&self) -> U0_PCIE_TEST_OUT_PCIE_511_480_R {
+        U0_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_123.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_123.rs
@@ -2,40 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_123_SPEC>;
 #[doc = "Register `stg_syscfg_123` writer"]
 pub type W = crate::W<STG_SYSCFG_123_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_sel` reader - u0_plda_pcie_test_sel"]
-pub type U0_PLDA_PCIE_TEST_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_test_sel` writer - u0_plda_pcie_test_sel"]
-pub type U0_PLDA_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u0_plda_pcie_tl_clock_freq` reader - u0_plda_pcie_tl_clock_freq"]
-pub type U0_PLDA_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_tl_clock_freq` writer - u0_plda_pcie_tl_clock_freq"]
-pub type U0_PLDA_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
+#[doc = "Field `u0_pcie_test_sel` reader - u0_pcie_test_sel"]
+pub type U0_PCIE_TEST_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_test_sel` writer - u0_pcie_test_sel"]
+pub type U0_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_tl_clock_freq` reader - u0_pcie_tl_clock_freq"]
+pub type U0_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_tl_clock_freq` writer - u0_pcie_tl_clock_freq"]
+pub type U0_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
 impl R {
-    #[doc = "Bits 0:3 - u0_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u0_pcie_test_sel"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_sel(&self) -> U0_PLDA_PCIE_TEST_SEL_R {
-        U0_PLDA_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
+    pub fn u0_pcie_test_sel(&self) -> U0_PCIE_TEST_SEL_R {
+        U0_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:25 - u0_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u0_pcie_tl_clock_freq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_clock_freq(&self) -> U0_PLDA_PCIE_TL_CLOCK_FREQ_R {
-        U0_PLDA_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
+    pub fn u0_pcie_tl_clock_freq(&self) -> U0_PCIE_TL_CLOCK_FREQ_R {
+        U0_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - u0_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u0_pcie_test_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_sel(&mut self) -> U0_PLDA_PCIE_TEST_SEL_W<STG_SYSCFG_123_SPEC> {
-        U0_PLDA_PCIE_TEST_SEL_W::new(self, 0)
+    pub fn u0_pcie_test_sel(&mut self) -> U0_PCIE_TEST_SEL_W<STG_SYSCFG_123_SPEC> {
+        U0_PCIE_TEST_SEL_W::new(self, 0)
     }
-    #[doc = "Bits 4:25 - u0_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u0_pcie_tl_clock_freq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tl_clock_freq(
-        &mut self,
-    ) -> U0_PLDA_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_123_SPEC> {
-        U0_PLDA_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
+    pub fn u0_pcie_tl_clock_freq(&mut self) -> U0_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_123_SPEC> {
+        U0_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_124.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_124.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_124_SPEC>;
 #[doc = "Register `stg_syscfg_124` writer"]
 pub type W = crate::W<STG_SYSCFG_124_SPEC>;
-#[doc = "Field `u0_plda_pcie_tl_ctrl_hotplug` reader - u0_plda_pcie_tl_ctrl_hotplug"]
-pub type U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_tl_report_hotplug` reader - u0_plda_pcie_tl_report_hotplug"]
-pub type U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_tl_report_hotplug` writer - u0_plda_pcie_tl_report_hotplug"]
-pub type U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `u0_pcie_tl_ctrl_hotplug` reader - u0_pcie_tl_ctrl_hotplug"]
+pub type U0_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_tl_report_hotplug` reader - u0_pcie_tl_report_hotplug"]
+pub type U0_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_tl_report_hotplug` writer - u0_pcie_tl_report_hotplug"]
+pub type U0_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
 impl R {
-    #[doc = "Bits 0:15 - u0_plda_pcie_tl_ctrl_hotplug"]
+    #[doc = "Bits 0:15 - u0_pcie_tl_ctrl_hotplug"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_ctrl_hotplug(&self) -> U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R {
-        U0_PLDA_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
+    pub fn u0_pcie_tl_ctrl_hotplug(&self) -> U0_PCIE_TL_CTRL_HOTPLUG_R {
+        U0_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:31 - u0_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u0_pcie_tl_report_hotplug"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tl_report_hotplug(&self) -> U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R {
-        U0_PLDA_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn u0_pcie_tl_report_hotplug(&self) -> U0_PCIE_TL_REPORT_HOTPLUG_R {
+        U0_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 16:31 - u0_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u0_pcie_tl_report_hotplug"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tl_report_hotplug(
+    pub fn u0_pcie_tl_report_hotplug(
         &mut self,
-    ) -> U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_124_SPEC> {
-        U0_PLDA_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
+    ) -> U0_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_124_SPEC> {
+        U0_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_125.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_125.rs
@@ -2,34 +2,34 @@
 pub type R = crate::R<STG_SYSCFG_125_SPEC>;
 #[doc = "Register `stg_syscfg_125` writer"]
 pub type W = crate::W<STG_SYSCFG_125_SPEC>;
-#[doc = "Field `u0_plda_pcie_tx_pattern` reader - u0_plda_pcie_tx_pattern"]
-pub type U0_PLDA_PCIE_TX_PATTERN_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_tx_pattern` writer - u0_plda_pcie_tx_pattern"]
-pub type U0_PLDA_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_bus_width` reader - u0_plda_pcie_usb3_bus_width"]
-pub type U0_PLDA_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_usb3_bus_width` writer - u0_plda_pcie_usb3_bus_width"]
-pub type U0_PLDA_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_phy_enable` reader - u0_plda_pcie_usb3_phy_enable"]
-pub type U0_PLDA_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_usb3_phy_enable` writer - u0_plda_pcie_usb3_phy_enable"]
-pub type U0_PLDA_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_usb3_rate` reader - u0_plda_pcie_usb3_rate"]
-pub type U0_PLDA_PCIE_USB3_RATE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_usb3_rate` writer - u0_plda_pcie_usb3_rate"]
-pub type U0_PLDA_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_usb3_rx_standby` reader - u0_plda_pcie_usb3_rx_standby"]
-pub type U0_PLDA_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_usb3_rx_standby` writer - u0_plda_pcie_usb3_rx_standby"]
-pub type U0_PLDA_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_xwdecerr` reader - u0_plda_pcie_xwdecerr"]
-pub type U0_PLDA_PCIE_XWDECERR_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_xwerrclr` reader - u0_plda_pcie_xwerrclr"]
-pub type U0_PLDA_PCIE_XWERRCLR_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_xwerrclr` writer - u0_plda_pcie_xwerrclr"]
-pub type U0_PLDA_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_xwslverr` reader - u0_plda_pcie_xwslverr"]
-pub type U0_PLDA_PCIE_XWSLVERR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_tx_pattern` reader - u0_pcie_tx_pattern"]
+pub type U0_PCIE_TX_PATTERN_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_tx_pattern` writer - u0_pcie_tx_pattern"]
+pub type U0_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_bus_width` reader - u0_pcie_usb3_bus_width"]
+pub type U0_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_usb3_bus_width` writer - u0_pcie_usb3_bus_width"]
+pub type U0_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_phy_enable` reader - u0_pcie_usb3_phy_enable"]
+pub type U0_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_usb3_phy_enable` writer - u0_pcie_usb3_phy_enable"]
+pub type U0_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_usb3_rate` reader - u0_pcie_usb3_rate"]
+pub type U0_PCIE_USB3_RATE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_usb3_rate` writer - u0_pcie_usb3_rate"]
+pub type U0_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_usb3_rx_standby` reader - u0_pcie_usb3_rx_standby"]
+pub type U0_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
+#[doc = "Field `u0_pcie_usb3_rx_standby` writer - u0_pcie_usb3_rx_standby"]
+pub type U0_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_xwdecerr` reader - u0_pcie_xwdecerr"]
+pub type U0_PCIE_XWDECERR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_xwerrclr` reader - u0_pcie_xwerrclr"]
+pub type U0_PCIE_XWERRCLR_R = crate::BitReader;
+#[doc = "Field `u0_pcie_xwerrclr` writer - u0_pcie_xwerrclr"]
+pub type U0_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_xwslverr` reader - u0_pcie_xwslverr"]
+pub type U0_PCIE_XWSLVERR_R = crate::BitReader;
 #[doc = "Field `u0_sec_top_sramcfg_slp` reader - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
 pub type U0_SEC_TOP_SRAMCFG_SLP_R = crate::BitReader;
 #[doc = "Field `u0_sec_top_sramcfg_slp` writer - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
@@ -65,45 +65,45 @@ pub type U0_SEC_TOP_SRAMCFG_VG_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `u0_plda_pcie_align_detect` reader - u0_plda_pcie_align_detect"]
 pub type U0_PLDA_PCIE_ALIGN_DETECT_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u0_pcie_tx_pattern"]
     #[inline(always)]
-    pub fn u0_plda_pcie_tx_pattern(&self) -> U0_PLDA_PCIE_TX_PATTERN_R {
-        U0_PLDA_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_tx_pattern(&self) -> U0_PCIE_TX_PATTERN_R {
+        U0_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:3 - u0_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u0_pcie_usb3_bus_width"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_bus_width(&self) -> U0_PLDA_PCIE_USB3_BUS_WIDTH_R {
-        U0_PLDA_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
+    pub fn u0_pcie_usb3_bus_width(&self) -> U0_PCIE_USB3_BUS_WIDTH_R {
+        U0_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
     }
-    #[doc = "Bit 4 - u0_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u0_pcie_usb3_phy_enable"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_phy_enable(&self) -> U0_PLDA_PCIE_USB3_PHY_ENABLE_R {
-        U0_PLDA_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_pcie_usb3_phy_enable(&self) -> U0_PCIE_USB3_PHY_ENABLE_R {
+        U0_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:6 - u0_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u0_pcie_usb3_rate"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_rate(&self) -> U0_PLDA_PCIE_USB3_RATE_R {
-        U0_PLDA_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
+    pub fn u0_pcie_usb3_rate(&self) -> U0_PCIE_USB3_RATE_R {
+        U0_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
     }
-    #[doc = "Bit 7 - u0_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u0_pcie_usb3_rx_standby"]
     #[inline(always)]
-    pub fn u0_plda_pcie_usb3_rx_standby(&self) -> U0_PLDA_PCIE_USB3_RX_STANDBY_R {
-        U0_PLDA_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_pcie_usb3_rx_standby(&self) -> U0_PCIE_USB3_RX_STANDBY_R {
+        U0_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_xwdecerr"]
+    #[doc = "Bit 8 - u0_pcie_xwdecerr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwdecerr(&self) -> U0_PLDA_PCIE_XWDECERR_R {
-        U0_PLDA_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_pcie_xwdecerr(&self) -> U0_PCIE_XWDECERR_R {
+        U0_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u0_pcie_xwerrclr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwerrclr(&self) -> U0_PLDA_PCIE_XWERRCLR_R {
-        U0_PLDA_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_pcie_xwerrclr(&self) -> U0_PCIE_XWERRCLR_R {
+        U0_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_xwslverr"]
+    #[doc = "Bit 10 - u0_pcie_xwslverr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_xwslverr(&self) -> U0_PLDA_PCIE_XWSLVERR_R {
-        U0_PLDA_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_pcie_xwslverr(&self) -> U0_PCIE_XWSLVERR_R {
+        U0_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -152,47 +152,41 @@ impl R {
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u0_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u0_pcie_tx_pattern"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_tx_pattern(&mut self) -> U0_PLDA_PCIE_TX_PATTERN_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_TX_PATTERN_W::new(self, 0)
+    pub fn u0_pcie_tx_pattern(&mut self) -> U0_PCIE_TX_PATTERN_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_TX_PATTERN_W::new(self, 0)
     }
-    #[doc = "Bits 2:3 - u0_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u0_pcie_usb3_bus_width"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_bus_width(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
+    pub fn u0_pcie_usb3_bus_width(&mut self) -> U0_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
     }
-    #[doc = "Bit 4 - u0_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u0_pcie_usb3_phy_enable"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_phy_enable(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
+    pub fn u0_pcie_usb3_phy_enable(&mut self) -> U0_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
     }
-    #[doc = "Bits 5:6 - u0_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u0_pcie_usb3_rate"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_rate(&mut self) -> U0_PLDA_PCIE_USB3_RATE_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_RATE_W::new(self, 5)
+    pub fn u0_pcie_usb3_rate(&mut self) -> U0_PCIE_USB3_RATE_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_RATE_W::new(self, 5)
     }
-    #[doc = "Bit 7 - u0_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u0_pcie_usb3_rx_standby"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_usb3_rx_standby(
-        &mut self,
-    ) -> U0_PLDA_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_USB3_RX_STANDBY_W::new(self, 7)
+    pub fn u0_pcie_usb3_rx_standby(&mut self) -> U0_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_USB3_RX_STANDBY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u0_pcie_xwerrclr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_xwerrclr(&mut self) -> U0_PLDA_PCIE_XWERRCLR_W<STG_SYSCFG_125_SPEC> {
-        U0_PLDA_PCIE_XWERRCLR_W::new(self, 9)
+    pub fn u0_pcie_xwerrclr(&mut self) -> U0_PCIE_XWERRCLR_W<STG_SYSCFG_125_SPEC> {
+        U0_PCIE_XWERRCLR_W::new(self, 9)
     }
     #[doc = "Bit 11 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_126.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_126.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_126_SPEC>;
 #[doc = "Register `stg_syscfg_126` writer"]
 pub type W = crate::W<STG_SYSCFG_126_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_31_0` reader - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_31_0` reader - u0_pcie_axi4_mst0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_127.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_127.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_127_SPEC>;
 #[doc = "Register `stg_syscfg_127` writer"]
 pub type W = crate::W<STG_SYSCFG_127_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_63_32` reader - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_63_32` reader - u0_pcie_axi4_mst0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_128.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_128.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_128_SPEC>;
 #[doc = "Register `stg_syscfg_128` writer"]
 pub type W = crate::W<STG_SYSCFG_128_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_95_64` reader - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_95_64` reader - u0_pcie_axi4_mst0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_129.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_129.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_129_SPEC>;
 #[doc = "Register `stg_syscfg_129` writer"]
 pub type W = crate::W<STG_SYSCFG_129_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_127_96` reader - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_127_96` reader - u0_pcie_axi4_mst0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_127_96(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_130.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_130.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_130_SPEC>;
 #[doc = "Register `stg_syscfg_130` writer"]
 pub type W = crate::W<STG_SYSCFG_130_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_159_128` reader - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_159_128` reader - u0_pcie_axi4_mst0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_159_128(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_131.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_131.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_131_SPEC>;
 #[doc = "Register `stg_syscfg_131` writer"]
 pub type W = crate::W<STG_SYSCFG_131_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_191_160` reader - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_191_160` reader - u0_pcie_axi4_mst0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_191_160(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_132.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_132.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_132_SPEC>;
 #[doc = "Register `stg_syscfg_132` writer"]
 pub type W = crate::W<STG_SYSCFG_132_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_223_192` reader - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_223_192` reader - u0_pcie_axi4_mst0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_223_192(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_133.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_133.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_133_SPEC>;
 #[doc = "Register `stg_syscfg_133` writer"]
 pub type W = crate::W<STG_SYSCFG_133_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_255_224` reader - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_255_224` reader - u0_pcie_axi4_mst0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_255_224(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_134.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_134.rs
@@ -2,29 +2,27 @@
 pub type R = crate::R<STG_SYSCFG_134_SPEC>;
 #[doc = "Register `stg_syscfg_134` writer"]
 pub type W = crate::W<STG_SYSCFG_134_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_257_256` reader - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arfunc` reader - u0_plda_pcie_axi4_mst0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arregion` reader - u0_plda_pcie_axi4_mst0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_257_256` reader - u0_pcie_axi4_mst0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_arfunc` reader - u0_pcie_axi4_mst0_arfunc"]
+pub type U0_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_arregion` reader - u0_pcie_axi4_mst0_arregion"]
+pub type U0_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_mst0_aratomop_257_256(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_mst0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_mst0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_arfunc(&self) -> U0_PCIE_AXI4_MST0_ARFUNC_R {
+        U0_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_mst0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_mst0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_arregion(&self) -> U0_PCIE_AXI4_MST0_ARREGION_R {
+        U0_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_135.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_135.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_135_SPEC>;
 #[doc = "Register `stg_syscfg_135` writer"]
 pub type W = crate::W<STG_SYSCFG_135_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aruser_31_0` reader - u1_plda_pcie_axi4_mst0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_aruser_31_0` reader - u1_pcie_axi4_mst0_aruser_31_0"]
+pub type U1_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_aruser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aruser_31_0(&self) -> U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_aruser_31_0(&self) -> U1_PCIE_AXI4_MST0_ARUSER_31_0_R {
+        U1_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_136.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_136.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_136_SPEC>;
 #[doc = "Register `stg_syscfg_136` writer"]
 pub type W = crate::W<STG_SYSCFG_136_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aruser_52_32` reader - u1_plda_pcie_axi4_mst0_aruser_52_32"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_aruser_52_32` reader - u1_pcie_axi4_mst0_aruser_52_32"]
+pub type U1_PCIE_AXI4_MST0_ARUSER_52_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:20 - u1_plda_pcie_axi4_mst0_aruser_52_32"]
+    #[doc = "Bits 0:20 - u1_pcie_axi4_mst0_aruser_52_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aruser_52_32(&self) -> U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARUSER_52_32_R::new(self.bits & 0x001f_ffff)
+    pub fn u1_pcie_axi4_mst0_aruser_52_32(&self) -> U1_PCIE_AXI4_MST0_ARUSER_52_32_R {
+        U1_PCIE_AXI4_MST0_ARUSER_52_32_R::new(self.bits & 0x001f_ffff)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_137.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_137.rs
@@ -2,20 +2,20 @@
 pub type R = crate::R<STG_SYSCFG_137_SPEC>;
 #[doc = "Register `stg_syscfg_137` writer"]
 pub type W = crate::W<STG_SYSCFG_137_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awfunc` reader - u1_plda_pcie_axi4_mst0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awregion` reader - u1_plda_pcie_axi4_mst0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_awfunc` reader - u1_pcie_axi4_mst0_awfunc"]
+pub type U1_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_mst0_awregion` reader - u1_pcie_axi4_mst0_awregion"]
+pub type U1_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_mst0_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_mst0_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awfunc(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_mst0_awfunc(&self) -> U1_PCIE_AXI4_MST0_AWFUNC_R {
+        U1_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:18 - u1_plda_pcie_axi4_mst0_awregion"]
+    #[doc = "Bits 15:18 - u1_pcie_axi4_mst0_awregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awregion(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWREGION_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_mst0_awregion(&self) -> U1_PCIE_AXI4_MST0_AWREGION_R {
+        U1_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_138.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_138.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_138_SPEC>;
 #[doc = "Register `stg_syscfg_138` writer"]
 pub type W = crate::W<STG_SYSCFG_138_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awuser_31_0` reader - u1_plda_pcie_axi4_mst0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_awuser_31_0` reader - u1_pcie_axi4_mst0_awuser_31_0"]
+pub type U1_PCIE_AXI4_MST0_AWUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_awuser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awuser_31_0(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_awuser_31_0(&self) -> U1_PCIE_AXI4_MST0_AWUSER_31_0_R {
+        U1_PCIE_AXI4_MST0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_139.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_139.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_139_SPEC>;
 #[doc = "Register `stg_syscfg_139` writer"]
 pub type W = crate::W<STG_SYSCFG_139_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_awuser_42_32` reader - u1_plda_pcie_axi4_mst0_awuser_42_32"]
-pub type U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_rderr` reader - u1_plda_pcie_axi4_mst0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_rderr` writer - u1_plda_pcie_axi4_mst0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_axi4_mst0_awuser_42_32` reader - u1_pcie_axi4_mst0_awuser_42_32"]
+pub type U1_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_mst0_rderr` reader - u1_pcie_axi4_mst0_rderr"]
+pub type U1_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_rderr` writer - u1_pcie_axi4_mst0_rderr"]
+pub type U1_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:10 - u1_plda_pcie_axi4_mst0_awuser_42_32"]
+    #[doc = "Bits 0:10 - u1_pcie_axi4_mst0_awuser_42_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_awuser_42_32(&self) -> U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R {
-        U1_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
+    pub fn u1_pcie_axi4_mst0_awuser_42_32(&self) -> U1_PCIE_AXI4_MST0_AWUSER_42_32_R {
+        U1_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
     }
-    #[doc = "Bits 11:18 - u1_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u1_pcie_axi4_mst0_rderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_rderr(&self) -> U1_PLDA_PCIE_AXI4_MST0_RDERR_R {
-        U1_PLDA_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
+    pub fn u1_pcie_axi4_mst0_rderr(&self) -> U1_PCIE_AXI4_MST0_RDERR_R {
+        U1_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 11:18 - u1_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u1_pcie_axi4_mst0_rderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_rderr(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_139_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
+    pub fn u1_pcie_axi4_mst0_rderr(&mut self) -> U1_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_139_SPEC> {
+        U1_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_140.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_140.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_140_SPEC>;
 #[doc = "Register `stg_syscfg_140` writer"]
 pub type W = crate::W<STG_SYSCFG_140_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_ruser` reader - u1_plda_pcie_axi4_mst0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_ruser` writer - u1_plda_pcie_axi4_mst0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_ruser` reader - u1_pcie_axi4_mst0_ruser"]
+pub type U1_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_mst0_ruser` writer - u1_pcie_axi4_mst0_ruser"]
+pub type U1_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_ruser"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_ruser(&self) -> U1_PLDA_PCIE_AXI4_MST0_RUSER_R {
-        U1_PLDA_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
+    pub fn u1_pcie_axi4_mst0_ruser(&self) -> U1_PCIE_AXI4_MST0_RUSER_R {
+        U1_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_mst0_ruser"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_ruser(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_140_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
+    pub fn u1_pcie_axi4_mst0_ruser(&mut self) -> U1_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_140_SPEC> {
+        U1_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_141.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_141.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_141_SPEC>;
 #[doc = "Register `stg_syscfg_141` writer"]
 pub type W = crate::W<STG_SYSCFG_141_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_wderr` reader - u1_plda_pcie_axi4_mst0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_wderr` reader - u1_pcie_axi4_mst0_wderr"]
+pub type U1_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_mst0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_mst0_wderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_wderr(&self) -> U1_PLDA_PCIE_AXI4_MST0_WDERR_R {
-        U1_PLDA_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_axi4_mst0_wderr(&self) -> U1_PCIE_AXI4_MST0_WDERR_R {
+        U1_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_142.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_142.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_142_SPEC>;
 #[doc = "Register `stg_syscfg_142` writer"]
 pub type W = crate::W<STG_SYSCFG_142_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_31_0` reader - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_31_0` writer - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_31_0` reader - u1_pcie_axi4_slv0_aratomop_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_31_0` writer - u1_pcie_axi4_slv0_aratomop_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_31_0(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_31_0(
+    pub fn u1_pcie_axi4_slv0_aratomop_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_142_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_142_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_143.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_143.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_143_SPEC>;
 #[doc = "Register `stg_syscfg_143` writer"]
 pub type W = crate::W<STG_SYSCFG_143_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_63_32` reader - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_63_32` writer - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_63_32` reader - u1_pcie_axi4_slv0_aratomop_63_32"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_63_32` writer - u1_pcie_axi4_slv0_aratomop_63_32"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_63_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_63_32(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_63_32(
+    pub fn u1_pcie_axi4_slv0_aratomop_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_143_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_143_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_144.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_144.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_144_SPEC>;
 #[doc = "Register `stg_syscfg_144` writer"]
 pub type W = crate::W<STG_SYSCFG_144_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_95_64` reader - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_95_64` writer - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_95_64` reader - u1_pcie_axi4_slv0_aratomop_95_64"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_95_64` writer - u1_pcie_axi4_slv0_aratomop_95_64"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_95_64(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_95_64(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_95_64(
+    pub fn u1_pcie_axi4_slv0_aratomop_95_64(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_144_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_144_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_145.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_145.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_145_SPEC>;
 #[doc = "Register `stg_syscfg_145` writer"]
 pub type W = crate::W<STG_SYSCFG_145_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_127_96` reader - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_127_96` writer - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_127_96` reader - u1_pcie_axi4_slv0_aratomop_127_96"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_127_96` writer - u1_pcie_axi4_slv0_aratomop_127_96"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_127_96(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_127_96(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_127_96(
+    pub fn u1_pcie_axi4_slv0_aratomop_127_96(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_145_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_145_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_146.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_146.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_146_SPEC>;
 #[doc = "Register `stg_syscfg_146` writer"]
 pub type W = crate::W<STG_SYSCFG_146_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_159_128` reader - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_159_128` writer - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_159_128` reader - u1_pcie_axi4_slv0_aratomop_159_128"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_159_128` writer - u1_pcie_axi4_slv0_aratomop_159_128"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_159_128(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_159_128(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_159_128(
+    pub fn u1_pcie_axi4_slv0_aratomop_159_128(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_146_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_146_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_147.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_147.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_147_SPEC>;
 #[doc = "Register `stg_syscfg_147` writer"]
 pub type W = crate::W<STG_SYSCFG_147_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_191_160` reader - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_191_160` writer - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_191_160` reader - u1_pcie_axi4_slv0_aratomop_191_160"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_191_160` writer - u1_pcie_axi4_slv0_aratomop_191_160"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_191_160(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_191_160(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_191_160(
+    pub fn u1_pcie_axi4_slv0_aratomop_191_160(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_147_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_147_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_148.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_148.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_148_SPEC>;
 #[doc = "Register `stg_syscfg_148` writer"]
 pub type W = crate::W<STG_SYSCFG_148_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_223_192` reader - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_223_192` writer - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_223_192` reader - u1_pcie_axi4_slv0_aratomop_223_192"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_223_192` writer - u1_pcie_axi4_slv0_aratomop_223_192"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_223_192(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_223_192(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_223_192(
+    pub fn u1_pcie_axi4_slv0_aratomop_223_192(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_148_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_148_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_149.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_149.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_149_SPEC>;
 #[doc = "Register `stg_syscfg_149` writer"]
 pub type W = crate::W<STG_SYSCFG_149_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_255_224` reader - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aratomop_255_224` writer - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_255_224` reader - u1_pcie_axi4_slv0_aratomop_255_224"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aratomop_255_224` writer - u1_pcie_axi4_slv0_aratomop_255_224"]
+pub type U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_255_224(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aratomop_255_224(&self) -> U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aratomop_255_224(
+    pub fn u1_pcie_axi4_slv0_aratomop_255_224(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_149_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_149_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_150.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_150.rs
@@ -2,61 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_150_SPEC>;
 #[doc = "Register `stg_syscfg_150` writer"]
 pub type W = crate::W<STG_SYSCFG_150_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aratomop_257_256` reader - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_mst0_aratomop_257_256` writer - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arfunc` reader - u1_plda_pcie_axi4_slv0_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arfunc` writer - u1_plda_pcie_axi4_slv0_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arregion` reader - u1_plda_pcie_axi4_slv0_arregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_arregion` writer - u1_plda_pcie_axi4_slv0_arregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_axi4_mst0_aratomop_257_256` reader - u1_pcie_axi4_mst0_aratomop_257_256"]
+pub type U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_mst0_aratomop_257_256` writer - u1_pcie_axi4_mst0_aratomop_257_256"]
+pub type U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_axi4_slv0_arfunc` reader - u1_pcie_axi4_slv0_arfunc"]
+pub type U1_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_arfunc` writer - u1_pcie_axi4_slv0_arfunc"]
+pub type U1_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_arregion` reader - u1_pcie_axi4_slv0_arregion"]
+pub type U1_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_arregion` writer - u1_pcie_axi4_slv0_arregion"]
+pub type U1_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:1 - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u1_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u1_pcie_axi4_mst0_aratomop_257_256(&self) -> U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U1_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u1_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u1_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_arfunc(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slv0_arfunc(&self) -> U1_PCIE_AXI4_SLV0_ARFUNC_R {
+        U1_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u1_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u1_pcie_axi4_slv0_arregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_arregion(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_slv0_arregion(&self) -> U1_PCIE_AXI4_SLV0_ARREGION_R {
+        U1_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u1_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u1_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_mst0_aratomop_257_256(
+    pub fn u1_pcie_axi4_mst0_aratomop_257_256(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_MST0_ARATOMOP_257_256_W::new(self, 0)
     }
-    #[doc = "Bits 2:16 - u1_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u1_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_arfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
+    pub fn u1_pcie_axi4_slv0_arfunc(&mut self) -> U1_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
     }
-    #[doc = "Bits 17:20 - u1_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u1_pcie_axi4_slv0_arregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_arregion(
+    pub fn u1_pcie_axi4_slv0_arregion(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_150_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
+    ) -> U1_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_150_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_151.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_151.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_151_SPEC>;
 #[doc = "Register `stg_syscfg_151` writer"]
 pub type W = crate::W<STG_SYSCFG_151_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_31_0` reader - u1_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_31_0` writer - u1_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_31_0` reader - u1_pcie_axi4_slv0_aruser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_31_0` writer - u1_pcie_axi4_slv0_aruser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_aruser_31_0(&self) -> U1_PCIE_AXI4_SLV0_ARUSER_31_0_R {
+        U1_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_31_0(
+    pub fn u1_pcie_axi4_slv0_aruser_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_151_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_151_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_152.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_152.rs
@@ -2,59 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_152_SPEC>;
 #[doc = "Register `stg_syscfg_152` writer"]
 pub type W = crate::W<STG_SYSCFG_152_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_40_32` reader - u1_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_aruser_40_32` writer - u1_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awfunc` reader - u1_plda_pcie_axi4_slv0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awfunc` writer - u1_plda_pcie_axi4_slv0_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awregion` reader - u1_plda_pcie_axi4_slv0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awregion` writer - u1_plda_pcie_axi4_slv0_awregion"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_40_32` reader - u1_pcie_axi4_slv0_aruser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_aruser_40_32` writer - u1_pcie_axi4_slv0_aruser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awfunc` reader - u1_pcie_axi4_slv0_awfunc"]
+pub type U1_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awfunc` writer - u1_pcie_axi4_slv0_awfunc"]
+pub type U1_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awregion` reader - u1_pcie_axi4_slv0_awregion"]
+pub type U1_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_awregion` writer - u1_pcie_axi4_slv0_awregion"]
+pub type U1_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_40_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u1_pcie_axi4_slv0_aruser_40_32(&self) -> U1_PCIE_AXI4_SLV0_ARUSER_40_32_R {
+        U1_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:23 - u1_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u1_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awfunc(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slv0_awfunc(&self) -> U1_PCIE_AXI4_SLV0_AWFUNC_R {
+        U1_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
     }
-    #[doc = "Bits 24:27 - u1_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u1_pcie_axi4_slv0_awregion"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awregion(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn u1_pcie_axi4_slv0_awregion(&self) -> U1_PCIE_AXI4_SLV0_AWREGION_R {
+        U1_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_aruser_40_32(
+    pub fn u1_pcie_axi4_slv0_aruser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
     }
-    #[doc = "Bits 9:23 - u1_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u1_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
+    pub fn u1_pcie_axi4_slv0_awfunc(&mut self) -> U1_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
     }
-    #[doc = "Bits 24:27 - u1_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u1_pcie_axi4_slv0_awregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awregion(
+    pub fn u1_pcie_axi4_slv0_awregion(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_152_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
+    ) -> U1_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_152_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_153.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_153.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_153_SPEC>;
 #[doc = "Register `stg_syscfg_153` writer"]
 pub type W = crate::W<STG_SYSCFG_153_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_31_0` reader - u1_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_31_0` writer - u1_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_31_0` reader - u1_pcie_axi4_slv0_awuser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_31_0` writer - u1_pcie_axi4_slv0_awuser_31_0"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_31_0(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_awuser_31_0(&self) -> U1_PCIE_AXI4_SLV0_AWUSER_31_0_R {
+        U1_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_31_0(
+    pub fn u1_pcie_axi4_slv0_awuser_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_153_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_153_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_154.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_154.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_154_SPEC>;
 #[doc = "Register `stg_syscfg_154` writer"]
 pub type W = crate::W<STG_SYSCFG_154_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` reader - u1_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_awuser_40_32` writer - u1_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_rderr` reader - u1_plda_pcie_axi4_slv0_rderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_40_32` reader - u1_pcie_axi4_slv0_awuser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_awuser_40_32` writer - u1_pcie_axi4_slv0_awuser_40_32"]
+pub type U1_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_rderr` reader - u1_pcie_axi4_slv0_rderr"]
+pub type U1_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(&self) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u1_pcie_axi4_slv0_awuser_40_32(&self) -> U1_PCIE_AXI4_SLV0_AWUSER_40_32_R {
+        U1_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:16 - u1_plda_pcie_axi4_slv0_rderr"]
+    #[doc = "Bits 9:16 - u1_pcie_axi4_slv0_rderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_rderr(&self) -> U1_PLDA_PCIE_AXI4_SLV0_RDERR_R {
-        U1_PLDA_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
+    pub fn u1_pcie_axi4_slv0_rderr(&self) -> U1_PCIE_AXI4_SLV0_RDERR_R {
+        U1_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u1_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u1_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_awuser_40_32(
+    pub fn u1_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
+    ) -> U1_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_154_SPEC> {
+        U1_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_155.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_155.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_155_SPEC>;
 #[doc = "Register `stg_syscfg_155` writer"]
 pub type W = crate::W<STG_SYSCFG_155_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_ruser` reader - u1_plda_pcie_axi4_slv0_ruser"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_axi4_slv0_ruser` reader - u1_pcie_axi4_slv0_ruser"]
+pub type U1_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_axi4_slv0_ruser"]
+    #[doc = "Bits 0:31 - u1_pcie_axi4_slv0_ruser"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_ruser(&self) -> U1_PLDA_PCIE_AXI4_SLV0_RUSER_R {
-        U1_PLDA_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
+    pub fn u1_pcie_axi4_slv0_ruser(&self) -> U1_PCIE_AXI4_SLV0_RUSER_R {
+        U1_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_156.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_156.rs
@@ -2,42 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_156_SPEC>;
 #[doc = "Register `stg_syscfg_156` writer"]
 pub type W = crate::W<STG_SYSCFG_156_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_wderr` reader - u1_plda_pcie_axi4_slv0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_axi4_slv0_wderr` writer - u1_plda_pcie_axi4_slv0_wderr"]
-pub type U1_PLDA_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_arfunc` reader - u1_plda_pcie_axi4_slvl_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_arfunc` writer - u1_plda_pcie_axi4_slvl_arfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_axi4_slv0_wderr` reader - u1_pcie_axi4_slv0_wderr"]
+pub type U1_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_axi4_slv0_wderr` writer - u1_pcie_axi4_slv0_wderr"]
+pub type U1_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_axi4_slvl_arfunc` reader - u1_pcie_axi4_slvl_arfunc"]
+pub type U1_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slvl_arfunc` writer - u1_pcie_axi4_slvl_arfunc"]
+pub type U1_PCIE_AXI4_SLVL_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_slv0_wderr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slv0_wderr(&self) -> U1_PLDA_PCIE_AXI4_SLV0_WDERR_R {
-        U1_PLDA_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_axi4_slv0_wderr(&self) -> U1_PCIE_AXI4_SLV0_WDERR_R {
+        U1_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bits 8:22 - u1_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u1_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slvl_arfunc(&self) -> U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slvl_arfunc(&self) -> U1_PCIE_AXI4_SLVL_ARFUNC_R {
+        U1_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u1_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u1_pcie_axi4_slv0_wderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slv0_wderr(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_156_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
+    pub fn u1_pcie_axi4_slv0_wderr(&mut self) -> U1_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_156_SPEC> {
+        U1_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
     }
-    #[doc = "Bits 8:22 - u1_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u1_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slvl_arfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W<STG_SYSCFG_156_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLVL_ARFUNC_W::new(self, 8)
+    pub fn u1_pcie_axi4_slvl_arfunc(&mut self) -> U1_PCIE_AXI4_SLVL_ARFUNC_W<STG_SYSCFG_156_SPEC> {
+        U1_PCIE_AXI4_SLVL_ARFUNC_W::new(self, 8)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_157.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_157.rs
@@ -2,94 +2,90 @@
 pub type R = crate::R<STG_SYSCFG_157_SPEC>;
 #[doc = "Register `stg_syscfg_157` writer"]
 pub type W = crate::W<STG_SYSCFG_157_SPEC>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_awfunc` reader - u1_plda_pcie_axi4_slvl_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_axi4_slvl_awfunc` writer - u1_plda_pcie_axi4_slvl_awfunc"]
-pub type U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u1_plda_pcie_bus_width_o` reader - u1_plda_pcie_bus_width_o"]
-pub type U1_PLDA_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_bypass_codec` reader - u1_plda_pcie_bypass_codec"]
-pub type U1_PLDA_PCIE_BYPASS_CODEC_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_bypass_codec` writer - u1_plda_pcie_bypass_codec"]
-pub type U1_PLDA_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_ckref_src` reader - u1_plda_pcie_ckref_src"]
-pub type U1_PLDA_PCIE_CKREF_SRC_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_ckref_src` writer - u1_plda_pcie_ckref_src"]
-pub type U1_PLDA_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_clk_sel` reader - u1_plda_pcie_clk_sel"]
-pub type U1_PLDA_PCIE_CLK_SEL_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_clk_sel` writer - u1_plda_pcie_clk_sel"]
-pub type U1_PLDA_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_clkreq` reader - u1_plda_pcie_clkreq"]
-pub type U1_PLDA_PCIE_CLKREQ_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_clkreq` writer - u1_plda_pcie_clkreq"]
-pub type U1_PLDA_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi4_slvl_awfunc` reader - u1_pcie_axi4_slvl_awfunc"]
+pub type U1_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_axi4_slvl_awfunc` writer - u1_pcie_axi4_slvl_awfunc"]
+pub type U1_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u1_pcie_bus_width_o` reader - u1_pcie_bus_width_o"]
+pub type U1_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_bypass_codec` reader - u1_pcie_bypass_codec"]
+pub type U1_PCIE_BYPASS_CODEC_R = crate::BitReader;
+#[doc = "Field `u1_pcie_bypass_codec` writer - u1_pcie_bypass_codec"]
+pub type U1_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_ckref_src` reader - u1_pcie_ckref_src"]
+pub type U1_PCIE_CKREF_SRC_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_ckref_src` writer - u1_pcie_ckref_src"]
+pub type U1_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_clk_sel` reader - u1_pcie_clk_sel"]
+pub type U1_PCIE_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_clk_sel` writer - u1_pcie_clk_sel"]
+pub type U1_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_clkreq` reader - u1_pcie_clkreq"]
+pub type U1_PCIE_CLKREQ_R = crate::BitReader;
+#[doc = "Field `u1_pcie_clkreq` writer - u1_pcie_clkreq"]
+pub type U1_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
-    pub fn u1_plda_pcie_axi4_slvl_awfunc(&self) -> U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R {
-        U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u1_pcie_axi4_slvl_awfunc(&self) -> U1_PCIE_AXI4_SLVL_AWFUNC_R {
+        U1_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:16 - u1_plda_pcie_bus_width_o"]
+    #[doc = "Bits 15:16 - u1_pcie_bus_width_o"]
     #[inline(always)]
-    pub fn u1_plda_pcie_bus_width_o(&self) -> U1_PLDA_PCIE_BUS_WIDTH_O_R {
-        U1_PLDA_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
+    pub fn u1_pcie_bus_width_o(&self) -> U1_PCIE_BUS_WIDTH_O_R {
+        U1_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
     }
-    #[doc = "Bit 17 - u1_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u1_pcie_bypass_codec"]
     #[inline(always)]
-    pub fn u1_plda_pcie_bypass_codec(&self) -> U1_PLDA_PCIE_BYPASS_CODEC_R {
-        U1_PLDA_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_bypass_codec(&self) -> U1_PCIE_BYPASS_CODEC_R {
+        U1_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bits 18:19 - u1_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u1_pcie_ckref_src"]
     #[inline(always)]
-    pub fn u1_plda_pcie_ckref_src(&self) -> U1_PLDA_PCIE_CKREF_SRC_R {
-        U1_PLDA_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
+    pub fn u1_pcie_ckref_src(&self) -> U1_PCIE_CKREF_SRC_R {
+        U1_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u1_pcie_clk_sel"]
     #[inline(always)]
-    pub fn u1_plda_pcie_clk_sel(&self) -> U1_PLDA_PCIE_CLK_SEL_R {
-        U1_PLDA_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u1_pcie_clk_sel(&self) -> U1_PCIE_CLK_SEL_R {
+        U1_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u1_pcie_clkreq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_clkreq(&self) -> U1_PLDA_PCIE_CLKREQ_R {
-        U1_PLDA_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_clkreq(&self) -> U1_PCIE_CLKREQ_R {
+        U1_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:14 - u1_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u1_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_axi4_slvl_awfunc(
-        &mut self,
-    ) -> U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
+    pub fn u1_pcie_axi4_slvl_awfunc(&mut self) -> U1_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
     }
-    #[doc = "Bit 17 - u1_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u1_pcie_bypass_codec"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_bypass_codec(
-        &mut self,
-    ) -> U1_PLDA_PCIE_BYPASS_CODEC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_BYPASS_CODEC_W::new(self, 17)
+    pub fn u1_pcie_bypass_codec(&mut self) -> U1_PCIE_BYPASS_CODEC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_BYPASS_CODEC_W::new(self, 17)
     }
-    #[doc = "Bits 18:19 - u1_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u1_pcie_ckref_src"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_ckref_src(&mut self) -> U1_PLDA_PCIE_CKREF_SRC_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CKREF_SRC_W::new(self, 18)
+    pub fn u1_pcie_ckref_src(&mut self) -> U1_PCIE_CKREF_SRC_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CKREF_SRC_W::new(self, 18)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u1_pcie_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_clk_sel(&mut self) -> U1_PLDA_PCIE_CLK_SEL_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CLK_SEL_W::new(self, 20)
+    pub fn u1_pcie_clk_sel(&mut self) -> U1_PCIE_CLK_SEL_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CLK_SEL_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u1_pcie_clkreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_clkreq(&mut self) -> U1_PLDA_PCIE_CLKREQ_W<STG_SYSCFG_157_SPEC> {
-        U1_PLDA_PCIE_CLKREQ_W::new(self, 22)
+    pub fn u1_pcie_clkreq(&mut self) -> U1_PCIE_CLKREQ_W<STG_SYSCFG_157_SPEC> {
+        U1_PCIE_CLKREQ_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_17.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_17.rs
@@ -46,8 +46,8 @@ pub type U0_HIFI4_TRIGIN_IDMA_W<'a, REG> = crate::BitWriter<'a, REG>;
 pub type U0_HIFI4_TRIGOUT_IDMA_R = crate::BitReader;
 #[doc = "Field `u0_hifi4_xocdmode` reader - Debug signal"]
 pub type U0_HIFI4_XOCDMODE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_align_detect` reader - u0_plda_pcie_align_detect"]
-pub type U0_PLDA_PCIE_ALIGN_DETECT_R = crate::BitReader;
+#[doc = "Field `u0_pcie_align_detect` reader - u0_pcie_align_detect"]
+pub type U0_PCIE_ALIGN_DETECT_R = crate::BitReader;
 impl R {
     #[doc = "Bit 0 - SRAM/ROM configuration. SLP: sleep enable, high active, default is low."]
     #[inline(always)]
@@ -109,10 +109,10 @@ impl R {
     pub fn u0_hifi4_xocdmode(&self) -> U0_HIFI4_XOCDMODE_R {
         U0_HIFI4_XOCDMODE_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_plda_pcie_align_detect"]
+    #[doc = "Bit 16 - u0_pcie_align_detect"]
     #[inline(always)]
-    pub fn u0_plda_pcie_align_detect(&self) -> U0_PLDA_PCIE_ALIGN_DETECT_R {
-        U0_PLDA_PCIE_ALIGN_DETECT_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_align_detect(&self) -> U0_PCIE_ALIGN_DETECT_R {
+        U0_PCIE_ALIGN_DETECT_R::new(((self.bits >> 16) & 1) != 0)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_18.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_18.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_18_SPEC>;
 #[doc = "Register `stg_syscfg_18` writer"]
 pub type W = crate::W<STG_SYSCFG_18_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_31_0` reader - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_31_0` reader - u0_pcie_axi4_mst0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_31_0(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_184.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_184.rs
@@ -2,64 +2,62 @@
 pub type R = crate::R<STG_SYSCFG_184_SPEC>;
 #[doc = "Register `stg_syscfg_184` writer"]
 pub type W = crate::W<STG_SYSCFG_184_SPEC>;
-#[doc = "Field `u1_plda_pcie_k_phyparam_839_832` reader - u1_plda_pcie_k_phyparam_839_832"]
-pub type U1_PLDA_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_k_phyparam_839_832` writer - u1_plda_pcie_k_phyparam_839_832"]
-pub type U1_PLDA_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u1_plda_pcie_k_rp_nep` reader - u1_plda_pcie_k_rp_nep"]
-pub type U1_PLDA_PCIE_K_RP_NEP_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_k_rp_nep` writer - u1_plda_pcie_k_rp_nep"]
-pub type U1_PLDA_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_l1sub_entack` reader - u1_plda_pcie_l1sub_entack"]
-pub type U1_PLDA_PCIE_L1SUB_ENTACK_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_l1sub_entreq` reader - u1_plda_pcie_l1sub_entreq"]
-pub type U1_PLDA_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_l1sub_entreq` writer - u1_plda_pcie_l1sub_entreq"]
-pub type U1_PLDA_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_k_phyparam_839_832` reader - u1_pcie_k_phyparam_839_832"]
+pub type U1_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_k_phyparam_839_832` writer - u1_pcie_k_phyparam_839_832"]
+pub type U1_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u1_pcie_k_rp_nep` reader - u1_pcie_k_rp_nep"]
+pub type U1_PCIE_K_RP_NEP_R = crate::BitReader;
+#[doc = "Field `u1_pcie_k_rp_nep` writer - u1_pcie_k_rp_nep"]
+pub type U1_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_l1sub_entack` reader - u1_pcie_l1sub_entack"]
+pub type U1_PCIE_L1SUB_ENTACK_R = crate::BitReader;
+#[doc = "Field `u1_pcie_l1sub_entreq` reader - u1_pcie_l1sub_entreq"]
+pub type U1_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
+#[doc = "Field `u1_pcie_l1sub_entreq` writer - u1_pcie_l1sub_entreq"]
+pub type U1_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:7 - u1_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u1_pcie_k_phyparam_839_832"]
     #[inline(always)]
-    pub fn u1_plda_pcie_k_phyparam_839_832(&self) -> U1_PLDA_PCIE_K_PHYPARAM_839_832_R {
-        U1_PLDA_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
+    pub fn u1_pcie_k_phyparam_839_832(&self) -> U1_PCIE_K_PHYPARAM_839_832_R {
+        U1_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u1_pcie_k_rp_nep"]
     #[inline(always)]
-    pub fn u1_plda_pcie_k_rp_nep(&self) -> U1_PLDA_PCIE_K_RP_NEP_R {
-        U1_PLDA_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_pcie_k_rp_nep(&self) -> U1_PCIE_K_RP_NEP_R {
+        U1_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_l1sub_entack"]
+    #[doc = "Bit 9 - u1_pcie_l1sub_entack"]
     #[inline(always)]
-    pub fn u1_plda_pcie_l1sub_entack(&self) -> U1_PLDA_PCIE_L1SUB_ENTACK_R {
-        U1_PLDA_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u1_pcie_l1sub_entack(&self) -> U1_PCIE_L1SUB_ENTACK_R {
+        U1_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u1_pcie_l1sub_entreq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_l1sub_entreq(&self) -> U1_PLDA_PCIE_L1SUB_ENTREQ_R {
-        U1_PLDA_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u1_pcie_l1sub_entreq(&self) -> U1_PCIE_L1SUB_ENTREQ_R {
+        U1_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u1_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u1_pcie_k_phyparam_839_832"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_k_phyparam_839_832(
+    pub fn u1_pcie_k_phyparam_839_832(
         &mut self,
-    ) -> U1_PLDA_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
+    ) -> U1_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u1_pcie_k_rp_nep"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_k_rp_nep(&mut self) -> U1_PLDA_PCIE_K_RP_NEP_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_K_RP_NEP_W::new(self, 8)
+    pub fn u1_pcie_k_rp_nep(&mut self) -> U1_PCIE_K_RP_NEP_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_K_RP_NEP_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u1_pcie_l1sub_entreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_l1sub_entreq(
-        &mut self,
-    ) -> U1_PLDA_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_184_SPEC> {
-        U1_PLDA_PCIE_L1SUB_ENTREQ_W::new(self, 10)
+    pub fn u1_pcie_l1sub_entreq(&mut self) -> U1_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_184_SPEC> {
+        U1_PCIE_L1SUB_ENTREQ_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_185.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_185.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_185_SPEC>;
 #[doc = "Register `stg_syscfg_185` writer"]
 pub type W = crate::W<STG_SYSCFG_185_SPEC>;
-#[doc = "Field `u1_plda_pcie_local_interrupt_in` reader - u1_plda_pcie_local_interrupt_in"]
-pub type U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_local_interrupt_in` writer - u1_plda_pcie_local_interrupt_in"]
-pub type U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_local_interrupt_in` reader - u1_pcie_local_interrupt_in"]
+pub type U1_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_local_interrupt_in` writer - u1_pcie_local_interrupt_in"]
+pub type U1_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u1_pcie_local_interrupt_in"]
     #[inline(always)]
-    pub fn u1_plda_pcie_local_interrupt_in(&self) -> U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R {
-        U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
+    pub fn u1_pcie_local_interrupt_in(&self) -> U1_PCIE_LOCAL_INTERRUPT_IN_R {
+        U1_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u1_pcie_local_interrupt_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_local_interrupt_in(
+    pub fn u1_pcie_local_interrupt_in(
         &mut self,
-    ) -> U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_185_SPEC> {
-        U1_PLDA_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
+    ) -> U1_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_185_SPEC> {
+        U1_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_186.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_186.rs
@@ -2,108 +2,104 @@
 pub type R = crate::R<STG_SYSCFG_186_SPEC>;
 #[doc = "Register `stg_syscfg_186` writer"]
 pub type W = crate::W<STG_SYSCFG_186_SPEC>;
-#[doc = "Field `u1_plda_pcie_mperstn` reader - u1_plda_pcie_mperstn"]
-pub type U1_PLDA_PCIE_MPERSTN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_mperstn` writer - u1_plda_pcie_mperstn"]
-pub type U1_PLDA_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_ebuf_mode` reader - u1_plda_pcie_pcie_ebuf_mode"]
-pub type U1_PLDA_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_ebuf_mode` writer - u1_plda_pcie_pcie_ebuf_mode"]
-pub type U1_PLDA_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_phy_test_cfg` reader - u1_plda_pcie_pcie_phy_test_cfg"]
-pub type U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pcie_phy_test_cfg` writer - u1_plda_pcie_pcie_phy_test_cfg"]
-pub type U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
-#[doc = "Field `u1_plda_pcie_pcie_rx_eq_training` reader - u1_plda_pcie_pcie_rx_eq_training"]
-pub type U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_rx_eq_training` writer - u1_plda_pcie_pcie_rx_eq_training"]
-pub type U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_rxterm_en` reader - u1_plda_pcie_pcie_rxterm_en"]
-pub type U1_PLDA_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_rxterm_en` writer - u1_plda_pcie_pcie_rxterm_en"]
-pub type U1_PLDA_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pcie_tx_oneszeros` reader - u1_plda_pcie_pcie_tx_oneszeros"]
-pub type U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pcie_tx_oneszeros` writer - u1_plda_pcie_pcie_tx_oneszeros"]
-pub type U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_mperstn` reader - u1_pcie_mperstn"]
+pub type U1_PCIE_MPERSTN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_mperstn` writer - u1_pcie_mperstn"]
+pub type U1_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_ebuf_mode` reader - u1_pcie_pcie_ebuf_mode"]
+pub type U1_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_ebuf_mode` writer - u1_pcie_pcie_ebuf_mode"]
+pub type U1_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_phy_test_cfg` reader - u1_pcie_pcie_phy_test_cfg"]
+pub type U1_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pcie_phy_test_cfg` writer - u1_pcie_pcie_phy_test_cfg"]
+pub type U1_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
+#[doc = "Field `u1_pcie_pcie_rx_eq_training` reader - u1_pcie_pcie_rx_eq_training"]
+pub type U1_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_rx_eq_training` writer - u1_pcie_pcie_rx_eq_training"]
+pub type U1_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_rxterm_en` reader - u1_pcie_pcie_rxterm_en"]
+pub type U1_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_rxterm_en` writer - u1_pcie_pcie_rxterm_en"]
+pub type U1_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie_tx_oneszeros` reader - u1_pcie_pcie_tx_oneszeros"]
+pub type U1_PCIE_PCIE_TX_ONESZEROS_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie_tx_oneszeros` writer - u1_pcie_pcie_tx_oneszeros"]
+pub type U1_PCIE_PCIE_TX_ONESZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u1_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u1_pcie_mperstn"]
     #[inline(always)]
-    pub fn u1_plda_pcie_mperstn(&self) -> U1_PLDA_PCIE_MPERSTN_R {
-        U1_PLDA_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
+    pub fn u1_pcie_mperstn(&self) -> U1_PCIE_MPERSTN_R {
+        U1_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u1_pcie_pcie_ebuf_mode"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_ebuf_mode(&self) -> U1_PLDA_PCIE_PCIE_EBUF_MODE_R {
-        U1_PLDA_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_pcie_pcie_ebuf_mode(&self) -> U1_PCIE_PCIE_EBUF_MODE_R {
+        U1_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:24 - u1_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u1_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_phy_test_cfg(&self) -> U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R {
-        U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
+    pub fn u1_pcie_pcie_phy_test_cfg(&self) -> U1_PCIE_PCIE_PHY_TEST_CFG_R {
+        U1_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
     }
-    #[doc = "Bit 25 - u1_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u1_pcie_pcie_rx_eq_training"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_rx_eq_training(&self) -> U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R {
-        U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u1_pcie_pcie_rx_eq_training(&self) -> U1_PCIE_PCIE_RX_EQ_TRAINING_R {
+        U1_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u1_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u1_pcie_pcie_rxterm_en"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_rxterm_en(&self) -> U1_PLDA_PCIE_PCIE_RXTERM_EN_R {
-        U1_PLDA_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_pcie_pcie_rxterm_en(&self) -> U1_PCIE_PCIE_RXTERM_EN_R {
+        U1_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u1_plda_pcie_pcie_tx_oneszeros"]
+    #[doc = "Bit 27 - u1_pcie_pcie_tx_oneszeros"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pcie_tx_oneszeros(&self) -> U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R {
-        U1_PLDA_PCIE_PCIE_TX_ONESZEROS_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u1_pcie_pcie_tx_oneszeros(&self) -> U1_PCIE_PCIE_TX_ONESZEROS_R {
+        U1_PCIE_PCIE_TX_ONESZEROS_R::new(((self.bits >> 27) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u1_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u1_pcie_mperstn"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_mperstn(&mut self) -> U1_PLDA_PCIE_MPERSTN_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_MPERSTN_W::new(self, 0)
+    pub fn u1_pcie_mperstn(&mut self) -> U1_PCIE_MPERSTN_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_MPERSTN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u1_pcie_pcie_ebuf_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_ebuf_mode(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
+    pub fn u1_pcie_pcie_ebuf_mode(&mut self) -> U1_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
     }
-    #[doc = "Bits 2:24 - u1_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u1_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_phy_test_cfg(
+    pub fn u1_pcie_pcie_phy_test_cfg(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
+    ) -> U1_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
     }
-    #[doc = "Bit 25 - u1_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u1_pcie_pcie_rx_eq_training"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_rx_eq_training(
+    pub fn u1_pcie_pcie_rx_eq_training(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
+    ) -> U1_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
     }
-    #[doc = "Bit 26 - u1_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u1_pcie_pcie_rxterm_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_rxterm_en(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
+    pub fn u1_pcie_pcie_rxterm_en(&mut self) -> U1_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
     }
-    #[doc = "Bit 27 - u1_plda_pcie_pcie_tx_oneszeros"]
+    #[doc = "Bit 27 - u1_pcie_pcie_tx_oneszeros"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pcie_tx_oneszeros(
+    pub fn u1_pcie_pcie_tx_oneszeros(
         &mut self,
-    ) -> U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W<STG_SYSCFG_186_SPEC> {
-        U1_PLDA_PCIE_PCIE_TX_ONESZEROS_W::new(self, 27)
+    ) -> U1_PCIE_PCIE_TX_ONESZEROS_W<STG_SYSCFG_186_SPEC> {
+        U1_PCIE_PCIE_TX_ONESZEROS_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_187.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_187.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_187_SPEC>;
 #[doc = "Register `stg_syscfg_187` writer"]
 pub type W = crate::W<STG_SYSCFG_187_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf0_offset` reader - u1_plda_pcie_pf0_offset"]
-pub type U1_PLDA_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf0_offset` writer - u1_plda_pcie_pf0_offset"]
-pub type U1_PLDA_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf0_offset` reader - u1_pcie_pf0_offset"]
+pub type U1_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf0_offset` writer - u1_pcie_pf0_offset"]
+pub type U1_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf0_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf0_offset(&self) -> U1_PLDA_PCIE_PF0_OFFSET_R {
-        U1_PLDA_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf0_offset(&self) -> U1_PCIE_PF0_OFFSET_R {
+        U1_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf0_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf0_offset(&mut self) -> U1_PLDA_PCIE_PF0_OFFSET_W<STG_SYSCFG_187_SPEC> {
-        U1_PLDA_PCIE_PF0_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf0_offset(&mut self) -> U1_PCIE_PF0_OFFSET_W<STG_SYSCFG_187_SPEC> {
+        U1_PCIE_PF0_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_188.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_188.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_188_SPEC>;
 #[doc = "Register `stg_syscfg_188` writer"]
 pub type W = crate::W<STG_SYSCFG_188_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf1_offset` reader - u1_plda_pcie_pf1_offset"]
-pub type U1_PLDA_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf1_offset` writer - u1_plda_pcie_pf1_offset"]
-pub type U1_PLDA_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf1_offset` reader - u1_pcie_pf1_offset"]
+pub type U1_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf1_offset` writer - u1_pcie_pf1_offset"]
+pub type U1_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf1_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf1_offset(&self) -> U1_PLDA_PCIE_PF1_OFFSET_R {
-        U1_PLDA_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf1_offset(&self) -> U1_PCIE_PF1_OFFSET_R {
+        U1_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf1_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf1_offset(&mut self) -> U1_PLDA_PCIE_PF1_OFFSET_W<STG_SYSCFG_188_SPEC> {
-        U1_PLDA_PCIE_PF1_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf1_offset(&mut self) -> U1_PCIE_PF1_OFFSET_W<STG_SYSCFG_188_SPEC> {
+        U1_PCIE_PF1_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_189.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_189.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_189_SPEC>;
 #[doc = "Register `stg_syscfg_189` writer"]
 pub type W = crate::W<STG_SYSCFG_189_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf2_offset` reader - u1_plda_pcie_pf2_offset"]
-pub type U1_PLDA_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf2_offset` writer - u1_plda_pcie_pf2_offset"]
-pub type U1_PLDA_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_pf2_offset` reader - u1_pcie_pf2_offset"]
+pub type U1_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf2_offset` writer - u1_pcie_pf2_offset"]
+pub type U1_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf2_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf2_offset(&self) -> U1_PLDA_PCIE_PF2_OFFSET_R {
-        U1_PLDA_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf2_offset(&self) -> U1_PCIE_PF2_OFFSET_R {
+        U1_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf2_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf2_offset(&mut self) -> U1_PLDA_PCIE_PF2_OFFSET_W<STG_SYSCFG_189_SPEC> {
-        U1_PLDA_PCIE_PF2_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf2_offset(&mut self) -> U1_PCIE_PF2_OFFSET_W<STG_SYSCFG_189_SPEC> {
+        U1_PCIE_PF2_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_19.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_19.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_19_SPEC>;
 #[doc = "Register `stg_syscfg_19` writer"]
 pub type W = crate::W<STG_SYSCFG_19_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_63_32` reader - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_63_32` reader - u0_pcie_axi4_mst0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_63_32(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_190.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_190.rs
@@ -2,76 +2,74 @@
 pub type R = crate::R<STG_SYSCFG_190_SPEC>;
 #[doc = "Register `stg_syscfg_190` writer"]
 pub type W = crate::W<STG_SYSCFG_190_SPEC>;
-#[doc = "Field `u1_plda_pcie_pf3_offset` reader - u1_plda_pcie_pf3_offset"]
-pub type U1_PLDA_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pf3_offset` writer - u1_plda_pcie_pf3_offset"]
-pub type U1_PLDA_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
-#[doc = "Field `u1_plda_pcie_phy_mode` reader - u1_plda_pcie_phy_mode"]
-pub type U1_PLDA_PCIE_PHY_MODE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_phy_mode` writer - u1_plda_pcie_phy_mode"]
-pub type U1_PLDA_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_pl_clkrem_allow` reader - u1_plda_pcie_pl_clkrem_allow"]
-pub type U1_PLDA_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_clkrem_allow` writer - u1_plda_pcie_pl_clkrem_allow"]
-pub type U1_PLDA_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pl_clkreq_oen` reader - u1_plda_pcie_pl_clkreq_oen"]
-pub type U1_PLDA_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_equ_phase` reader - u1_plda_pcie_pl_equ_phase"]
-pub type U1_PLDA_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_pl_ltssm` reader - u1_plda_pcie_pl_ltssm"]
-pub type U1_PLDA_PCIE_PL_LTSSM_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pf3_offset` reader - u1_pcie_pf3_offset"]
+pub type U1_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pf3_offset` writer - u1_pcie_pf3_offset"]
+pub type U1_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u1_pcie_phy_mode` reader - u1_pcie_phy_mode"]
+pub type U1_PCIE_PHY_MODE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_phy_mode` writer - u1_pcie_phy_mode"]
+pub type U1_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_pl_clkrem_allow` reader - u1_pcie_pl_clkrem_allow"]
+pub type U1_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_clkrem_allow` writer - u1_pcie_pl_clkrem_allow"]
+pub type U1_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pl_clkreq_oen` reader - u1_pcie_pl_clkreq_oen"]
+pub type U1_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_equ_phase` reader - u1_pcie_pl_equ_phase"]
+pub type U1_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pl_ltssm` reader - u1_pcie_pl_ltssm"]
+pub type U1_PCIE_PL_LTSSM_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf3_offset"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pf3_offset(&self) -> U1_PLDA_PCIE_PF3_OFFSET_R {
-        U1_PLDA_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u1_pcie_pf3_offset(&self) -> U1_PCIE_PF3_OFFSET_R {
+        U1_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u1_pcie_phy_mode"]
     #[inline(always)]
-    pub fn u1_plda_pcie_phy_mode(&self) -> U1_PLDA_PCIE_PHY_MODE_R {
-        U1_PLDA_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u1_pcie_phy_mode(&self) -> U1_PCIE_PHY_MODE_R {
+        U1_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u1_pcie_pl_clkrem_allow"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_clkrem_allow(&self) -> U1_PLDA_PCIE_PL_CLKREM_ALLOW_R {
-        U1_PLDA_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_pl_clkrem_allow(&self) -> U1_PCIE_PL_CLKREM_ALLOW_R {
+        U1_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u1_plda_pcie_pl_clkreq_oen"]
+    #[doc = "Bit 23 - u1_pcie_pl_clkreq_oen"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_clkreq_oen(&self) -> U1_PLDA_PCIE_PL_CLKREQ_OEN_R {
-        U1_PLDA_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u1_pcie_pl_clkreq_oen(&self) -> U1_PCIE_PL_CLKREQ_OEN_R {
+        U1_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bits 24:25 - u1_plda_pcie_pl_equ_phase"]
+    #[doc = "Bits 24:25 - u1_pcie_pl_equ_phase"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_equ_phase(&self) -> U1_PLDA_PCIE_PL_EQU_PHASE_R {
-        U1_PLDA_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
+    pub fn u1_pcie_pl_equ_phase(&self) -> U1_PCIE_PL_EQU_PHASE_R {
+        U1_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
     }
-    #[doc = "Bits 26:30 - u1_plda_pcie_pl_ltssm"]
+    #[doc = "Bits 26:30 - u1_pcie_pl_ltssm"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_ltssm(&self) -> U1_PLDA_PCIE_PL_LTSSM_R {
-        U1_PLDA_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn u1_pcie_pl_ltssm(&self) -> U1_PCIE_PL_LTSSM_R {
+        U1_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u1_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u1_pcie_pf3_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pf3_offset(&mut self) -> U1_PLDA_PCIE_PF3_OFFSET_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PF3_OFFSET_W::new(self, 0)
+    pub fn u1_pcie_pf3_offset(&mut self) -> U1_PCIE_PF3_OFFSET_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PF3_OFFSET_W::new(self, 0)
     }
-    #[doc = "Bits 20:21 - u1_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u1_pcie_phy_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_phy_mode(&mut self) -> U1_PLDA_PCIE_PHY_MODE_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PHY_MODE_W::new(self, 20)
+    pub fn u1_pcie_phy_mode(&mut self) -> U1_PCIE_PHY_MODE_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PHY_MODE_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u1_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u1_pcie_pl_clkrem_allow"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_clkrem_allow(
-        &mut self,
-    ) -> U1_PLDA_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_190_SPEC> {
-        U1_PLDA_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
+    pub fn u1_pcie_pl_clkrem_allow(&mut self) -> U1_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_190_SPEC> {
+        U1_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_191.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_191.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_191_SPEC>;
 #[doc = "Register `stg_syscfg_191` writer"]
 pub type W = crate::W<STG_SYSCFG_191_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_pclk_rate` reader - u1_plda_pcie_pl_pclk_rate"]
-pub type U1_PLDA_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_pl_pclk_rate` reader - u1_pcie_pl_pclk_rate"]
+pub type U1_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:4 - u1_plda_pcie_pl_pclk_rate"]
+    #[doc = "Bits 0:4 - u1_pcie_pl_pclk_rate"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_pclk_rate(&self) -> U1_PLDA_PCIE_PL_PCLK_RATE_R {
-        U1_PLDA_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
+    pub fn u1_pcie_pl_pclk_rate(&self) -> U1_PCIE_PL_PCLK_RATE_R {
+        U1_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_192.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_192.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_192_SPEC>;
 #[doc = "Register `stg_syscfg_192` writer"]
 pub type W = crate::W<STG_SYSCFG_192_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_31_0` reader - u1_plda_pcie_pl_sideband_in_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_31_0` writer - u1_plda_pcie_pl_sideband_in_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_31_0` reader - u1_pcie_pl_sideband_in_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_31_0` writer - u1_pcie_pl_sideband_in_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_in_31_0(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_in_31_0(&self) -> U1_PCIE_PL_SIDEBAND_IN_31_0_R {
+        U1_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_in_31_0(
+    pub fn u1_pcie_pl_sideband_in_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W<STG_SYSCFG_192_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_31_0_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_IN_31_0_W<STG_SYSCFG_192_SPEC> {
+        U1_PCIE_PL_SIDEBAND_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_193.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_193.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_193_SPEC>;
 #[doc = "Register `stg_syscfg_193` writer"]
 pub type W = crate::W<STG_SYSCFG_193_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_63_32` reader - u1_plda_pcie_pl_sideband_in_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_in_63_32` writer - u1_plda_pcie_pl_sideband_in_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_63_32` reader - u1_pcie_pl_sideband_in_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_in_63_32` writer - u1_pcie_pl_sideband_in_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_in_63_32(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_in_63_32(&self) -> U1_PCIE_PL_SIDEBAND_IN_63_32_R {
+        U1_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_in_63_32(
+    pub fn u1_pcie_pl_sideband_in_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W<STG_SYSCFG_193_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_IN_63_32_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_IN_63_32_W<STG_SYSCFG_193_SPEC> {
+        U1_PCIE_PL_SIDEBAND_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_194.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_194.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_194_SPEC>;
 #[doc = "Register `stg_syscfg_194` writer"]
 pub type W = crate::W<STG_SYSCFG_194_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_31_0` reader - u1_plda_pcie_pl_sideband_out_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_31_0` writer - u1_plda_pcie_pl_sideband_out_31_0"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_31_0` reader - u1_pcie_pl_sideband_out_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_31_0` writer - u1_pcie_pl_sideband_out_31_0"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_out_31_0(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_out_31_0(&self) -> U1_PCIE_PL_SIDEBAND_OUT_31_0_R {
+        U1_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_out_31_0(
+    pub fn u1_pcie_pl_sideband_out_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W<STG_SYSCFG_194_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_OUT_31_0_W<STG_SYSCFG_194_SPEC> {
+        U1_PCIE_PL_SIDEBAND_OUT_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_195.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_195.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_195_SPEC>;
 #[doc = "Register `stg_syscfg_195` writer"]
 pub type W = crate::W<STG_SYSCFG_195_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_63_32` reader - u1_plda_pcie_pl_sideband_out_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_pl_sideband_out_63_32` writer - u1_plda_pcie_pl_sideband_out_63_32"]
-pub type U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_63_32` reader - u1_pcie_pl_sideband_out_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_pl_sideband_out_63_32` writer - u1_pcie_pl_sideband_out_63_32"]
+pub type U1_PCIE_PL_SIDEBAND_OUT_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_sideband_out_63_32(&self) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
+    pub fn u1_pcie_pl_sideband_out_63_32(&self) -> U1_PCIE_PL_SIDEBAND_OUT_63_32_R {
+        U1_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_sideband_out_63_32(
+    pub fn u1_pcie_pl_sideband_out_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W<STG_SYSCFG_195_SPEC> {
-        U1_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_W::new(self, 0)
+    ) -> U1_PCIE_PL_SIDEBAND_OUT_63_32_W<STG_SYSCFG_195_SPEC> {
+        U1_PCIE_PL_SIDEBAND_OUT_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_196.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_196.rs
@@ -2,37 +2,37 @@
 pub type R = crate::R<STG_SYSCFG_196_SPEC>;
 #[doc = "Register `stg_syscfg_196` writer"]
 pub type W = crate::W<STG_SYSCFG_196_SPEC>;
-#[doc = "Field `u1_plda_pcie_pl_wake_in` reader - u1_plda_pcie_pl_wake_in"]
-pub type U1_PLDA_PCIE_PL_WAKE_IN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_pl_wake_in` writer - u1_plda_pcie_pl_wake_in"]
-pub type U1_PLDA_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_pl_wake_oen` reader - u1_plda_pcie_pl_wake_oen"]
-pub type U1_PLDA_PCIE_PL_WAKE_OEN_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_rx_standby_o` reader - u1_plda_pcie_rx_standby_o"]
-pub type U1_PLDA_PCIE_RX_STANDBY_O_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_wake_in` reader - u1_pcie_pl_wake_in"]
+pub type U1_PCIE_PL_WAKE_IN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pl_wake_in` writer - u1_pcie_pl_wake_in"]
+pub type U1_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pl_wake_oen` reader - u1_pcie_pl_wake_oen"]
+pub type U1_PCIE_PL_WAKE_OEN_R = crate::BitReader;
+#[doc = "Field `u1_pcie_rx_standby_o` reader - u1_pcie_rx_standby_o"]
+pub type U1_PCIE_RX_STANDBY_O_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u1_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u1_pcie_pl_wake_in"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_wake_in(&self) -> U1_PLDA_PCIE_PL_WAKE_IN_R {
-        U1_PLDA_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
+    pub fn u1_pcie_pl_wake_in(&self) -> U1_PCIE_PL_WAKE_IN_R {
+        U1_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u1_plda_pcie_pl_wake_oen"]
+    #[doc = "Bit 1 - u1_pcie_pl_wake_oen"]
     #[inline(always)]
-    pub fn u1_plda_pcie_pl_wake_oen(&self) -> U1_PLDA_PCIE_PL_WAKE_OEN_R {
-        U1_PLDA_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_pcie_pl_wake_oen(&self) -> U1_PCIE_PL_WAKE_OEN_R {
+        U1_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u1_plda_pcie_rx_standby_o"]
+    #[doc = "Bit 2 - u1_pcie_rx_standby_o"]
     #[inline(always)]
-    pub fn u1_plda_pcie_rx_standby_o(&self) -> U1_PLDA_PCIE_RX_STANDBY_O_R {
-        U1_PLDA_PCIE_RX_STANDBY_O_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_pcie_rx_standby_o(&self) -> U1_PCIE_RX_STANDBY_O_R {
+        U1_PCIE_RX_STANDBY_O_R::new(((self.bits >> 2) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u1_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u1_pcie_pl_wake_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_pl_wake_in(&mut self) -> U1_PLDA_PCIE_PL_WAKE_IN_W<STG_SYSCFG_196_SPEC> {
-        U1_PLDA_PCIE_PL_WAKE_IN_W::new(self, 0)
+    pub fn u1_pcie_pl_wake_in(&mut self) -> U1_PCIE_PL_WAKE_IN_W<STG_SYSCFG_196_SPEC> {
+        U1_PCIE_PL_WAKE_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_197.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_197.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_197_SPEC>;
 #[doc = "Register `stg_syscfg_197` writer"]
 pub type W = crate::W<STG_SYSCFG_197_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_in_31_0` reader - u1_plda_pcie_test_in_31_0"]
-pub type U1_PLDA_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_in_31_0` writer - u1_plda_pcie_test_in_31_0"]
-pub type U1_PLDA_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_in_31_0` reader - u1_pcie_test_in_31_0"]
+pub type U1_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_in_31_0` writer - u1_pcie_test_in_31_0"]
+pub type U1_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_in_31_0(&self) -> U1_PLDA_PCIE_TEST_IN_31_0_R {
-        U1_PLDA_PCIE_TEST_IN_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_in_31_0(&self) -> U1_PCIE_TEST_IN_31_0_R {
+        U1_PCIE_TEST_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_in_31_0(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TEST_IN_31_0_W<STG_SYSCFG_197_SPEC> {
-        U1_PLDA_PCIE_TEST_IN_31_0_W::new(self, 0)
+    pub fn u1_pcie_test_in_31_0(&mut self) -> U1_PCIE_TEST_IN_31_0_W<STG_SYSCFG_197_SPEC> {
+        U1_PCIE_TEST_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_198.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_198.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_198_SPEC>;
 #[doc = "Register `stg_syscfg_198` writer"]
 pub type W = crate::W<STG_SYSCFG_198_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_in_63_32` reader - u1_plda_pcie_test_in_63_32"]
-pub type U1_PLDA_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_in_63_32` writer - u1_plda_pcie_test_in_63_32"]
-pub type U1_PLDA_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_in_63_32` reader - u1_pcie_test_in_63_32"]
+pub type U1_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_in_63_32` writer - u1_pcie_test_in_63_32"]
+pub type U1_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_in_63_32(&self) -> U1_PLDA_PCIE_TEST_IN_63_32_R {
-        U1_PLDA_PCIE_TEST_IN_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_in_63_32(&self) -> U1_PCIE_TEST_IN_63_32_R {
+        U1_PCIE_TEST_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_in_63_32(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TEST_IN_63_32_W<STG_SYSCFG_198_SPEC> {
-        U1_PLDA_PCIE_TEST_IN_63_32_W::new(self, 0)
+    pub fn u1_pcie_test_in_63_32(&mut self) -> U1_PCIE_TEST_IN_63_32_W<STG_SYSCFG_198_SPEC> {
+        U1_PCIE_TEST_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_199.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_199.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_199_SPEC>;
 #[doc = "Register `stg_syscfg_199` writer"]
 pub type W = crate::W<STG_SYSCFG_199_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_31_0` reader - u1_plda_pcie_test_out_bridge_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_31_0` writer - u1_plda_pcie_test_out_bridge_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_31_0` reader - u1_pcie_test_out_bridge_31_0"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_31_0` writer - u1_pcie_test_out_bridge_31_0"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_31_0(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_31_0(&self) -> U1_PCIE_TEST_OUT_BRIDGE_31_0_R {
+        U1_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_31_0(
+    pub fn u1_pcie_test_out_bridge_31_0(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W<STG_SYSCFG_199_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_31_0_W<STG_SYSCFG_199_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_2.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_2.rs
@@ -2,318 +2,312 @@
 pub type R = crate::R<STG_SYSCFG_2_SPEC>;
 #[doc = "Register `stg_syscfg_2` writer"]
 pub type W = crate::W<STG_SYSCFG_2_SPEC>;
-#[doc = "Field `u0_cdn_usb_rx_dp` reader - u0_cdn_usb_rx_dp"]
-pub type U0_CDN_USB_RX_DP_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_rx_rcv` reader - u0_cdn_usb_rx_rcv"]
-pub type U0_CDN_USB_RX_RCV_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_self_test` reader - For software bist_test"]
-pub type U0_CDN_USB_SELF_TEST_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_self_test` writer - For software bist_test"]
-pub type U0_CDN_USB_SELF_TEST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_sessend` reader - u0_cdn_usb_sessend"]
-pub type U0_CDN_USB_SESSEND_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_sessvalid` reader - u0_cdn_usb_sessvalid"]
-pub type U0_CDN_USB_SESSVALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_sof` reader - u0_cdn_usb_sof"]
-pub type U0_CDN_USB_SOF_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_test_bist` reader - For software bist_test"]
-pub type U0_CDN_USB_TEST_BIST_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_ack` reader - u0_cdn_usb_usbdev_main_power_off_ack"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_ready` reader - u0_cdn_usb_usbdev_main_power_off_ready"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_req` reader - u0_cdn_usb_usbdev_main_power_off_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_off_req` writer - u0_cdn_usb_usbdev_main_power_off_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_ready` reader - u0_cdn_usb_usbdev_main_power_on_ready"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_req` reader - u0_cdn_usb_usbdev_main_power_on_req"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_valid` reader - u0_cdn_usb_usbdev_main_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_main_power_on_valid` writer - u0_cdn_usb_usbdev_main_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_ack` reader - u0_cdn_usb_usbdev_power_off_ack"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_ready` reader - u0_cdn_usb_usbdev_power_off_ready"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_req` reader - u0_cdn_usb_usbdev_power_off_req"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_off_req` writer - u0_cdn_usb_usbdev_power_off_req"]
-pub type U0_CDN_USB_USBDEV_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_ready` reader - u0_cdn_usb_usbdev_power_on_ready"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_req` reader - u0_cdn_usb_usbdev_power_on_req"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_valid` reader - u0_cdn_usb_usbdev_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_usbdev_power_on_valid` writer - u0_cdn_usb_usbdev_power_on_valid"]
-pub type U0_CDN_USB_USBDEV_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_dmpulldown_sit` reader - u0_cdn_usb_utmi_dmpulldown_sit"]
-pub type U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_dmpulldown_sit` writer - u0_cdn_usb_utmi_dmpulldown_sit"]
-pub type U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_dppulldown_sit` reader - u0_cdn_usb_utmi_dppulldown_sit"]
-pub type U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_dppulldown_sit` writer - u0_cdn_usb_utmi_dppulldown_sit"]
-pub type U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_fslsserialmode_sit` reader - u0_cdn_usb_utmi_fslsserialmode_sit"]
-pub type U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_fslsserialmode_sit` writer - u0_cdn_usb_utmi_fslsserialmode_sit"]
-pub type U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_hostdisconnect_sit` reader - u0_cdn_usb_utmi_hostdisconnect_sit"]
-pub type U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_iddig_sit` reader - u0_cdn_usb_utmi_iddig_sit"]
-pub type U0_CDN_USB_UTMI_IDDIG_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_idpullup_sit` reader - u0_cdn_usb_utmi_idpullup_sit"]
-pub type U0_CDN_USB_UTMI_IDPULLUP_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_idpullup_sit` writer - u0_cdn_usb_utmi_idpullup_sit"]
-pub type U0_CDN_USB_UTMI_IDPULLUP_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_linestate_sit` reader - u0_cdn_usb_utmi_linestate_sit"]
-pub type U0_CDN_USB_UTMI_LINESTATE_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_opmode_sit` reader - u0_cdn_usb_utmi_opmode_sit"]
-pub type U0_CDN_USB_UTMI_OPMODE_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_opmode_sit` writer - u0_cdn_usb_utmi_opmode_sit"]
-pub type U0_CDN_USB_UTMI_OPMODE_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_cdn_usb_utmi_rxactive_sit` reader - u0_cdn_usb_utmi_rxactive_sit"]
-pub type U0_CDN_USB_UTMI_RXACTIVE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_rxerror_sit` reader - u0_cdn_usb_utmi_rxerror_sit"]
-pub type U0_CDN_USB_UTMI_RXERROR_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_rxvalid_sit` reader - u0_cdn_usb_utmi_rxvalid_sit"]
-pub type U0_CDN_USB_UTMI_RXVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_dp` reader - u0_usb_rx_dp"]
+pub type U0_USB_RX_DP_R = crate::BitReader;
+#[doc = "Field `u0_usb_rx_rcv` reader - u0_usb_rx_rcv"]
+pub type U0_USB_RX_RCV_R = crate::BitReader;
+#[doc = "Field `u0_usb_self_test` reader - For software bist_test"]
+pub type U0_USB_SELF_TEST_R = crate::BitReader;
+#[doc = "Field `u0_usb_self_test` writer - For software bist_test"]
+pub type U0_USB_SELF_TEST_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_sessend` reader - u0_usb_sessend"]
+pub type U0_USB_SESSEND_R = crate::BitReader;
+#[doc = "Field `u0_usb_sessvalid` reader - u0_usb_sessvalid"]
+pub type U0_USB_SESSVALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_sof` reader - u0_usb_sof"]
+pub type U0_USB_SOF_R = crate::BitReader;
+#[doc = "Field `u0_usb_test_bist` reader - For software bist_test"]
+pub type U0_USB_TEST_BIST_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_ack` reader - u0_usb_usbdev_main_power_off_ack"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_ready` reader - u0_usb_usbdev_main_power_off_ready"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_req` reader - u0_usb_usbdev_main_power_off_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_off_req` writer - u0_usb_usbdev_main_power_off_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_main_power_on_ready` reader - u0_usb_usbdev_main_power_on_ready"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_req` reader - u0_usb_usbdev_main_power_on_req"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_valid` reader - u0_usb_usbdev_main_power_on_valid"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_main_power_on_valid` writer - u0_usb_usbdev_main_power_on_valid"]
+pub type U0_USB_USBDEV_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_power_off_ack` reader - u0_usb_usbdev_power_off_ack"]
+pub type U0_USB_USBDEV_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_ready` reader - u0_usb_usbdev_power_off_ready"]
+pub type U0_USB_USBDEV_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_req` reader - u0_usb_usbdev_power_off_req"]
+pub type U0_USB_USBDEV_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_off_req` writer - u0_usb_usbdev_power_off_req"]
+pub type U0_USB_USBDEV_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_usbdev_power_on_ready` reader - u0_usb_usbdev_power_on_ready"]
+pub type U0_USB_USBDEV_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_req` reader - u0_usb_usbdev_power_on_req"]
+pub type U0_USB_USBDEV_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_valid` reader - u0_usb_usbdev_power_on_valid"]
+pub type U0_USB_USBDEV_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_usbdev_power_on_valid` writer - u0_usb_usbdev_power_on_valid"]
+pub type U0_USB_USBDEV_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_dmpulldown_sit` reader - u0_usb_utmi_dmpulldown_sit"]
+pub type U0_USB_UTMI_DMPULLDOWN_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_dmpulldown_sit` writer - u0_usb_utmi_dmpulldown_sit"]
+pub type U0_USB_UTMI_DMPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_dppulldown_sit` reader - u0_usb_utmi_dppulldown_sit"]
+pub type U0_USB_UTMI_DPPULLDOWN_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_dppulldown_sit` writer - u0_usb_utmi_dppulldown_sit"]
+pub type U0_USB_UTMI_DPPULLDOWN_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_fslsserialmode_sit` reader - u0_usb_utmi_fslsserialmode_sit"]
+pub type U0_USB_UTMI_FSLSSERIALMODE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_fslsserialmode_sit` writer - u0_usb_utmi_fslsserialmode_sit"]
+pub type U0_USB_UTMI_FSLSSERIALMODE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_hostdisconnect_sit` reader - u0_usb_utmi_hostdisconnect_sit"]
+pub type U0_USB_UTMI_HOSTDISCONNECT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_iddig_sit` reader - u0_usb_utmi_iddig_sit"]
+pub type U0_USB_UTMI_IDDIG_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_idpullup_sit` reader - u0_usb_utmi_idpullup_sit"]
+pub type U0_USB_UTMI_IDPULLUP_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_idpullup_sit` writer - u0_usb_utmi_idpullup_sit"]
+pub type U0_USB_UTMI_IDPULLUP_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_linestate_sit` reader - u0_usb_utmi_linestate_sit"]
+pub type U0_USB_UTMI_LINESTATE_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_opmode_sit` reader - u0_usb_utmi_opmode_sit"]
+pub type U0_USB_UTMI_OPMODE_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_opmode_sit` writer - u0_usb_utmi_opmode_sit"]
+pub type U0_USB_UTMI_OPMODE_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_usb_utmi_rxactive_sit` reader - u0_usb_utmi_rxactive_sit"]
+pub type U0_USB_UTMI_RXACTIVE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_rxerror_sit` reader - u0_usb_utmi_rxerror_sit"]
+pub type U0_USB_UTMI_RXERROR_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_rxvalid_sit` reader - u0_usb_utmi_rxvalid_sit"]
+pub type U0_USB_UTMI_RXVALID_SIT_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_cdn_usb_rx_dp"]
+    #[doc = "Bit 0 - u0_usb_rx_dp"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_dp(&self) -> U0_CDN_USB_RX_DP_R {
-        U0_CDN_USB_RX_DP_R::new((self.bits & 1) != 0)
+    pub fn u0_usb_rx_dp(&self) -> U0_USB_RX_DP_R {
+        U0_USB_RX_DP_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_cdn_usb_rx_rcv"]
+    #[doc = "Bit 1 - u0_usb_rx_rcv"]
     #[inline(always)]
-    pub fn u0_cdn_usb_rx_rcv(&self) -> U0_CDN_USB_RX_RCV_R {
-        U0_CDN_USB_RX_RCV_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_usb_rx_rcv(&self) -> U0_USB_RX_RCV_R {
+        U0_USB_RX_RCV_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - For software bist_test"]
     #[inline(always)]
-    pub fn u0_cdn_usb_self_test(&self) -> U0_CDN_USB_SELF_TEST_R {
-        U0_CDN_USB_SELF_TEST_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_usb_self_test(&self) -> U0_USB_SELF_TEST_R {
+        U0_USB_SELF_TEST_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_sessend"]
+    #[doc = "Bit 3 - u0_usb_sessend"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sessend(&self) -> U0_CDN_USB_SESSEND_R {
-        U0_CDN_USB_SESSEND_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_usb_sessend(&self) -> U0_USB_SESSEND_R {
+        U0_USB_SESSEND_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_sessvalid"]
+    #[doc = "Bit 4 - u0_usb_sessvalid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sessvalid(&self) -> U0_CDN_USB_SESSVALID_R {
-        U0_CDN_USB_SESSVALID_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_usb_sessvalid(&self) -> U0_USB_SESSVALID_R {
+        U0_USB_SESSVALID_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_sof"]
+    #[doc = "Bit 5 - u0_usb_sof"]
     #[inline(always)]
-    pub fn u0_cdn_usb_sof(&self) -> U0_CDN_USB_SOF_R {
-        U0_CDN_USB_SOF_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_sof(&self) -> U0_USB_SOF_R {
+        U0_USB_SOF_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - For software bist_test"]
     #[inline(always)]
-    pub fn u0_cdn_usb_test_bist(&self) -> U0_CDN_USB_TEST_BIST_R {
-        U0_CDN_USB_TEST_BIST_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_test_bist(&self) -> U0_USB_TEST_BIST_R {
+        U0_USB_TEST_BIST_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_usbdev_main_power_off_ack"]
+    #[doc = "Bit 7 - u0_usb_usbdev_main_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_ack(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_ack(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_usbdev_main_power_off_ready"]
+    #[doc = "Bit 8 - u0_usb_usbdev_main_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_ready(
-        &self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_READY_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_ready(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_READY_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_READY_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_usbdev_main_power_off_req"]
+    #[doc = "Bit 9 - u0_usb_usbdev_main_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_off_req(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_off_req(&self) -> U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R {
+        U0_USB_USBDEV_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_usbdev_main_power_on_ready"]
+    #[doc = "Bit 10 - u0_usb_usbdev_main_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_ready(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_READY_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_ready(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_READY_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_READY_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_usbdev_main_power_on_req"]
+    #[doc = "Bit 11 - u0_usb_usbdev_main_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_req(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_REQ_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_req(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_REQ_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_REQ_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_usbdev_main_power_on_valid"]
+    #[doc = "Bit 12 - u0_usb_usbdev_main_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_main_power_on_valid(&self) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_usbdev_main_power_on_valid(&self) -> U0_USB_USBDEV_MAIN_POWER_ON_VALID_R {
+        U0_USB_USBDEV_MAIN_POWER_ON_VALID_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_usbdev_power_off_ack"]
+    #[doc = "Bit 13 - u0_usb_usbdev_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_ack(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_ACK_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_ACK_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_ack(&self) -> U0_USB_USBDEV_POWER_OFF_ACK_R {
+        U0_USB_USBDEV_POWER_OFF_ACK_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_usbdev_power_off_ready"]
+    #[doc = "Bit 14 - u0_usb_usbdev_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_ready(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_READY_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_READY_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_ready(&self) -> U0_USB_USBDEV_POWER_OFF_READY_R {
+        U0_USB_USBDEV_POWER_OFF_READY_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_usbdev_power_off_req"]
+    #[doc = "Bit 15 - u0_usb_usbdev_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_off_req(&self) -> U0_CDN_USB_USBDEV_POWER_OFF_REQ_R {
-        U0_CDN_USB_USBDEV_POWER_OFF_REQ_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_usbdev_power_off_req(&self) -> U0_USB_USBDEV_POWER_OFF_REQ_R {
+        U0_USB_USBDEV_POWER_OFF_REQ_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_usbdev_power_on_ready"]
+    #[doc = "Bit 16 - u0_usb_usbdev_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_ready(&self) -> U0_CDN_USB_USBDEV_POWER_ON_READY_R {
-        U0_CDN_USB_USBDEV_POWER_ON_READY_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_ready(&self) -> U0_USB_USBDEV_POWER_ON_READY_R {
+        U0_USB_USBDEV_POWER_ON_READY_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_usbdev_power_on_req"]
+    #[doc = "Bit 17 - u0_usb_usbdev_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_req(&self) -> U0_CDN_USB_USBDEV_POWER_ON_REQ_R {
-        U0_CDN_USB_USBDEV_POWER_ON_REQ_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_req(&self) -> U0_USB_USBDEV_POWER_ON_REQ_R {
+        U0_USB_USBDEV_POWER_ON_REQ_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_usbdev_power_on_valid"]
+    #[doc = "Bit 18 - u0_usb_usbdev_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_usbdev_power_on_valid(&self) -> U0_CDN_USB_USBDEV_POWER_ON_VALID_R {
-        U0_CDN_USB_USBDEV_POWER_ON_VALID_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_usb_usbdev_power_on_valid(&self) -> U0_USB_USBDEV_POWER_ON_VALID_R {
+        U0_USB_USBDEV_POWER_ON_VALID_R::new(((self.bits >> 18) & 1) != 0)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_utmi_dmpulldown_sit"]
+    #[doc = "Bit 19 - u0_usb_utmi_dmpulldown_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_dmpulldown_sit(&self) -> U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R {
-        U0_CDN_USB_UTMI_DMPULLDOWN_SIT_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_usb_utmi_dmpulldown_sit(&self) -> U0_USB_UTMI_DMPULLDOWN_SIT_R {
+        U0_USB_UTMI_DMPULLDOWN_SIT_R::new(((self.bits >> 19) & 1) != 0)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_utmi_dppulldown_sit"]
+    #[doc = "Bit 20 - u0_usb_utmi_dppulldown_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_dppulldown_sit(&self) -> U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R {
-        U0_CDN_USB_UTMI_DPPULLDOWN_SIT_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_usb_utmi_dppulldown_sit(&self) -> U0_USB_UTMI_DPPULLDOWN_SIT_R {
+        U0_USB_UTMI_DPPULLDOWN_SIT_R::new(((self.bits >> 20) & 1) != 0)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_utmi_fslsserialmode_sit"]
+    #[doc = "Bit 21 - u0_usb_utmi_fslsserialmode_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_fslsserialmode_sit(&self) -> U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R {
-        U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_usb_utmi_fslsserialmode_sit(&self) -> U0_USB_UTMI_FSLSSERIALMODE_SIT_R {
+        U0_USB_UTMI_FSLSSERIALMODE_SIT_R::new(((self.bits >> 21) & 1) != 0)
     }
-    #[doc = "Bit 22 - u0_cdn_usb_utmi_hostdisconnect_sit"]
+    #[doc = "Bit 22 - u0_usb_utmi_hostdisconnect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_hostdisconnect_sit(&self) -> U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R {
-        U0_CDN_USB_UTMI_HOSTDISCONNECT_SIT_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_usb_utmi_hostdisconnect_sit(&self) -> U0_USB_UTMI_HOSTDISCONNECT_SIT_R {
+        U0_USB_UTMI_HOSTDISCONNECT_SIT_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_cdn_usb_utmi_iddig_sit"]
+    #[doc = "Bit 23 - u0_usb_utmi_iddig_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_iddig_sit(&self) -> U0_CDN_USB_UTMI_IDDIG_SIT_R {
-        U0_CDN_USB_UTMI_IDDIG_SIT_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_usb_utmi_iddig_sit(&self) -> U0_USB_UTMI_IDDIG_SIT_R {
+        U0_USB_UTMI_IDDIG_SIT_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_utmi_idpullup_sit"]
+    #[doc = "Bit 24 - u0_usb_utmi_idpullup_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_idpullup_sit(&self) -> U0_CDN_USB_UTMI_IDPULLUP_SIT_R {
-        U0_CDN_USB_UTMI_IDPULLUP_SIT_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_usb_utmi_idpullup_sit(&self) -> U0_USB_UTMI_IDPULLUP_SIT_R {
+        U0_USB_UTMI_IDPULLUP_SIT_R::new(((self.bits >> 24) & 1) != 0)
     }
-    #[doc = "Bits 25:26 - u0_cdn_usb_utmi_linestate_sit"]
+    #[doc = "Bits 25:26 - u0_usb_utmi_linestate_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_linestate_sit(&self) -> U0_CDN_USB_UTMI_LINESTATE_SIT_R {
-        U0_CDN_USB_UTMI_LINESTATE_SIT_R::new(((self.bits >> 25) & 3) as u8)
+    pub fn u0_usb_utmi_linestate_sit(&self) -> U0_USB_UTMI_LINESTATE_SIT_R {
+        U0_USB_UTMI_LINESTATE_SIT_R::new(((self.bits >> 25) & 3) as u8)
     }
-    #[doc = "Bits 27:28 - u0_cdn_usb_utmi_opmode_sit"]
+    #[doc = "Bits 27:28 - u0_usb_utmi_opmode_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_opmode_sit(&self) -> U0_CDN_USB_UTMI_OPMODE_SIT_R {
-        U0_CDN_USB_UTMI_OPMODE_SIT_R::new(((self.bits >> 27) & 3) as u8)
+    pub fn u0_usb_utmi_opmode_sit(&self) -> U0_USB_UTMI_OPMODE_SIT_R {
+        U0_USB_UTMI_OPMODE_SIT_R::new(((self.bits >> 27) & 3) as u8)
     }
-    #[doc = "Bit 29 - u0_cdn_usb_utmi_rxactive_sit"]
+    #[doc = "Bit 29 - u0_usb_utmi_rxactive_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxactive_sit(&self) -> U0_CDN_USB_UTMI_RXACTIVE_SIT_R {
-        U0_CDN_USB_UTMI_RXACTIVE_SIT_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_usb_utmi_rxactive_sit(&self) -> U0_USB_UTMI_RXACTIVE_SIT_R {
+        U0_USB_UTMI_RXACTIVE_SIT_R::new(((self.bits >> 29) & 1) != 0)
     }
-    #[doc = "Bit 30 - u0_cdn_usb_utmi_rxerror_sit"]
+    #[doc = "Bit 30 - u0_usb_utmi_rxerror_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxerror_sit(&self) -> U0_CDN_USB_UTMI_RXERROR_SIT_R {
-        U0_CDN_USB_UTMI_RXERROR_SIT_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_usb_utmi_rxerror_sit(&self) -> U0_USB_UTMI_RXERROR_SIT_R {
+        U0_USB_UTMI_RXERROR_SIT_R::new(((self.bits >> 30) & 1) != 0)
     }
-    #[doc = "Bit 31 - u0_cdn_usb_utmi_rxvalid_sit"]
+    #[doc = "Bit 31 - u0_usb_utmi_rxvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxvalid_sit(&self) -> U0_CDN_USB_UTMI_RXVALID_SIT_R {
-        U0_CDN_USB_UTMI_RXVALID_SIT_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_usb_utmi_rxvalid_sit(&self) -> U0_USB_UTMI_RXVALID_SIT_R {
+        U0_USB_UTMI_RXVALID_SIT_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 2 - For software bist_test"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_self_test(&mut self) -> U0_CDN_USB_SELF_TEST_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_SELF_TEST_W::new(self, 2)
+    pub fn u0_usb_self_test(&mut self) -> U0_USB_SELF_TEST_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_SELF_TEST_W::new(self, 2)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_usbdev_main_power_off_req"]
+    #[doc = "Bit 9 - u0_usb_usbdev_main_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_main_power_off_req(
+    pub fn u0_usb_usbdev_main_power_off_req(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_MAIN_POWER_OFF_REQ_W::new(self, 9)
+    ) -> U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_MAIN_POWER_OFF_REQ_W::new(self, 9)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_usbdev_main_power_on_valid"]
+    #[doc = "Bit 12 - u0_usb_usbdev_main_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_main_power_on_valid(
+    pub fn u0_usb_usbdev_main_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_MAIN_POWER_ON_VALID_W::new(self, 12)
+    ) -> U0_USB_USBDEV_MAIN_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_MAIN_POWER_ON_VALID_W::new(self, 12)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_usbdev_power_off_req"]
+    #[doc = "Bit 15 - u0_usb_usbdev_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_power_off_req(
+    pub fn u0_usb_usbdev_power_off_req(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_POWER_OFF_REQ_W::new(self, 15)
+    ) -> U0_USB_USBDEV_POWER_OFF_REQ_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_POWER_OFF_REQ_W::new(self, 15)
     }
-    #[doc = "Bit 18 - u0_cdn_usb_usbdev_power_on_valid"]
+    #[doc = "Bit 18 - u0_usb_usbdev_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_usbdev_power_on_valid(
+    pub fn u0_usb_usbdev_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_USBDEV_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_USBDEV_POWER_ON_VALID_W::new(self, 18)
+    ) -> U0_USB_USBDEV_POWER_ON_VALID_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_USBDEV_POWER_ON_VALID_W::new(self, 18)
     }
-    #[doc = "Bit 19 - u0_cdn_usb_utmi_dmpulldown_sit"]
+    #[doc = "Bit 19 - u0_usb_utmi_dmpulldown_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_dmpulldown_sit(
+    pub fn u0_usb_utmi_dmpulldown_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_DMPULLDOWN_SIT_W::new(self, 19)
+    ) -> U0_USB_UTMI_DMPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_DMPULLDOWN_SIT_W::new(self, 19)
     }
-    #[doc = "Bit 20 - u0_cdn_usb_utmi_dppulldown_sit"]
+    #[doc = "Bit 20 - u0_usb_utmi_dppulldown_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_dppulldown_sit(
+    pub fn u0_usb_utmi_dppulldown_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_DPPULLDOWN_SIT_W::new(self, 20)
+    ) -> U0_USB_UTMI_DPPULLDOWN_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_DPPULLDOWN_SIT_W::new(self, 20)
     }
-    #[doc = "Bit 21 - u0_cdn_usb_utmi_fslsserialmode_sit"]
+    #[doc = "Bit 21 - u0_usb_utmi_fslsserialmode_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_fslsserialmode_sit(
+    pub fn u0_usb_utmi_fslsserialmode_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_FSLSSERIALMODE_SIT_W::new(self, 21)
+    ) -> U0_USB_UTMI_FSLSSERIALMODE_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_FSLSSERIALMODE_SIT_W::new(self, 21)
     }
-    #[doc = "Bit 24 - u0_cdn_usb_utmi_idpullup_sit"]
+    #[doc = "Bit 24 - u0_usb_utmi_idpullup_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_idpullup_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_IDPULLUP_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_IDPULLUP_SIT_W::new(self, 24)
+    pub fn u0_usb_utmi_idpullup_sit(&mut self) -> U0_USB_UTMI_IDPULLUP_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_IDPULLUP_SIT_W::new(self, 24)
     }
-    #[doc = "Bits 27:28 - u0_cdn_usb_utmi_opmode_sit"]
+    #[doc = "Bits 27:28 - u0_usb_utmi_opmode_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_opmode_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_OPMODE_SIT_W<STG_SYSCFG_2_SPEC> {
-        U0_CDN_USB_UTMI_OPMODE_SIT_W::new(self, 27)
+    pub fn u0_usb_utmi_opmode_sit(&mut self) -> U0_USB_UTMI_OPMODE_SIT_W<STG_SYSCFG_2_SPEC> {
+        U0_USB_UTMI_OPMODE_SIT_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_20.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_20.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_20_SPEC>;
 #[doc = "Register `stg_syscfg_20` writer"]
 pub type W = crate::W<STG_SYSCFG_20_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_95_64` reader - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_95_64` reader - u0_pcie_axi4_mst0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_95_64(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_200.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_200.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_200_SPEC>;
 #[doc = "Register `stg_syscfg_200` writer"]
 pub type W = crate::W<STG_SYSCFG_200_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_63_32` reader - u1_plda_pcie_test_out_bridge_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_63_32` writer - u1_plda_pcie_test_out_bridge_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_63_32` reader - u1_pcie_test_out_bridge_63_32"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_63_32` writer - u1_pcie_test_out_bridge_63_32"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_63_32(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_63_32(&self) -> U1_PCIE_TEST_OUT_BRIDGE_63_32_R {
+        U1_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_63_32(
+    pub fn u1_pcie_test_out_bridge_63_32(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W<STG_SYSCFG_200_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_63_32_W<STG_SYSCFG_200_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_201.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_201.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_201_SPEC>;
 #[doc = "Register `stg_syscfg_201` writer"]
 pub type W = crate::W<STG_SYSCFG_201_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_95_64` reader - u1_plda_pcie_test_out_bridge_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_95_64` writer - u1_plda_pcie_test_out_bridge_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_95_64` reader - u1_pcie_test_out_bridge_95_64"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_95_64` writer - u1_pcie_test_out_bridge_95_64"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_95_64(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_95_64(&self) -> U1_PCIE_TEST_OUT_BRIDGE_95_64_R {
+        U1_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_95_64(
+    pub fn u1_pcie_test_out_bridge_95_64(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W<STG_SYSCFG_201_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_95_64_W<STG_SYSCFG_201_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_202.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_202.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_202_SPEC>;
 #[doc = "Register `stg_syscfg_202` writer"]
 pub type W = crate::W<STG_SYSCFG_202_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_127_96` reader - u1_plda_pcie_test_out_bridge_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_127_96` writer - u1_plda_pcie_test_out_bridge_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_127_96` reader - u1_pcie_test_out_bridge_127_96"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_127_96` writer - u1_pcie_test_out_bridge_127_96"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_127_96(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_127_96(&self) -> U1_PCIE_TEST_OUT_BRIDGE_127_96_R {
+        U1_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_127_96(
+    pub fn u1_pcie_test_out_bridge_127_96(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W<STG_SYSCFG_202_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_127_96_W<STG_SYSCFG_202_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_203.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_203.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_203_SPEC>;
 #[doc = "Register `stg_syscfg_203` writer"]
 pub type W = crate::W<STG_SYSCFG_203_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_159_128` reader - u1_plda_pcie_test_out_bridge_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_159_128` writer - u1_plda_pcie_test_out_bridge_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_159_128` reader - u1_pcie_test_out_bridge_159_128"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_159_128` writer - u1_pcie_test_out_bridge_159_128"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_159_128(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_159_128(&self) -> U1_PCIE_TEST_OUT_BRIDGE_159_128_R {
+        U1_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_159_128(
+    pub fn u1_pcie_test_out_bridge_159_128(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W<STG_SYSCFG_203_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_159_128_W<STG_SYSCFG_203_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_204.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_204.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_204_SPEC>;
 #[doc = "Register `stg_syscfg_204` writer"]
 pub type W = crate::W<STG_SYSCFG_204_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_191_160` reader - u1_plda_pcie_test_out_bridge_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_191_160` writer - u1_plda_pcie_test_out_bridge_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_191_160` reader - u1_pcie_test_out_bridge_191_160"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_191_160` writer - u1_pcie_test_out_bridge_191_160"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_191_160(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_191_160(&self) -> U1_PCIE_TEST_OUT_BRIDGE_191_160_R {
+        U1_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_191_160(
+    pub fn u1_pcie_test_out_bridge_191_160(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W<STG_SYSCFG_204_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_191_160_W<STG_SYSCFG_204_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_205.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_205.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_205_SPEC>;
 #[doc = "Register `stg_syscfg_205` writer"]
 pub type W = crate::W<STG_SYSCFG_205_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_223_192` reader - u1_plda_pcie_test_out_bridge_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_223_192` writer - u1_plda_pcie_test_out_bridge_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_223_192` reader - u1_pcie_test_out_bridge_223_192"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_223_192` writer - u1_pcie_test_out_bridge_223_192"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_223_192(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_223_192(&self) -> U1_PCIE_TEST_OUT_BRIDGE_223_192_R {
+        U1_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_223_192(
+    pub fn u1_pcie_test_out_bridge_223_192(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W<STG_SYSCFG_205_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_223_192_W<STG_SYSCFG_205_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_206.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_206.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_206_SPEC>;
 #[doc = "Register `stg_syscfg_206` writer"]
 pub type W = crate::W<STG_SYSCFG_206_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_255_224` reader - u1_plda_pcie_test_out_bridge_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_255_224` writer - u1_plda_pcie_test_out_bridge_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_255_224` reader - u1_pcie_test_out_bridge_255_224"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_255_224` writer - u1_pcie_test_out_bridge_255_224"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_255_224(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_255_224(&self) -> U1_PCIE_TEST_OUT_BRIDGE_255_224_R {
+        U1_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_255_224(
+    pub fn u1_pcie_test_out_bridge_255_224(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W<STG_SYSCFG_206_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_255_224_W<STG_SYSCFG_206_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_207.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_207.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_207_SPEC>;
 #[doc = "Register `stg_syscfg_207` writer"]
 pub type W = crate::W<STG_SYSCFG_207_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_287_256` reader - u1_plda_pcie_test_out_bridge_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_287_256` writer - u1_plda_pcie_test_out_bridge_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_287_256` reader - u1_pcie_test_out_bridge_287_256"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_287_256` writer - u1_pcie_test_out_bridge_287_256"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_287_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_287_256(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_287_256(&self) -> U1_PCIE_TEST_OUT_BRIDGE_287_256_R {
+        U1_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_287_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_287_256(
+    pub fn u1_pcie_test_out_bridge_287_256(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W<STG_SYSCFG_207_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_287_256_W<STG_SYSCFG_207_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_287_256_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_208.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_208.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_208_SPEC>;
 #[doc = "Register `stg_syscfg_208` writer"]
 pub type W = crate::W<STG_SYSCFG_208_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_319_288` reader - u1_plda_pcie_test_out_bridge_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_319_288` writer - u1_plda_pcie_test_out_bridge_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_319_288` reader - u1_pcie_test_out_bridge_319_288"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_319_288` writer - u1_pcie_test_out_bridge_319_288"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_319_288"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_319_288(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_319_288(&self) -> U1_PCIE_TEST_OUT_BRIDGE_319_288_R {
+        U1_PCIE_TEST_OUT_BRIDGE_319_288_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_319_288"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_319_288(
+    pub fn u1_pcie_test_out_bridge_319_288(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W<STG_SYSCFG_208_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_319_288_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_319_288_W<STG_SYSCFG_208_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_319_288_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_209.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_209.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_209_SPEC>;
 #[doc = "Register `stg_syscfg_209` writer"]
 pub type W = crate::W<STG_SYSCFG_209_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_351_320` reader - u1_plda_pcie_test_out_bridge_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_351_320` writer - u1_plda_pcie_test_out_bridge_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_351_320` reader - u1_pcie_test_out_bridge_351_320"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_351_320` writer - u1_pcie_test_out_bridge_351_320"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_351_320"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_351_320(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_351_320(&self) -> U1_PCIE_TEST_OUT_BRIDGE_351_320_R {
+        U1_PCIE_TEST_OUT_BRIDGE_351_320_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_351_320"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_351_320(
+    pub fn u1_pcie_test_out_bridge_351_320(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W<STG_SYSCFG_209_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_351_320_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_351_320_W<STG_SYSCFG_209_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_351_320_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_21.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_21.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_21_SPEC>;
 #[doc = "Register `stg_syscfg_21` writer"]
 pub type W = crate::W<STG_SYSCFG_21_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_127_96` reader - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_127_96` reader - u0_pcie_axi4_mst0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_127_96(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_210.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_210.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_210_SPEC>;
 #[doc = "Register `stg_syscfg_210` writer"]
 pub type W = crate::W<STG_SYSCFG_210_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_383_352` reader - u1_plda_pcie_test_out_bridge_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_383_352` writer - u1_plda_pcie_test_out_bridge_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_383_352` reader - u1_pcie_test_out_bridge_383_352"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_383_352` writer - u1_pcie_test_out_bridge_383_352"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_383_352"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_383_352(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_383_352(&self) -> U1_PCIE_TEST_OUT_BRIDGE_383_352_R {
+        U1_PCIE_TEST_OUT_BRIDGE_383_352_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_383_352"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_383_352(
+    pub fn u1_pcie_test_out_bridge_383_352(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W<STG_SYSCFG_210_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_383_352_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_383_352_W<STG_SYSCFG_210_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_383_352_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_211.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_211.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_211_SPEC>;
 #[doc = "Register `stg_syscfg_211` writer"]
 pub type W = crate::W<STG_SYSCFG_211_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_415_384` reader - u1_plda_pcie_test_out_bridge_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_415_384` writer - u1_plda_pcie_test_out_bridge_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_415_384` reader - u1_pcie_test_out_bridge_415_384"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_415_384` writer - u1_pcie_test_out_bridge_415_384"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_415_384"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_415_384(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_415_384(&self) -> U1_PCIE_TEST_OUT_BRIDGE_415_384_R {
+        U1_PCIE_TEST_OUT_BRIDGE_415_384_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_415_384"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_415_384(
+    pub fn u1_pcie_test_out_bridge_415_384(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W<STG_SYSCFG_211_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_415_384_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_415_384_W<STG_SYSCFG_211_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_415_384_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_212.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_212.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_212_SPEC>;
 #[doc = "Register `stg_syscfg_212` writer"]
 pub type W = crate::W<STG_SYSCFG_212_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_447_416` reader - u1_plda_pcie_test_out_bridge_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_447_416` writer - u1_plda_pcie_test_out_bridge_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_447_416` reader - u1_pcie_test_out_bridge_447_416"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_447_416` writer - u1_pcie_test_out_bridge_447_416"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_447_416"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_447_416(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_447_416(&self) -> U1_PCIE_TEST_OUT_BRIDGE_447_416_R {
+        U1_PCIE_TEST_OUT_BRIDGE_447_416_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_447_416"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_447_416(
+    pub fn u1_pcie_test_out_bridge_447_416(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W<STG_SYSCFG_212_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_447_416_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_447_416_W<STG_SYSCFG_212_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_447_416_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_213.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_213.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_213_SPEC>;
 #[doc = "Register `stg_syscfg_213` writer"]
 pub type W = crate::W<STG_SYSCFG_213_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_479_448` reader - u1_plda_pcie_test_out_bridge_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_479_448` writer - u1_plda_pcie_test_out_bridge_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_479_448` reader - u1_pcie_test_out_bridge_479_448"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_479_448` writer - u1_pcie_test_out_bridge_479_448"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_479_448"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_479_448(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_479_448(&self) -> U1_PCIE_TEST_OUT_BRIDGE_479_448_R {
+        U1_PCIE_TEST_OUT_BRIDGE_479_448_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_479_448"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_479_448(
+    pub fn u1_pcie_test_out_bridge_479_448(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W<STG_SYSCFG_213_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_479_448_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_479_448_W<STG_SYSCFG_213_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_479_448_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_214.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_214.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_214_SPEC>;
 #[doc = "Register `stg_syscfg_214` writer"]
 pub type W = crate::W<STG_SYSCFG_214_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_511_480` reader - u1_plda_pcie_test_out_bridge_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_test_out_bridge_511_480` writer - u1_plda_pcie_test_out_bridge_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_511_480` reader - u1_pcie_test_out_bridge_511_480"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_bridge_511_480` writer - u1_pcie_test_out_bridge_511_480"]
+pub type U1_PCIE_TEST_OUT_BRIDGE_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_511_480"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_bridge_511_480(&self) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
+    pub fn u1_pcie_test_out_bridge_511_480(&self) -> U1_PCIE_TEST_OUT_BRIDGE_511_480_R {
+        U1_PCIE_TEST_OUT_BRIDGE_511_480_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_bridge_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_bridge_511_480"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_out_bridge_511_480(
+    pub fn u1_pcie_test_out_bridge_511_480(
         &mut self,
-    ) -> U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W<STG_SYSCFG_214_SPEC> {
-        U1_PLDA_PCIE_TEST_OUT_BRIDGE_511_480_W::new(self, 0)
+    ) -> U1_PCIE_TEST_OUT_BRIDGE_511_480_W<STG_SYSCFG_214_SPEC> {
+        U1_PCIE_TEST_OUT_BRIDGE_511_480_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_215.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_215.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_215_SPEC>;
 #[doc = "Register `stg_syscfg_215` writer"]
 pub type W = crate::W<STG_SYSCFG_215_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_31_0` reader - u1_plda_pcie_test_out_pcie_31_0"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_31_0` reader - u1_pcie_test_out_pcie_31_0"]
+pub type U1_PCIE_TEST_OUT_PCIE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_31_0"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_31_0"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_31_0(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_31_0(&self) -> U1_PCIE_TEST_OUT_PCIE_31_0_R {
+        U1_PCIE_TEST_OUT_PCIE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_216.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_216.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_216_SPEC>;
 #[doc = "Register `stg_syscfg_216` writer"]
 pub type W = crate::W<STG_SYSCFG_216_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_63_32` reader - u1_plda_pcie_test_out_pcie_63_32"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_63_32` reader - u1_pcie_test_out_pcie_63_32"]
+pub type U1_PCIE_TEST_OUT_PCIE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_63_32"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_63_32"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_63_32(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_63_32(&self) -> U1_PCIE_TEST_OUT_PCIE_63_32_R {
+        U1_PCIE_TEST_OUT_PCIE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_217.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_217.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_217_SPEC>;
 #[doc = "Register `stg_syscfg_217` writer"]
 pub type W = crate::W<STG_SYSCFG_217_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_95_64` reader - u1_plda_pcie_test_out_pcie_95_64"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_95_64` reader - u1_pcie_test_out_pcie_95_64"]
+pub type U1_PCIE_TEST_OUT_PCIE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_95_64"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_95_64"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_95_64(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_95_64(&self) -> U1_PCIE_TEST_OUT_PCIE_95_64_R {
+        U1_PCIE_TEST_OUT_PCIE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_218.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_218.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_218_SPEC>;
 #[doc = "Register `stg_syscfg_218` writer"]
 pub type W = crate::W<STG_SYSCFG_218_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_127_96` reader - u1_plda_pcie_test_out_pcie_127_96"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_127_96` reader - u1_pcie_test_out_pcie_127_96"]
+pub type U1_PCIE_TEST_OUT_PCIE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_127_96"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_127_96"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_127_96(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_127_96(&self) -> U1_PCIE_TEST_OUT_PCIE_127_96_R {
+        U1_PCIE_TEST_OUT_PCIE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_219.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_219.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_219_SPEC>;
 #[doc = "Register `stg_syscfg_219` writer"]
 pub type W = crate::W<STG_SYSCFG_219_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_159_128` reader - u1_plda_pcie_test_out_pcie_159_128"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_159_128` reader - u1_pcie_test_out_pcie_159_128"]
+pub type U1_PCIE_TEST_OUT_PCIE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_159_128"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_159_128"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_159_128(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_159_128(&self) -> U1_PCIE_TEST_OUT_PCIE_159_128_R {
+        U1_PCIE_TEST_OUT_PCIE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_22.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_22.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_22_SPEC>;
 #[doc = "Register `stg_syscfg_22` writer"]
 pub type W = crate::W<STG_SYSCFG_22_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_159_128` reader - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_159_128` reader - u0_pcie_axi4_mst0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_159_128(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_220.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_220.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_220_SPEC>;
 #[doc = "Register `stg_syscfg_220` writer"]
 pub type W = crate::W<STG_SYSCFG_220_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_191_160` reader - u1_plda_pcie_test_out_pcie_191_160"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_191_160` reader - u1_pcie_test_out_pcie_191_160"]
+pub type U1_PCIE_TEST_OUT_PCIE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_191_160"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_191_160"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_191_160(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_191_160(&self) -> U1_PCIE_TEST_OUT_PCIE_191_160_R {
+        U1_PCIE_TEST_OUT_PCIE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_221.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_221.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_221_SPEC>;
 #[doc = "Register `stg_syscfg_221` writer"]
 pub type W = crate::W<STG_SYSCFG_221_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_223_192` reader - u1_plda_pcie_test_out_pcie_223_192"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_223_192` reader - u1_pcie_test_out_pcie_223_192"]
+pub type U1_PCIE_TEST_OUT_PCIE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_223_192"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_223_192"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_223_192(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_223_192(&self) -> U1_PCIE_TEST_OUT_PCIE_223_192_R {
+        U1_PCIE_TEST_OUT_PCIE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_222.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_222.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_222_SPEC>;
 #[doc = "Register `stg_syscfg_222` writer"]
 pub type W = crate::W<STG_SYSCFG_222_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_255_224` reader - u1_plda_pcie_test_out_pcie_255_224"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_255_224` reader - u1_pcie_test_out_pcie_255_224"]
+pub type U1_PCIE_TEST_OUT_PCIE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_255_224"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_255_224"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_255_224(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_255_224(&self) -> U1_PCIE_TEST_OUT_PCIE_255_224_R {
+        U1_PCIE_TEST_OUT_PCIE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_223.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_223.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_223_SPEC>;
 #[doc = "Register `stg_syscfg_223` writer"]
 pub type W = crate::W<STG_SYSCFG_223_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_287_256` reader - u1_plda_pcie_test_out_pcie_287_256"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_287_256` reader - u1_pcie_test_out_pcie_287_256"]
+pub type U1_PCIE_TEST_OUT_PCIE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_287_256"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_287_256"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_287_256(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_287_256(&self) -> U1_PCIE_TEST_OUT_PCIE_287_256_R {
+        U1_PCIE_TEST_OUT_PCIE_287_256_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_224.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_224.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_224_SPEC>;
 #[doc = "Register `stg_syscfg_224` writer"]
 pub type W = crate::W<STG_SYSCFG_224_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_319_288` reader - u1_plda_pcie_test_out_pcie_319_288"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_319_288` reader - u1_pcie_test_out_pcie_319_288"]
+pub type U1_PCIE_TEST_OUT_PCIE_319_288_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_319_288"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_319_288"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_319_288(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_319_288(&self) -> U1_PCIE_TEST_OUT_PCIE_319_288_R {
+        U1_PCIE_TEST_OUT_PCIE_319_288_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_225.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_225.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_225_SPEC>;
 #[doc = "Register `stg_syscfg_225` writer"]
 pub type W = crate::W<STG_SYSCFG_225_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_351_320` reader - u1_plda_pcie_test_out_pcie_351_320"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_351_320` reader - u1_pcie_test_out_pcie_351_320"]
+pub type U1_PCIE_TEST_OUT_PCIE_351_320_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_351_320"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_351_320"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_351_320(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_351_320(&self) -> U1_PCIE_TEST_OUT_PCIE_351_320_R {
+        U1_PCIE_TEST_OUT_PCIE_351_320_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_226.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_226.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_226_SPEC>;
 #[doc = "Register `stg_syscfg_226` writer"]
 pub type W = crate::W<STG_SYSCFG_226_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_383_352` reader - u1_plda_pcie_test_out_pcie_383_352"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_383_352` reader - u1_pcie_test_out_pcie_383_352"]
+pub type U1_PCIE_TEST_OUT_PCIE_383_352_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_383_352"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_383_352"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_383_352(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_383_352(&self) -> U1_PCIE_TEST_OUT_PCIE_383_352_R {
+        U1_PCIE_TEST_OUT_PCIE_383_352_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_227.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_227.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_227_SPEC>;
 #[doc = "Register `stg_syscfg_227` writer"]
 pub type W = crate::W<STG_SYSCFG_227_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_415_384` reader - u1_plda_pcie_test_out_pcie_415_384"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_415_384` reader - u1_pcie_test_out_pcie_415_384"]
+pub type U1_PCIE_TEST_OUT_PCIE_415_384_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_415_384"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_415_384"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_415_384(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_415_384(&self) -> U1_PCIE_TEST_OUT_PCIE_415_384_R {
+        U1_PCIE_TEST_OUT_PCIE_415_384_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_228.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_228.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_228_SPEC>;
 #[doc = "Register `stg_syscfg_228` writer"]
 pub type W = crate::W<STG_SYSCFG_228_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_447_416` reader - u1_plda_pcie_test_out_pcie_447_416"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_447_416` reader - u1_pcie_test_out_pcie_447_416"]
+pub type U1_PCIE_TEST_OUT_PCIE_447_416_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_447_416"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_447_416"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_447_416(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_447_416(&self) -> U1_PCIE_TEST_OUT_PCIE_447_416_R {
+        U1_PCIE_TEST_OUT_PCIE_447_416_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_229.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_229.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_229_SPEC>;
 #[doc = "Register `stg_syscfg_229` writer"]
 pub type W = crate::W<STG_SYSCFG_229_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_479_448` reader - u1_plda_pcie_test_out_pcie_479_448"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_479_448` reader - u1_pcie_test_out_pcie_479_448"]
+pub type U1_PCIE_TEST_OUT_PCIE_479_448_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_479_448"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_479_448"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_479_448(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_479_448(&self) -> U1_PCIE_TEST_OUT_PCIE_479_448_R {
+        U1_PCIE_TEST_OUT_PCIE_479_448_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_23.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_23.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_23_SPEC>;
 #[doc = "Register `stg_syscfg_23` writer"]
 pub type W = crate::W<STG_SYSCFG_23_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_191_160` reader - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_191_160` reader - u0_pcie_axi4_mst0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_191_160(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_230.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_230.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_230_SPEC>;
 #[doc = "Register `stg_syscfg_230` writer"]
 pub type W = crate::W<STG_SYSCFG_230_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_out_pcie_511_480` reader - u1_plda_pcie_test_out_pcie_511_480"]
-pub type U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_test_out_pcie_511_480` reader - u1_pcie_test_out_pcie_511_480"]
+pub type U1_PCIE_TEST_OUT_PCIE_511_480_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u1_plda_pcie_test_out_pcie_511_480"]
+    #[doc = "Bits 0:31 - u1_pcie_test_out_pcie_511_480"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_out_pcie_511_480(&self) -> U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R {
-        U1_PLDA_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
+    pub fn u1_pcie_test_out_pcie_511_480(&self) -> U1_PCIE_TEST_OUT_PCIE_511_480_R {
+        U1_PCIE_TEST_OUT_PCIE_511_480_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_231.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_231.rs
@@ -2,40 +2,38 @@
 pub type R = crate::R<STG_SYSCFG_231_SPEC>;
 #[doc = "Register `stg_syscfg_231` writer"]
 pub type W = crate::W<STG_SYSCFG_231_SPEC>;
-#[doc = "Field `u1_plda_pcie_test_sel` reader - u1_plda_pcie_test_sel"]
-pub type U1_PLDA_PCIE_TEST_SEL_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_test_sel` writer - u1_plda_pcie_test_sel"]
-pub type U1_PLDA_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
-#[doc = "Field `u1_plda_pcie_tl_clock_freq` reader - u1_plda_pcie_tl_clock_freq"]
-pub type U1_PLDA_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
-#[doc = "Field `u1_plda_pcie_tl_clock_freq` writer - u1_plda_pcie_tl_clock_freq"]
-pub type U1_PLDA_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
+#[doc = "Field `u1_pcie_test_sel` reader - u1_pcie_test_sel"]
+pub type U1_PCIE_TEST_SEL_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_test_sel` writer - u1_pcie_test_sel"]
+pub type U1_PCIE_TEST_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u1_pcie_tl_clock_freq` reader - u1_pcie_tl_clock_freq"]
+pub type U1_PCIE_TL_CLOCK_FREQ_R = crate::FieldReader<u32>;
+#[doc = "Field `u1_pcie_tl_clock_freq` writer - u1_pcie_tl_clock_freq"]
+pub type U1_PCIE_TL_CLOCK_FREQ_W<'a, REG> = crate::FieldWriter<'a, REG, 22, u32>;
 impl R {
-    #[doc = "Bits 0:3 - u1_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u1_pcie_test_sel"]
     #[inline(always)]
-    pub fn u1_plda_pcie_test_sel(&self) -> U1_PLDA_PCIE_TEST_SEL_R {
-        U1_PLDA_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
+    pub fn u1_pcie_test_sel(&self) -> U1_PCIE_TEST_SEL_R {
+        U1_PCIE_TEST_SEL_R::new((self.bits & 0x0f) as u8)
     }
-    #[doc = "Bits 4:25 - u1_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u1_pcie_tl_clock_freq"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_clock_freq(&self) -> U1_PLDA_PCIE_TL_CLOCK_FREQ_R {
-        U1_PLDA_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
+    pub fn u1_pcie_tl_clock_freq(&self) -> U1_PCIE_TL_CLOCK_FREQ_R {
+        U1_PCIE_TL_CLOCK_FREQ_R::new((self.bits >> 4) & 0x003f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:3 - u1_plda_pcie_test_sel"]
+    #[doc = "Bits 0:3 - u1_pcie_test_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_test_sel(&mut self) -> U1_PLDA_PCIE_TEST_SEL_W<STG_SYSCFG_231_SPEC> {
-        U1_PLDA_PCIE_TEST_SEL_W::new(self, 0)
+    pub fn u1_pcie_test_sel(&mut self) -> U1_PCIE_TEST_SEL_W<STG_SYSCFG_231_SPEC> {
+        U1_PCIE_TEST_SEL_W::new(self, 0)
     }
-    #[doc = "Bits 4:25 - u1_plda_pcie_tl_clock_freq"]
+    #[doc = "Bits 4:25 - u1_pcie_tl_clock_freq"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tl_clock_freq(
-        &mut self,
-    ) -> U1_PLDA_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_231_SPEC> {
-        U1_PLDA_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
+    pub fn u1_pcie_tl_clock_freq(&mut self) -> U1_PCIE_TL_CLOCK_FREQ_W<STG_SYSCFG_231_SPEC> {
+        U1_PCIE_TL_CLOCK_FREQ_W::new(self, 4)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_232.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_232.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_232_SPEC>;
 #[doc = "Register `stg_syscfg_232` writer"]
 pub type W = crate::W<STG_SYSCFG_232_SPEC>;
-#[doc = "Field `u1_plda_pcie_tl_ctrl_hotplug` reader - u1_plda_pcie_tl_ctrl_hotplug"]
-pub type U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_tl_report_hotplug` reader - u1_plda_pcie_tl_report_hotplug"]
-pub type U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
-#[doc = "Field `u1_plda_pcie_tl_report_hotplug` writer - u1_plda_pcie_tl_report_hotplug"]
-pub type U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
+#[doc = "Field `u1_pcie_tl_ctrl_hotplug` reader - u1_pcie_tl_ctrl_hotplug"]
+pub type U1_PCIE_TL_CTRL_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_tl_report_hotplug` reader - u1_pcie_tl_report_hotplug"]
+pub type U1_PCIE_TL_REPORT_HOTPLUG_R = crate::FieldReader<u16>;
+#[doc = "Field `u1_pcie_tl_report_hotplug` writer - u1_pcie_tl_report_hotplug"]
+pub type U1_PCIE_TL_REPORT_HOTPLUG_W<'a, REG> = crate::FieldWriter<'a, REG, 16, u16>;
 impl R {
-    #[doc = "Bits 0:15 - u1_plda_pcie_tl_ctrl_hotplug"]
+    #[doc = "Bits 0:15 - u1_pcie_tl_ctrl_hotplug"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_ctrl_hotplug(&self) -> U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R {
-        U1_PLDA_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
+    pub fn u1_pcie_tl_ctrl_hotplug(&self) -> U1_PCIE_TL_CTRL_HOTPLUG_R {
+        U1_PCIE_TL_CTRL_HOTPLUG_R::new((self.bits & 0xffff) as u16)
     }
-    #[doc = "Bits 16:31 - u1_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u1_pcie_tl_report_hotplug"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tl_report_hotplug(&self) -> U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R {
-        U1_PLDA_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
+    pub fn u1_pcie_tl_report_hotplug(&self) -> U1_PCIE_TL_REPORT_HOTPLUG_R {
+        U1_PCIE_TL_REPORT_HOTPLUG_R::new(((self.bits >> 16) & 0xffff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 16:31 - u1_plda_pcie_tl_report_hotplug"]
+    #[doc = "Bits 16:31 - u1_pcie_tl_report_hotplug"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tl_report_hotplug(
+    pub fn u1_pcie_tl_report_hotplug(
         &mut self,
-    ) -> U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_232_SPEC> {
-        U1_PLDA_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
+    ) -> U1_PCIE_TL_REPORT_HOTPLUG_W<STG_SYSCFG_232_SPEC> {
+        U1_PCIE_TL_REPORT_HOTPLUG_W::new(self, 16)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_233.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_233.rs
@@ -2,118 +2,112 @@
 pub type R = crate::R<STG_SYSCFG_233_SPEC>;
 #[doc = "Register `stg_syscfg_233` writer"]
 pub type W = crate::W<STG_SYSCFG_233_SPEC>;
-#[doc = "Field `u1_plda_pcie_tx_pattern` reader - u1_plda_pcie_tx_pattern"]
-pub type U1_PLDA_PCIE_TX_PATTERN_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_tx_pattern` writer - u1_plda_pcie_tx_pattern"]
-pub type U1_PLDA_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_bus_width` reader - u1_plda_pcie_usb3_bus_width"]
-pub type U1_PLDA_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_usb3_bus_width` writer - u1_plda_pcie_usb3_bus_width"]
-pub type U1_PLDA_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_phy_enable` reader - u1_plda_pcie_usb3_phy_enable"]
-pub type U1_PLDA_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_usb3_phy_enable` writer - u1_plda_pcie_usb3_phy_enable"]
-pub type U1_PLDA_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_usb3_rate` reader - u1_plda_pcie_usb3_rate"]
-pub type U1_PLDA_PCIE_USB3_RATE_R = crate::FieldReader;
-#[doc = "Field `u1_plda_pcie_usb3_rate` writer - u1_plda_pcie_usb3_rate"]
-pub type U1_PLDA_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u1_plda_pcie_usb3_rx_standby` reader - u1_plda_pcie_usb3_rx_standby"]
-pub type U1_PLDA_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_usb3_rx_standby` writer - u1_plda_pcie_usb3_rx_standby"]
-pub type U1_PLDA_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_xwdecerr` reader - u1_plda_pcie_xwdecerr"]
-pub type U1_PLDA_PCIE_XWDECERR_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_xwerrclr` reader - u1_plda_pcie_xwerrclr"]
-pub type U1_PLDA_PCIE_XWERRCLR_R = crate::BitReader;
-#[doc = "Field `u1_plda_pcie_xwerrclr` writer - u1_plda_pcie_xwerrclr"]
-pub type U1_PLDA_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u1_plda_pcie_xwslverr` reader - u1_plda_pcie_xwslverr"]
-pub type U1_PLDA_PCIE_XWSLVERR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_tx_pattern` reader - u1_pcie_tx_pattern"]
+pub type U1_PCIE_TX_PATTERN_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_tx_pattern` writer - u1_pcie_tx_pattern"]
+pub type U1_PCIE_TX_PATTERN_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_bus_width` reader - u1_pcie_usb3_bus_width"]
+pub type U1_PCIE_USB3_BUS_WIDTH_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_usb3_bus_width` writer - u1_pcie_usb3_bus_width"]
+pub type U1_PCIE_USB3_BUS_WIDTH_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_phy_enable` reader - u1_pcie_usb3_phy_enable"]
+pub type U1_PCIE_USB3_PHY_ENABLE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_usb3_phy_enable` writer - u1_pcie_usb3_phy_enable"]
+pub type U1_PCIE_USB3_PHY_ENABLE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_usb3_rate` reader - u1_pcie_usb3_rate"]
+pub type U1_PCIE_USB3_RATE_R = crate::FieldReader;
+#[doc = "Field `u1_pcie_usb3_rate` writer - u1_pcie_usb3_rate"]
+pub type U1_PCIE_USB3_RATE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u1_pcie_usb3_rx_standby` reader - u1_pcie_usb3_rx_standby"]
+pub type U1_PCIE_USB3_RX_STANDBY_R = crate::BitReader;
+#[doc = "Field `u1_pcie_usb3_rx_standby` writer - u1_pcie_usb3_rx_standby"]
+pub type U1_PCIE_USB3_RX_STANDBY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_xwdecerr` reader - u1_pcie_xwdecerr"]
+pub type U1_PCIE_XWDECERR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_xwerrclr` reader - u1_pcie_xwerrclr"]
+pub type U1_PCIE_XWERRCLR_R = crate::BitReader;
+#[doc = "Field `u1_pcie_xwerrclr` writer - u1_pcie_xwerrclr"]
+pub type U1_PCIE_XWERRCLR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_xwslverr` reader - u1_pcie_xwslverr"]
+pub type U1_PCIE_XWSLVERR_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:1 - u1_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u1_pcie_tx_pattern"]
     #[inline(always)]
-    pub fn u1_plda_pcie_tx_pattern(&self) -> U1_PLDA_PCIE_TX_PATTERN_R {
-        U1_PLDA_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
+    pub fn u1_pcie_tx_pattern(&self) -> U1_PCIE_TX_PATTERN_R {
+        U1_PCIE_TX_PATTERN_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:3 - u1_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u1_pcie_usb3_bus_width"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_bus_width(&self) -> U1_PLDA_PCIE_USB3_BUS_WIDTH_R {
-        U1_PLDA_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
+    pub fn u1_pcie_usb3_bus_width(&self) -> U1_PCIE_USB3_BUS_WIDTH_R {
+        U1_PCIE_USB3_BUS_WIDTH_R::new(((self.bits >> 2) & 3) as u8)
     }
-    #[doc = "Bit 4 - u1_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u1_pcie_usb3_phy_enable"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_phy_enable(&self) -> U1_PLDA_PCIE_USB3_PHY_ENABLE_R {
-        U1_PLDA_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u1_pcie_usb3_phy_enable(&self) -> U1_PCIE_USB3_PHY_ENABLE_R {
+        U1_PCIE_USB3_PHY_ENABLE_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bits 5:6 - u1_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u1_pcie_usb3_rate"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_rate(&self) -> U1_PLDA_PCIE_USB3_RATE_R {
-        U1_PLDA_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
+    pub fn u1_pcie_usb3_rate(&self) -> U1_PCIE_USB3_RATE_R {
+        U1_PCIE_USB3_RATE_R::new(((self.bits >> 5) & 3) as u8)
     }
-    #[doc = "Bit 7 - u1_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u1_pcie_usb3_rx_standby"]
     #[inline(always)]
-    pub fn u1_plda_pcie_usb3_rx_standby(&self) -> U1_PLDA_PCIE_USB3_RX_STANDBY_R {
-        U1_PLDA_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_pcie_usb3_rx_standby(&self) -> U1_PCIE_USB3_RX_STANDBY_R {
+        U1_PCIE_USB3_RX_STANDBY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u1_plda_pcie_xwdecerr"]
+    #[doc = "Bit 8 - u1_pcie_xwdecerr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwdecerr(&self) -> U1_PLDA_PCIE_XWDECERR_R {
-        U1_PLDA_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_pcie_xwdecerr(&self) -> U1_PCIE_XWDECERR_R {
+        U1_PCIE_XWDECERR_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u1_pcie_xwerrclr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwerrclr(&self) -> U1_PLDA_PCIE_XWERRCLR_R {
-        U1_PLDA_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u1_pcie_xwerrclr(&self) -> U1_PCIE_XWERRCLR_R {
+        U1_PCIE_XWERRCLR_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u1_plda_pcie_xwslverr"]
+    #[doc = "Bit 10 - u1_pcie_xwslverr"]
     #[inline(always)]
-    pub fn u1_plda_pcie_xwslverr(&self) -> U1_PLDA_PCIE_XWSLVERR_R {
-        U1_PLDA_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u1_pcie_xwslverr(&self) -> U1_PCIE_XWSLVERR_R {
+        U1_PCIE_XWSLVERR_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u1_plda_pcie_tx_pattern"]
+    #[doc = "Bits 0:1 - u1_pcie_tx_pattern"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_tx_pattern(&mut self) -> U1_PLDA_PCIE_TX_PATTERN_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_TX_PATTERN_W::new(self, 0)
+    pub fn u1_pcie_tx_pattern(&mut self) -> U1_PCIE_TX_PATTERN_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_TX_PATTERN_W::new(self, 0)
     }
-    #[doc = "Bits 2:3 - u1_plda_pcie_usb3_bus_width"]
+    #[doc = "Bits 2:3 - u1_pcie_usb3_bus_width"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_bus_width(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
+    pub fn u1_pcie_usb3_bus_width(&mut self) -> U1_PCIE_USB3_BUS_WIDTH_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_BUS_WIDTH_W::new(self, 2)
     }
-    #[doc = "Bit 4 - u1_plda_pcie_usb3_phy_enable"]
+    #[doc = "Bit 4 - u1_pcie_usb3_phy_enable"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_phy_enable(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
+    pub fn u1_pcie_usb3_phy_enable(&mut self) -> U1_PCIE_USB3_PHY_ENABLE_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_PHY_ENABLE_W::new(self, 4)
     }
-    #[doc = "Bits 5:6 - u1_plda_pcie_usb3_rate"]
+    #[doc = "Bits 5:6 - u1_pcie_usb3_rate"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_rate(&mut self) -> U1_PLDA_PCIE_USB3_RATE_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_RATE_W::new(self, 5)
+    pub fn u1_pcie_usb3_rate(&mut self) -> U1_PCIE_USB3_RATE_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_RATE_W::new(self, 5)
     }
-    #[doc = "Bit 7 - u1_plda_pcie_usb3_rx_standby"]
+    #[doc = "Bit 7 - u1_pcie_usb3_rx_standby"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_usb3_rx_standby(
-        &mut self,
-    ) -> U1_PLDA_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_USB3_RX_STANDBY_W::new(self, 7)
+    pub fn u1_pcie_usb3_rx_standby(&mut self) -> U1_PCIE_USB3_RX_STANDBY_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_USB3_RX_STANDBY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u1_plda_pcie_xwerrclr"]
+    #[doc = "Bit 9 - u1_pcie_xwerrclr"]
     #[inline(always)]
     #[must_use]
-    pub fn u1_plda_pcie_xwerrclr(&mut self) -> U1_PLDA_PCIE_XWERRCLR_W<STG_SYSCFG_233_SPEC> {
-        U1_PLDA_PCIE_XWERRCLR_W::new(self, 9)
+    pub fn u1_pcie_xwerrclr(&mut self) -> U1_PCIE_XWERRCLR_W<STG_SYSCFG_233_SPEC> {
+        U1_PCIE_XWERRCLR_W::new(self, 9)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_24.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_24.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_24_SPEC>;
 #[doc = "Register `stg_syscfg_24` writer"]
 pub type W = crate::W<STG_SYSCFG_24_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_223_192` reader - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_223_192` reader - u0_pcie_axi4_mst0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_223_192(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_25.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_25.rs
@@ -2,15 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_25_SPEC>;
 #[doc = "Register `stg_syscfg_25` writer"]
 pub type W = crate::W<STG_SYSCFG_25_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_255_224` reader - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_255_224` reader - u0_pcie_axi4_mst0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aratomop_255_224(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_26.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_26.rs
@@ -2,29 +2,27 @@
 pub type R = crate::R<STG_SYSCFG_26_SPEC>;
 #[doc = "Register `stg_syscfg_26` writer"]
 pub type W = crate::W<STG_SYSCFG_26_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aratomop_257_256` reader - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arfunc` reader - u0_plda_pcie_axi4_mst0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_arregion` reader - u0_plda_pcie_axi4_mst0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_aratomop_257_256` reader - u0_pcie_axi4_mst0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_arfunc` reader - u0_pcie_axi4_mst0_arfunc"]
+pub type U0_PCIE_AXI4_MST0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_arregion` reader - u0_pcie_axi4_mst0_arregion"]
+pub type U0_PCIE_AXI4_MST0_ARREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_mst0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_mst0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_mst0_aratomop_257_256(&self) -> U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_MST0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_mst0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_mst0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_arfunc(&self) -> U0_PCIE_AXI4_MST0_ARFUNC_R {
+        U0_PCIE_AXI4_MST0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_mst0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_mst0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_arregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_arregion(&self) -> U0_PCIE_AXI4_MST0_ARREGION_R {
+        U0_PCIE_AXI4_MST0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_27.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_27.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_27_SPEC>;
 #[doc = "Register `stg_syscfg_27` writer"]
 pub type W = crate::W<STG_SYSCFG_27_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aruser_31_0` reader - u0_plda_pcie_axi4_mst0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aruser_31_0` reader - u0_pcie_axi4_mst0_aruser_31_0"]
+pub type U0_PCIE_AXI4_MST0_ARUSER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aruser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aruser_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aruser_31_0(&self) -> U0_PCIE_AXI4_MST0_ARUSER_31_0_R {
+        U0_PCIE_AXI4_MST0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_28.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_28.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_28_SPEC>;
 #[doc = "Register `stg_syscfg_28` writer"]
 pub type W = crate::W<STG_SYSCFG_28_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_aruser_63_32` reader - u0_plda_pcie_axi4_mst0_aruser_63_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_aruser_63_32` reader - u0_pcie_axi4_mst0_aruser_63_32"]
+pub type U0_PCIE_AXI4_MST0_ARUSER_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_aruser_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_aruser_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_aruser_63_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_ARUSER_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_aruser_63_32(&self) -> U0_PCIE_AXI4_MST0_ARUSER_63_32_R {
+        U0_PCIE_AXI4_MST0_ARUSER_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_29.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_29.rs
@@ -2,20 +2,20 @@
 pub type R = crate::R<STG_SYSCFG_29_SPEC>;
 #[doc = "Register `stg_syscfg_29` writer"]
 pub type W = crate::W<STG_SYSCFG_29_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awfunc` reader - u0_plda_pcie_axi4_mst0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awregion` reader - u0_plda_pcie_axi4_mst0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_awfunc` reader - u0_pcie_axi4_mst0_awfunc"]
+pub type U0_PCIE_AXI4_MST0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_awregion` reader - u0_pcie_axi4_mst0_awregion"]
+pub type U0_PCIE_AXI4_MST0_AWREGION_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_mst0_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_mst0_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awfunc(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_mst0_awfunc(&self) -> U0_PCIE_AXI4_MST0_AWFUNC_R {
+        U0_PCIE_AXI4_MST0_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:18 - u0_plda_pcie_axi4_mst0_awregion"]
+    #[doc = "Bits 15:18 - u0_pcie_axi4_mst0_awregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awregion(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWREGION_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_mst0_awregion(&self) -> U0_PCIE_AXI4_MST0_AWREGION_R {
+        U0_PCIE_AXI4_MST0_AWREGION_R::new(((self.bits >> 15) & 0x0f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_3.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_3.rs
@@ -2,231 +2,223 @@
 pub type R = crate::R<STG_SYSCFG_3_SPEC>;
 #[doc = "Register `stg_syscfg_3` writer"]
 pub type W = crate::W<STG_SYSCFG_3_SPEC>;
-#[doc = "Field `u0_cdn_usb_utmi_rxvalidh_sit` reader - u0_cdn_usb_utmi_rxvalidh_sit"]
-pub type U0_CDN_USB_UTMI_RXVALIDH_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_sessvld` reader - u0_cdn_usb_utmi_sessvld"]
-pub type U0_CDN_USB_UTMI_SESSVLD_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_sessvld` writer - u0_cdn_usb_utmi_sessvld"]
-pub type U0_CDN_USB_UTMI_SESSVLD_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_termselect_sit` reader - u0_cdn_usb_utmi_termselect_sit"]
-pub type U0_CDN_USB_UTMI_TERMSELECT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_termselect_sit` writer - u0_cdn_usb_utmi_termselect_sit"]
-pub type U0_CDN_USB_UTMI_TERMSELECT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_dat_sit` reader - u0_cdn_usb_utmi_tx_dat_sit"]
-pub type U0_CDN_USB_UTMI_TX_DAT_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_dat_sit` writer - u0_cdn_usb_utmi_tx_dat_sit"]
-pub type U0_CDN_USB_UTMI_TX_DAT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_enable_n_sit` reader - u0_cdn_usb_utmi_tx_enable_n_sit"]
-pub type U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_enable_n_sit` writer - u0_cdn_usb_utmi_tx_enable_n_sit"]
-pub type U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_tx_se0_sit` reader - u0_cdn_usb_utmi_tx_se0_sit"]
-pub type U0_CDN_USB_UTMI_TX_SE0_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_tx_se0_sit` writer - u0_cdn_usb_utmi_tx_se0_sit"]
-pub type U0_CDN_USB_UTMI_TX_SE0_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txbitstuffenable_sit` reader - u0_cdn_usb_utmi_txbitstuffenable_sit"]
-pub type U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txbitstuffenable_sit` writer - u0_cdn_usb_utmi_txbitstuffenable_sit"]
-pub type U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txready_sit` reader - u0_cdn_usb_utmi_txready_sit"]
-pub type U0_CDN_USB_UTMI_TXREADY_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalid_sit` reader - u0_cdn_usb_utmi_txvalid_sit"]
-pub type U0_CDN_USB_UTMI_TXVALID_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalid_sit` writer - u0_cdn_usb_utmi_txvalid_sit"]
-pub type U0_CDN_USB_UTMI_TXVALID_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_txvalidh_sit` reader - u0_cdn_usb_utmi_txvalidh_sit"]
-pub type U0_CDN_USB_UTMI_TXVALIDH_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_txvalidh_sit` writer - u0_cdn_usb_utmi_txvalidh_sit"]
-pub type U0_CDN_USB_UTMI_TXVALIDH_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_utmi_vbusvalid_sit` reader - u0_cdn_usb_utmi_vbusvalid_sit"]
-pub type U0_CDN_USB_UTMI_VBUSVALID_SIT_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_xcvrselect_sit` reader - u0_cdn_usb_utmi_xcvrselect_sit"]
-pub type U0_CDN_USB_UTMI_XCVRSELECT_SIT_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_utmi_xcvrselect_sit` writer - u0_cdn_usb_utmi_xcvrselect_sit"]
-pub type U0_CDN_USB_UTMI_XCVRSELECT_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_cdn_usb_utmi_vdm_src_en` reader - u0_cdn_usb_utmi_vdm_src_en"]
-pub type U0_CDN_USB_UTMI_VDM_SRC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_utmi_vdp_src_en` reader - u0_cdn_usb_utmi_vdp_src_en"]
-pub type U0_CDN_USB_UTMI_VDP_SRC_EN_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_wakeup` reader - u0_cdn_usb_wakeup"]
-pub type U0_CDN_USB_WAKEUP_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_wakeup` writer - u0_cdn_usb_wakeup"]
-pub type U0_CDN_USB_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhc_d0_ack` reader - u0_cdn_usb_xhc_d0_ack"]
-pub type U0_CDN_USB_XHC_D0_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhc_d0_req` reader - u0_cdn_usb_xhc_d0_req"]
-pub type U0_CDN_USB_XHC_D0_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhc_d0_req` writer - u0_cdn_usb_xhc_d0_req"]
-pub type U0_CDN_USB_XHC_D0_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_rxvalidh_sit` reader - u0_usb_utmi_rxvalidh_sit"]
+pub type U0_USB_UTMI_RXVALIDH_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_sessvld` reader - u0_usb_utmi_sessvld"]
+pub type U0_USB_UTMI_SESSVLD_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_sessvld` writer - u0_usb_utmi_sessvld"]
+pub type U0_USB_UTMI_SESSVLD_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_termselect_sit` reader - u0_usb_utmi_termselect_sit"]
+pub type U0_USB_UTMI_TERMSELECT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_termselect_sit` writer - u0_usb_utmi_termselect_sit"]
+pub type U0_USB_UTMI_TERMSELECT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_dat_sit` reader - u0_usb_utmi_tx_dat_sit"]
+pub type U0_USB_UTMI_TX_DAT_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_dat_sit` writer - u0_usb_utmi_tx_dat_sit"]
+pub type U0_USB_UTMI_TX_DAT_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_enable_n_sit` reader - u0_usb_utmi_tx_enable_n_sit"]
+pub type U0_USB_UTMI_TX_ENABLE_N_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_enable_n_sit` writer - u0_usb_utmi_tx_enable_n_sit"]
+pub type U0_USB_UTMI_TX_ENABLE_N_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_tx_se0_sit` reader - u0_usb_utmi_tx_se0_sit"]
+pub type U0_USB_UTMI_TX_SE0_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_tx_se0_sit` writer - u0_usb_utmi_tx_se0_sit"]
+pub type U0_USB_UTMI_TX_SE0_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txbitstuffenable_sit` reader - u0_usb_utmi_txbitstuffenable_sit"]
+pub type U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txbitstuffenable_sit` writer - u0_usb_utmi_txbitstuffenable_sit"]
+pub type U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txready_sit` reader - u0_usb_utmi_txready_sit"]
+pub type U0_USB_UTMI_TXREADY_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalid_sit` reader - u0_usb_utmi_txvalid_sit"]
+pub type U0_USB_UTMI_TXVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalid_sit` writer - u0_usb_utmi_txvalid_sit"]
+pub type U0_USB_UTMI_TXVALID_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_txvalidh_sit` reader - u0_usb_utmi_txvalidh_sit"]
+pub type U0_USB_UTMI_TXVALIDH_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_txvalidh_sit` writer - u0_usb_utmi_txvalidh_sit"]
+pub type U0_USB_UTMI_TXVALIDH_SIT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_vbusvalid_sit` reader - u0_usb_utmi_vbusvalid_sit"]
+pub type U0_USB_UTMI_VBUSVALID_SIT_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_xcvrselect_sit` reader - u0_usb_utmi_xcvrselect_sit"]
+pub type U0_USB_UTMI_XCVRSELECT_SIT_R = crate::FieldReader;
+#[doc = "Field `u0_usb_utmi_xcvrselect_sit` writer - u0_usb_utmi_xcvrselect_sit"]
+pub type U0_USB_UTMI_XCVRSELECT_SIT_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_usb_utmi_vdm_src_en` reader - u0_usb_utmi_vdm_src_en"]
+pub type U0_USB_UTMI_VDM_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_vdp_src_en` reader - u0_usb_utmi_vdp_src_en"]
+pub type U0_USB_UTMI_VDP_SRC_EN_R = crate::BitReader;
+#[doc = "Field `u0_usb_wakeup` reader - u0_usb_wakeup"]
+pub type U0_USB_WAKEUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_wakeup` writer - u0_usb_wakeup"]
+pub type U0_USB_WAKEUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhc_d0_ack` reader - u0_usb_xhc_d0_ack"]
+pub type U0_USB_XHC_D0_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhc_d0_req` reader - u0_usb_xhc_d0_req"]
+pub type U0_USB_XHC_D0_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhc_d0_req` writer - u0_usb_xhc_d0_req"]
+pub type U0_USB_XHC_D0_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u0_cdn_usb_utmi_rxvalidh_sit"]
+    #[doc = "Bit 0 - u0_usb_utmi_rxvalidh_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_rxvalidh_sit(&self) -> U0_CDN_USB_UTMI_RXVALIDH_SIT_R {
-        U0_CDN_USB_UTMI_RXVALIDH_SIT_R::new((self.bits & 1) != 0)
+    pub fn u0_usb_utmi_rxvalidh_sit(&self) -> U0_USB_UTMI_RXVALIDH_SIT_R {
+        U0_USB_UTMI_RXVALIDH_SIT_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_cdn_usb_utmi_sessvld"]
+    #[doc = "Bit 1 - u0_usb_utmi_sessvld"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_sessvld(&self) -> U0_CDN_USB_UTMI_SESSVLD_R {
-        U0_CDN_USB_UTMI_SESSVLD_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_usb_utmi_sessvld(&self) -> U0_USB_UTMI_SESSVLD_R {
+        U0_USB_UTMI_SESSVLD_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_cdn_usb_utmi_termselect_sit"]
+    #[doc = "Bit 2 - u0_usb_utmi_termselect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_termselect_sit(&self) -> U0_CDN_USB_UTMI_TERMSELECT_SIT_R {
-        U0_CDN_USB_UTMI_TERMSELECT_SIT_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_usb_utmi_termselect_sit(&self) -> U0_USB_UTMI_TERMSELECT_SIT_R {
+        U0_USB_UTMI_TERMSELECT_SIT_R::new(((self.bits >> 2) & 1) != 0)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_utmi_tx_dat_sit"]
+    #[doc = "Bit 3 - u0_usb_utmi_tx_dat_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_dat_sit(&self) -> U0_CDN_USB_UTMI_TX_DAT_SIT_R {
-        U0_CDN_USB_UTMI_TX_DAT_SIT_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_usb_utmi_tx_dat_sit(&self) -> U0_USB_UTMI_TX_DAT_SIT_R {
+        U0_USB_UTMI_TX_DAT_SIT_R::new(((self.bits >> 3) & 1) != 0)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_utmi_tx_enable_n_sit"]
+    #[doc = "Bit 4 - u0_usb_utmi_tx_enable_n_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_enable_n_sit(&self) -> U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R {
-        U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_usb_utmi_tx_enable_n_sit(&self) -> U0_USB_UTMI_TX_ENABLE_N_SIT_R {
+        U0_USB_UTMI_TX_ENABLE_N_SIT_R::new(((self.bits >> 4) & 1) != 0)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_utmi_tx_se0_sit"]
+    #[doc = "Bit 5 - u0_usb_utmi_tx_se0_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_tx_se0_sit(&self) -> U0_CDN_USB_UTMI_TX_SE0_SIT_R {
-        U0_CDN_USB_UTMI_TX_SE0_SIT_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_utmi_tx_se0_sit(&self) -> U0_USB_UTMI_TX_SE0_SIT_R {
+        U0_USB_UTMI_TX_SE0_SIT_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_utmi_txbitstuffenable_sit"]
+    #[doc = "Bit 6 - u0_usb_utmi_txbitstuffenable_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txbitstuffenable_sit(&self) -> U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R {
-        U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_utmi_txbitstuffenable_sit(&self) -> U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R {
+        U0_USB_UTMI_TXBITSTUFFENABLE_SIT_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_utmi_txready_sit"]
+    #[doc = "Bit 7 - u0_usb_utmi_txready_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txready_sit(&self) -> U0_CDN_USB_UTMI_TXREADY_SIT_R {
-        U0_CDN_USB_UTMI_TXREADY_SIT_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_utmi_txready_sit(&self) -> U0_USB_UTMI_TXREADY_SIT_R {
+        U0_USB_UTMI_TXREADY_SIT_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_utmi_txvalid_sit"]
+    #[doc = "Bit 8 - u0_usb_utmi_txvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txvalid_sit(&self) -> U0_CDN_USB_UTMI_TXVALID_SIT_R {
-        U0_CDN_USB_UTMI_TXVALID_SIT_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_utmi_txvalid_sit(&self) -> U0_USB_UTMI_TXVALID_SIT_R {
+        U0_USB_UTMI_TXVALID_SIT_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_utmi_txvalidh_sit"]
+    #[doc = "Bit 9 - u0_usb_utmi_txvalidh_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_txvalidh_sit(&self) -> U0_CDN_USB_UTMI_TXVALIDH_SIT_R {
-        U0_CDN_USB_UTMI_TXVALIDH_SIT_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_txvalidh_sit(&self) -> U0_USB_UTMI_TXVALIDH_SIT_R {
+        U0_USB_UTMI_TXVALIDH_SIT_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_utmi_vbusvalid_sit"]
+    #[doc = "Bit 10 - u0_usb_utmi_vbusvalid_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vbusvalid_sit(&self) -> U0_CDN_USB_UTMI_VBUSVALID_SIT_R {
-        U0_CDN_USB_UTMI_VBUSVALID_SIT_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_utmi_vbusvalid_sit(&self) -> U0_USB_UTMI_VBUSVALID_SIT_R {
+        U0_USB_UTMI_VBUSVALID_SIT_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bits 11:12 - u0_cdn_usb_utmi_xcvrselect_sit"]
+    #[doc = "Bits 11:12 - u0_usb_utmi_xcvrselect_sit"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_xcvrselect_sit(&self) -> U0_CDN_USB_UTMI_XCVRSELECT_SIT_R {
-        U0_CDN_USB_UTMI_XCVRSELECT_SIT_R::new(((self.bits >> 11) & 3) as u8)
+    pub fn u0_usb_utmi_xcvrselect_sit(&self) -> U0_USB_UTMI_XCVRSELECT_SIT_R {
+        U0_USB_UTMI_XCVRSELECT_SIT_R::new(((self.bits >> 11) & 3) as u8)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_utmi_vdm_src_en"]
+    #[doc = "Bit 13 - u0_usb_utmi_vdm_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vdm_src_en(&self) -> U0_CDN_USB_UTMI_VDM_SRC_EN_R {
-        U0_CDN_USB_UTMI_VDM_SRC_EN_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_utmi_vdm_src_en(&self) -> U0_USB_UTMI_VDM_SRC_EN_R {
+        U0_USB_UTMI_VDM_SRC_EN_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_utmi_vdp_src_en"]
+    #[doc = "Bit 14 - u0_usb_utmi_vdp_src_en"]
     #[inline(always)]
-    pub fn u0_cdn_usb_utmi_vdp_src_en(&self) -> U0_CDN_USB_UTMI_VDP_SRC_EN_R {
-        U0_CDN_USB_UTMI_VDP_SRC_EN_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_utmi_vdp_src_en(&self) -> U0_USB_UTMI_VDP_SRC_EN_R {
+        U0_USB_UTMI_VDP_SRC_EN_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_wakeup"]
+    #[doc = "Bit 15 - u0_usb_wakeup"]
     #[inline(always)]
-    pub fn u0_cdn_usb_wakeup(&self) -> U0_CDN_USB_WAKEUP_R {
-        U0_CDN_USB_WAKEUP_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_wakeup(&self) -> U0_USB_WAKEUP_R {
+        U0_USB_WAKEUP_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_cdn_usb_xhc_d0_ack"]
+    #[doc = "Bit 16 - u0_usb_xhc_d0_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhc_d0_ack(&self) -> U0_CDN_USB_XHC_D0_ACK_R {
-        U0_CDN_USB_XHC_D0_ACK_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_usb_xhc_d0_ack(&self) -> U0_USB_XHC_D0_ACK_R {
+        U0_USB_XHC_D0_ACK_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_cdn_usb_xhc_d0_req"]
+    #[doc = "Bit 17 - u0_usb_xhc_d0_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhc_d0_req(&self) -> U0_CDN_USB_XHC_D0_REQ_R {
-        U0_CDN_USB_XHC_D0_REQ_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_usb_xhc_d0_req(&self) -> U0_USB_XHC_D0_REQ_R {
+        U0_USB_XHC_D0_REQ_R::new(((self.bits >> 17) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 1 - u0_cdn_usb_utmi_sessvld"]
+    #[doc = "Bit 1 - u0_usb_utmi_sessvld"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_sessvld(&mut self) -> U0_CDN_USB_UTMI_SESSVLD_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_SESSVLD_W::new(self, 1)
+    pub fn u0_usb_utmi_sessvld(&mut self) -> U0_USB_UTMI_SESSVLD_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_SESSVLD_W::new(self, 1)
     }
-    #[doc = "Bit 2 - u0_cdn_usb_utmi_termselect_sit"]
+    #[doc = "Bit 2 - u0_usb_utmi_termselect_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_termselect_sit(
+    pub fn u0_usb_utmi_termselect_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TERMSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TERMSELECT_SIT_W::new(self, 2)
+    ) -> U0_USB_UTMI_TERMSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TERMSELECT_SIT_W::new(self, 2)
     }
-    #[doc = "Bit 3 - u0_cdn_usb_utmi_tx_dat_sit"]
+    #[doc = "Bit 3 - u0_usb_utmi_tx_dat_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_dat_sit(
+    pub fn u0_usb_utmi_tx_dat_sit(&mut self) -> U0_USB_UTMI_TX_DAT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_DAT_SIT_W::new(self, 3)
+    }
+    #[doc = "Bit 4 - u0_usb_utmi_tx_enable_n_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_tx_enable_n_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_DAT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_DAT_SIT_W::new(self, 3)
+    ) -> U0_USB_UTMI_TX_ENABLE_N_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_ENABLE_N_SIT_W::new(self, 4)
     }
-    #[doc = "Bit 4 - u0_cdn_usb_utmi_tx_enable_n_sit"]
+    #[doc = "Bit 5 - u0_usb_utmi_tx_se0_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_enable_n_sit(
+    pub fn u0_usb_utmi_tx_se0_sit(&mut self) -> U0_USB_UTMI_TX_SE0_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TX_SE0_SIT_W::new(self, 5)
+    }
+    #[doc = "Bit 6 - u0_usb_utmi_txbitstuffenable_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_txbitstuffenable_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_ENABLE_N_SIT_W::new(self, 4)
+    ) -> U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXBITSTUFFENABLE_SIT_W::new(self, 6)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_utmi_tx_se0_sit"]
+    #[doc = "Bit 8 - u0_usb_utmi_txvalid_sit"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_tx_se0_sit(
+    pub fn u0_usb_utmi_txvalid_sit(&mut self) -> U0_USB_UTMI_TXVALID_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXVALID_SIT_W::new(self, 8)
+    }
+    #[doc = "Bit 9 - u0_usb_utmi_txvalidh_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_txvalidh_sit(&mut self) -> U0_USB_UTMI_TXVALIDH_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_TXVALIDH_SIT_W::new(self, 9)
+    }
+    #[doc = "Bits 11:12 - u0_usb_utmi_xcvrselect_sit"]
+    #[inline(always)]
+    #[must_use]
+    pub fn u0_usb_utmi_xcvrselect_sit(
         &mut self,
-    ) -> U0_CDN_USB_UTMI_TX_SE0_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TX_SE0_SIT_W::new(self, 5)
+    ) -> U0_USB_UTMI_XCVRSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_UTMI_XCVRSELECT_SIT_W::new(self, 11)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_utmi_txbitstuffenable_sit"]
+    #[doc = "Bit 15 - u0_usb_wakeup"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_txbitstuffenable_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXBITSTUFFENABLE_SIT_W::new(self, 6)
+    pub fn u0_usb_wakeup(&mut self) -> U0_USB_WAKEUP_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_WAKEUP_W::new(self, 15)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_utmi_txvalid_sit"]
+    #[doc = "Bit 17 - u0_usb_xhc_d0_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_utmi_txvalid_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXVALID_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXVALID_SIT_W::new(self, 8)
-    }
-    #[doc = "Bit 9 - u0_cdn_usb_utmi_txvalidh_sit"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_utmi_txvalidh_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_TXVALIDH_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_TXVALIDH_SIT_W::new(self, 9)
-    }
-    #[doc = "Bits 11:12 - u0_cdn_usb_utmi_xcvrselect_sit"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_utmi_xcvrselect_sit(
-        &mut self,
-    ) -> U0_CDN_USB_UTMI_XCVRSELECT_SIT_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_UTMI_XCVRSELECT_SIT_W::new(self, 11)
-    }
-    #[doc = "Bit 15 - u0_cdn_usb_wakeup"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_wakeup(&mut self) -> U0_CDN_USB_WAKEUP_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_WAKEUP_W::new(self, 15)
-    }
-    #[doc = "Bit 17 - u0_cdn_usb_xhc_d0_req"]
-    #[inline(always)]
-    #[must_use]
-    pub fn u0_cdn_usb_xhc_d0_req(&mut self) -> U0_CDN_USB_XHC_D0_REQ_W<STG_SYSCFG_3_SPEC> {
-        U0_CDN_USB_XHC_D0_REQ_W::new(self, 17)
+    pub fn u0_usb_xhc_d0_req(&mut self) -> U0_USB_XHC_D0_REQ_W<STG_SYSCFG_3_SPEC> {
+        U0_USB_XHC_D0_REQ_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_30.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_30.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_30_SPEC>;
 #[doc = "Register `stg_syscfg_30` writer"]
 pub type W = crate::W<STG_SYSCFG_30_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_a2user_31_0` reader - u0_plda_pcie_axi4_mst0_a2user_31_0"]
-pub type U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_a2user_31_0` reader - u0_pcie_axi4_mst0_a2user_31_0"]
+pub type U0_PCIE_AXI4_MST0_A2USER_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_a2user_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_a2user_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_a2user_31_0(&self) -> U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R {
-        U0_PLDA_PCIE_AXI4_MST0_A2USER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_a2user_31_0(&self) -> U0_PCIE_AXI4_MST0_A2USER_31_0_R {
+        U0_PCIE_AXI4_MST0_A2USER_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_31.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_31.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_31_SPEC>;
 #[doc = "Register `stg_syscfg_31` writer"]
 pub type W = crate::W<STG_SYSCFG_31_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_awuser_42_32` reader - u0_plda_pcie_axi4_mst0_awuser_42_32"]
-pub type U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_rderr` reader - u0_plda_pcie_axi4_mst0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_rderr` writer - u0_plda_pcie_axi4_mst0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_axi4_mst0_awuser_42_32` reader - u0_pcie_axi4_mst0_awuser_42_32"]
+pub type U0_PCIE_AXI4_MST0_AWUSER_42_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_mst0_rderr` reader - u0_pcie_axi4_mst0_rderr"]
+pub type U0_PCIE_AXI4_MST0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_rderr` writer - u0_pcie_axi4_mst0_rderr"]
+pub type U0_PCIE_AXI4_MST0_RDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
 impl R {
-    #[doc = "Bits 0:10 - u0_plda_pcie_axi4_mst0_awuser_42_32"]
+    #[doc = "Bits 0:10 - u0_pcie_axi4_mst0_awuser_42_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_awuser_42_32(&self) -> U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R {
-        U0_PLDA_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
+    pub fn u0_pcie_axi4_mst0_awuser_42_32(&self) -> U0_PCIE_AXI4_MST0_AWUSER_42_32_R {
+        U0_PCIE_AXI4_MST0_AWUSER_42_32_R::new((self.bits & 0x07ff) as u16)
     }
-    #[doc = "Bits 11:18 - u0_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u0_pcie_axi4_mst0_rderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_rderr(&self) -> U0_PLDA_PCIE_AXI4_MST0_RDERR_R {
-        U0_PLDA_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
+    pub fn u0_pcie_axi4_mst0_rderr(&self) -> U0_PCIE_AXI4_MST0_RDERR_R {
+        U0_PCIE_AXI4_MST0_RDERR_R::new(((self.bits >> 11) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 11:18 - u0_plda_pcie_axi4_mst0_rderr"]
+    #[doc = "Bits 11:18 - u0_pcie_axi4_mst0_rderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_mst0_rderr(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_31_SPEC> {
-        U0_PLDA_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
+    pub fn u0_pcie_axi4_mst0_rderr(&mut self) -> U0_PCIE_AXI4_MST0_RDERR_W<STG_SYSCFG_31_SPEC> {
+        U0_PCIE_AXI4_MST0_RDERR_W::new(self, 11)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_32.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_32.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_32_SPEC>;
 #[doc = "Register `stg_syscfg_32` writer"]
 pub type W = crate::W<STG_SYSCFG_32_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_ruser` reader - u0_plda_pcie_axi4_mst0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_ruser` writer - u0_plda_pcie_axi4_mst0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_ruser` reader - u0_pcie_axi4_mst0_ruser"]
+pub type U0_PCIE_AXI4_MST0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_mst0_ruser` writer - u0_pcie_axi4_mst0_ruser"]
+pub type U0_PCIE_AXI4_MST0_RUSER_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_ruser"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_ruser(&self) -> U0_PLDA_PCIE_AXI4_MST0_RUSER_R {
-        U0_PLDA_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
+    pub fn u0_pcie_axi4_mst0_ruser(&self) -> U0_PCIE_AXI4_MST0_RUSER_R {
+        U0_PCIE_AXI4_MST0_RUSER_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_mst0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_mst0_ruser"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_mst0_ruser(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_32_SPEC> {
-        U0_PLDA_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
+    pub fn u0_pcie_axi4_mst0_ruser(&mut self) -> U0_PCIE_AXI4_MST0_RUSER_W<STG_SYSCFG_32_SPEC> {
+        U0_PCIE_AXI4_MST0_RUSER_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_33.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_33.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_33_SPEC>;
 #[doc = "Register `stg_syscfg_33` writer"]
 pub type W = crate::W<STG_SYSCFG_33_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_mst0_wderr` reader - u0_plda_pcie_axi4_mst0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_mst0_wderr` reader - u0_pcie_axi4_mst0_wderr"]
+pub type U0_PCIE_AXI4_MST0_WDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_mst0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_mst0_wderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_mst0_wderr(&self) -> U0_PLDA_PCIE_AXI4_MST0_WDERR_R {
-        U0_PLDA_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_axi4_mst0_wderr(&self) -> U0_PCIE_AXI4_MST0_WDERR_R {
+        U0_PCIE_AXI4_MST0_WDERR_R::new((self.bits & 0xff) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_34.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_34.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_34_SPEC>;
 #[doc = "Register `stg_syscfg_34` writer"]
 pub type W = crate::W<STG_SYSCFG_34_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_31_0` reader - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_31_0` writer - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_31_0` reader - u0_pcie_axi4_slv0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_31_0` writer - u0_pcie_axi4_slv0_aratomop_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_31_0(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_31_0(
+    pub fn u0_pcie_axi4_slv0_aratomop_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_34_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W<STG_SYSCFG_34_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_35.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_35.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_35_SPEC>;
 #[doc = "Register `stg_syscfg_35` writer"]
 pub type W = crate::W<STG_SYSCFG_35_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_63_32` reader - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_63_32` writer - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_63_32` reader - u0_pcie_axi4_slv0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_63_32` writer - u0_pcie_axi4_slv0_aratomop_63_32"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_63_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_63_32(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_63_32(
+    pub fn u0_pcie_axi4_slv0_aratomop_63_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_35_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W<STG_SYSCFG_35_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_36.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_36.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_36_SPEC>;
 #[doc = "Register `stg_syscfg_36` writer"]
 pub type W = crate::W<STG_SYSCFG_36_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_95_64` reader - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_95_64` writer - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_95_64` reader - u0_pcie_axi4_slv0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_95_64` writer - u0_pcie_axi4_slv0_aratomop_95_64"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_95_64(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_95_64(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_95_64(
+    pub fn u0_pcie_axi4_slv0_aratomop_95_64(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_36_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W<STG_SYSCFG_36_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_37.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_37.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_37_SPEC>;
 #[doc = "Register `stg_syscfg_37` writer"]
 pub type W = crate::W<STG_SYSCFG_37_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_127_96` reader - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_127_96` writer - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_127_96` reader - u0_pcie_axi4_slv0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_127_96` writer - u0_pcie_axi4_slv0_aratomop_127_96"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_127_96(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_127_96(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_127_96(
+    pub fn u0_pcie_axi4_slv0_aratomop_127_96(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_37_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W<STG_SYSCFG_37_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_38.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_38.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_38_SPEC>;
 #[doc = "Register `stg_syscfg_38` writer"]
 pub type W = crate::W<STG_SYSCFG_38_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_159_128` reader - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_159_128` writer - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_159_128` reader - u0_pcie_axi4_slv0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_159_128` writer - u0_pcie_axi4_slv0_aratomop_159_128"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_159_128(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_159_128(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_159_128(
+    pub fn u0_pcie_axi4_slv0_aratomop_159_128(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_38_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W<STG_SYSCFG_38_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_39.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_39.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_39_SPEC>;
 #[doc = "Register `stg_syscfg_39` writer"]
 pub type W = crate::W<STG_SYSCFG_39_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_191_160` reader - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_191_160` writer - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_191_160` reader - u0_pcie_axi4_slv0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_191_160` writer - u0_pcie_axi4_slv0_aratomop_191_160"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_191_160(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_191_160(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_191_160(
+    pub fn u0_pcie_axi4_slv0_aratomop_191_160(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_39_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W<STG_SYSCFG_39_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_4.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_4.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_4_SPEC>;
 #[doc = "Register `stg_syscfg_4` writer"]
 pub type W = crate::W<STG_SYSCFG_4_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_bus` reader - u0_cdn_usb_xhci_debug_bus"]
-pub type U0_CDN_USB_XHCI_DEBUG_BUS_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_usb_xhci_debug_bus` reader - u0_usb_xhci_debug_bus"]
+pub type U0_USB_XHCI_DEBUG_BUS_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_cdn_usb_xhci_debug_bus"]
+    #[doc = "Bits 0:31 - u0_usb_xhci_debug_bus"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_bus(&self) -> U0_CDN_USB_XHCI_DEBUG_BUS_R {
-        U0_CDN_USB_XHCI_DEBUG_BUS_R::new(self.bits)
+    pub fn u0_usb_xhci_debug_bus(&self) -> U0_USB_XHCI_DEBUG_BUS_R {
+        U0_USB_XHCI_DEBUG_BUS_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_40.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_40.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_40_SPEC>;
 #[doc = "Register `stg_syscfg_40` writer"]
 pub type W = crate::W<STG_SYSCFG_40_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_223_192` reader - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_223_192` writer - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_223_192` reader - u0_pcie_axi4_slv0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_223_192` writer - u0_pcie_axi4_slv0_aratomop_223_192"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_223_192(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_223_192(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_223_192(
+    pub fn u0_pcie_axi4_slv0_aratomop_223_192(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_40_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W<STG_SYSCFG_40_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_41.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_41.rs
@@ -2,27 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_41_SPEC>;
 #[doc = "Register `stg_syscfg_41` writer"]
 pub type W = crate::W<STG_SYSCFG_41_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_255_224` reader - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_255_224` writer - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_255_224` reader - u0_pcie_axi4_slv0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_255_224` writer - u0_pcie_axi4_slv0_aratomop_255_224"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_255_224(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aratomop_255_224(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aratomop_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aratomop_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_255_224(
+    pub fn u0_pcie_axi4_slv0_aratomop_255_224(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_41_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W<STG_SYSCFG_41_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_42.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_42.rs
@@ -2,61 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_42_SPEC>;
 #[doc = "Register `stg_syscfg_42` writer"]
 pub type W = crate::W<STG_SYSCFG_42_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_257_256` reader - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aratomop_257_256` writer - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arfunc` reader - u0_plda_pcie_axi4_slv0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arfunc` writer - u0_plda_pcie_axi4_slv0_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arregion` reader - u0_plda_pcie_axi4_slv0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_arregion` writer - u0_plda_pcie_axi4_slv0_arregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_257_256` reader - u0_pcie_axi4_slv0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_aratomop_257_256` writer - u0_pcie_axi4_slv0_aratomop_257_256"]
+pub type U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_axi4_slv0_arfunc` reader - u0_pcie_axi4_slv0_arfunc"]
+pub type U0_PCIE_AXI4_SLV0_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_arfunc` writer - u0_pcie_axi4_slv0_arfunc"]
+pub type U0_PCIE_AXI4_SLV0_ARFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_arregion` reader - u0_pcie_axi4_slv0_arregion"]
+pub type U0_PCIE_AXI4_SLV0_ARREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_arregion` writer - u0_pcie_axi4_slv0_arregion"]
+pub type U0_PCIE_AXI4_SLV0_ARREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_slv0_aratomop_257_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_257_256(
-        &self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
+    pub fn u0_pcie_axi4_slv0_aratomop_257_256(&self) -> U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_R::new((self.bits & 3) as u8)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_arfunc(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slv0_arfunc(&self) -> U0_PCIE_AXI4_SLV0_ARFUNC_R {
+        U0_PCIE_AXI4_SLV0_ARFUNC_R::new(((self.bits >> 2) & 0x7fff) as u16)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_slv0_arregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_arregion(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_slv0_arregion(&self) -> U0_PCIE_AXI4_SLV0_ARREGION_R {
+        U0_PCIE_AXI4_SLV0_ARREGION_R::new(((self.bits >> 17) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:1 - u0_plda_pcie_axi4_slv0_aratomop_257_256"]
+    #[doc = "Bits 0:1 - u0_pcie_axi4_slv0_aratomop_257_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aratomop_257_256(
+    pub fn u0_pcie_axi4_slv0_aratomop_257_256(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARATOMOP_257_256_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARATOMOP_257_256_W::new(self, 0)
     }
-    #[doc = "Bits 2:16 - u0_plda_pcie_axi4_slv0_arfunc"]
+    #[doc = "Bits 2:16 - u0_pcie_axi4_slv0_arfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_arfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
+    pub fn u0_pcie_axi4_slv0_arfunc(&mut self) -> U0_PCIE_AXI4_SLV0_ARFUNC_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARFUNC_W::new(self, 2)
     }
-    #[doc = "Bits 17:20 - u0_plda_pcie_axi4_slv0_arregion"]
+    #[doc = "Bits 17:20 - u0_pcie_axi4_slv0_arregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_arregion(
+    pub fn u0_pcie_axi4_slv0_arregion(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_42_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
+    ) -> U0_PCIE_AXI4_SLV0_ARREGION_W<STG_SYSCFG_42_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARREGION_W::new(self, 17)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_43.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_43.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_43_SPEC>;
 #[doc = "Register `stg_syscfg_43` writer"]
 pub type W = crate::W<STG_SYSCFG_43_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_31_0` reader - u0_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_31_0` writer - u0_plda_pcie_axi4_slv0_aruser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_31_0` reader - u0_pcie_axi4_slv0_aruser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_31_0` writer - u0_pcie_axi4_slv0_aruser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_aruser_31_0(&self) -> U0_PCIE_AXI4_SLV0_ARUSER_31_0_R {
+        U0_PCIE_AXI4_SLV0_ARUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_aruser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_aruser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_31_0(
+    pub fn u0_pcie_axi4_slv0_aruser_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_43_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARUSER_31_0_W<STG_SYSCFG_43_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_44.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_44.rs
@@ -2,59 +2,57 @@
 pub type R = crate::R<STG_SYSCFG_44_SPEC>;
 #[doc = "Register `stg_syscfg_44` writer"]
 pub type W = crate::W<STG_SYSCFG_44_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_40_32` reader - u0_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_aruser_40_32` writer - u0_plda_pcie_axi4_slv0_aruser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awfunc` reader - u0_plda_pcie_axi4_slv0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awfunc` writer - u0_plda_pcie_axi4_slv0_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awregion` reader - u0_plda_pcie_axi4_slv0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awregion` writer - u0_plda_pcie_axi4_slv0_awregion"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_40_32` reader - u0_pcie_axi4_slv0_aruser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_aruser_40_32` writer - u0_pcie_axi4_slv0_aruser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_ARUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awfunc` reader - u0_pcie_axi4_slv0_awfunc"]
+pub type U0_PCIE_AXI4_SLV0_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awfunc` writer - u0_pcie_axi4_slv0_awfunc"]
+pub type U0_PCIE_AXI4_SLV0_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awregion` reader - u0_pcie_axi4_slv0_awregion"]
+pub type U0_PCIE_AXI4_SLV0_AWREGION_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_awregion` writer - u0_pcie_axi4_slv0_awregion"]
+pub type U0_PCIE_AXI4_SLV0_AWREGION_W<'a, REG> = crate::FieldWriter<'a, REG, 4>;
 impl R {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_40_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u0_pcie_axi4_slv0_aruser_40_32(&self) -> U0_PCIE_AXI4_SLV0_ARUSER_40_32_R {
+        U0_PCIE_AXI4_SLV0_ARUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:23 - u0_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u0_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awfunc(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slv0_awfunc(&self) -> U0_PCIE_AXI4_SLV0_AWFUNC_R {
+        U0_PCIE_AXI4_SLV0_AWFUNC_R::new(((self.bits >> 9) & 0x7fff) as u16)
     }
-    #[doc = "Bits 24:27 - u0_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u0_pcie_axi4_slv0_awregion"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awregion(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
+    pub fn u0_pcie_axi4_slv0_awregion(&self) -> U0_PCIE_AXI4_SLV0_AWREGION_R {
+        U0_PCIE_AXI4_SLV0_AWREGION_R::new(((self.bits >> 24) & 0x0f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_aruser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_aruser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_aruser_40_32(
+    pub fn u0_pcie_axi4_slv0_aruser_40_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_ARUSER_40_32_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_ARUSER_40_32_W::new(self, 0)
     }
-    #[doc = "Bits 9:23 - u0_plda_pcie_axi4_slv0_awfunc"]
+    #[doc = "Bits 9:23 - u0_pcie_axi4_slv0_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
+    pub fn u0_pcie_axi4_slv0_awfunc(&mut self) -> U0_PCIE_AXI4_SLV0_AWFUNC_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWFUNC_W::new(self, 9)
     }
-    #[doc = "Bits 24:27 - u0_plda_pcie_axi4_slv0_awregion"]
+    #[doc = "Bits 24:27 - u0_pcie_axi4_slv0_awregion"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awregion(
+    pub fn u0_pcie_axi4_slv0_awregion(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_44_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
+    ) -> U0_PCIE_AXI4_SLV0_AWREGION_W<STG_SYSCFG_44_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWREGION_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_45.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_45.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_45_SPEC>;
 #[doc = "Register `stg_syscfg_45` writer"]
 pub type W = crate::W<STG_SYSCFG_45_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_31_0` reader - u0_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_31_0` writer - u0_plda_pcie_axi4_slv0_awuser_31_0"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_31_0` reader - u0_pcie_axi4_slv0_awuser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_31_0` writer - u0_pcie_axi4_slv0_awuser_31_0"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_31_0(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_awuser_31_0(&self) -> U0_PCIE_AXI4_SLV0_AWUSER_31_0_R {
+        U0_PCIE_AXI4_SLV0_AWUSER_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_awuser_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_awuser_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_31_0(
+    pub fn u0_pcie_axi4_slv0_awuser_31_0(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_45_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_AWUSER_31_0_W<STG_SYSCFG_45_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWUSER_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_46.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_46.rs
@@ -2,32 +2,32 @@
 pub type R = crate::R<STG_SYSCFG_46_SPEC>;
 #[doc = "Register `stg_syscfg_46` writer"]
 pub type W = crate::W<STG_SYSCFG_46_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_40_32` reader - u0_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_awuser_40_32` writer - u0_plda_pcie_axi4_slv0_awuser_40_32"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_rderr` reader - u0_plda_pcie_axi4_slv0_rderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_40_32` reader - u0_pcie_axi4_slv0_awuser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_40_32_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_awuser_40_32` writer - u0_pcie_axi4_slv0_awuser_40_32"]
+pub type U0_PCIE_AXI4_SLV0_AWUSER_40_32_W<'a, REG> = crate::FieldWriter<'a, REG, 9, u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_rderr` reader - u0_pcie_axi4_slv0_rderr"]
+pub type U0_PCIE_AXI4_SLV0_RDERR_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_40_32(&self) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
+    pub fn u0_pcie_axi4_slv0_awuser_40_32(&self) -> U0_PCIE_AXI4_SLV0_AWUSER_40_32_R {
+        U0_PCIE_AXI4_SLV0_AWUSER_40_32_R::new((self.bits & 0x01ff) as u16)
     }
-    #[doc = "Bits 9:16 - u0_plda_pcie_axi4_slv0_rderr"]
+    #[doc = "Bits 9:16 - u0_pcie_axi4_slv0_rderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_rderr(&self) -> U0_PLDA_PCIE_AXI4_SLV0_RDERR_R {
-        U0_PLDA_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
+    pub fn u0_pcie_axi4_slv0_rderr(&self) -> U0_PCIE_AXI4_SLV0_RDERR_R {
+        U0_PCIE_AXI4_SLV0_RDERR_R::new(((self.bits >> 9) & 0xff) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:8 - u0_plda_pcie_axi4_slv0_awuser_40_32"]
+    #[doc = "Bits 0:8 - u0_pcie_axi4_slv0_awuser_40_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_awuser_40_32(
+    pub fn u0_pcie_axi4_slv0_awuser_40_32(
         &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_46_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
+    ) -> U0_PCIE_AXI4_SLV0_AWUSER_40_32_W<STG_SYSCFG_46_SPEC> {
+        U0_PCIE_AXI4_SLV0_AWUSER_40_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_47.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_47.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_47_SPEC>;
 #[doc = "Register `stg_syscfg_47` writer"]
 pub type W = crate::W<STG_SYSCFG_47_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_ruser` reader - u0_plda_pcie_axi4_slv0_ruser"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_axi4_slv0_ruser` reader - u0_pcie_axi4_slv0_ruser"]
+pub type U0_PCIE_AXI4_SLV0_RUSER_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_axi4_slv0_ruser"]
+    #[doc = "Bits 0:31 - u0_pcie_axi4_slv0_ruser"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_ruser(&self) -> U0_PLDA_PCIE_AXI4_SLV0_RUSER_R {
-        U0_PLDA_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
+    pub fn u0_pcie_axi4_slv0_ruser(&self) -> U0_PCIE_AXI4_SLV0_RUSER_R {
+        U0_PCIE_AXI4_SLV0_RUSER_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_48.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_48.rs
@@ -2,32 +2,30 @@
 pub type R = crate::R<STG_SYSCFG_48_SPEC>;
 #[doc = "Register `stg_syscfg_48` writer"]
 pub type W = crate::W<STG_SYSCFG_48_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_wderr` reader - u0_plda_pcie_axi4_slv0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_axi4_slv0_wderr` writer - u0_plda_pcie_axi4_slv0_wderr"]
-pub type U0_PLDA_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_arfunc` reader - u0_plda_pcie_axi4_slvl_arfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slv0_wderr` reader - u0_pcie_axi4_slv0_wderr"]
+pub type U0_PCIE_AXI4_SLV0_WDERR_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_axi4_slv0_wderr` writer - u0_pcie_axi4_slv0_wderr"]
+pub type U0_PCIE_AXI4_SLV0_WDERR_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_axi4_slvl_arfunc` reader - u0_pcie_axi4_slvl_arfunc"]
+pub type U0_PCIE_AXI4_SLVL_ARFUNC_R = crate::FieldReader<u16>;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_slv0_wderr"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slv0_wderr(&self) -> U0_PLDA_PCIE_AXI4_SLV0_WDERR_R {
-        U0_PLDA_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_axi4_slv0_wderr(&self) -> U0_PCIE_AXI4_SLV0_WDERR_R {
+        U0_PCIE_AXI4_SLV0_WDERR_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bits 8:22 - u0_plda_pcie_axi4_slvl_arfunc"]
+    #[doc = "Bits 8:22 - u0_pcie_axi4_slvl_arfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slvl_arfunc(&self) -> U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slvl_arfunc(&self) -> U0_PCIE_AXI4_SLVL_ARFUNC_R {
+        U0_PCIE_AXI4_SLVL_ARFUNC_R::new(((self.bits >> 8) & 0x7fff) as u16)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u0_plda_pcie_axi4_slv0_wderr"]
+    #[doc = "Bits 0:7 - u0_pcie_axi4_slv0_wderr"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slv0_wderr(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_48_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
+    pub fn u0_pcie_axi4_slv0_wderr(&mut self) -> U0_PCIE_AXI4_SLV0_WDERR_W<STG_SYSCFG_48_SPEC> {
+        U0_PCIE_AXI4_SLV0_WDERR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_49.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_49.rs
@@ -2,92 +2,90 @@
 pub type R = crate::R<STG_SYSCFG_49_SPEC>;
 #[doc = "Register `stg_syscfg_49` writer"]
 pub type W = crate::W<STG_SYSCFG_49_SPEC>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_awfunc` reader - u0_plda_pcie_axi4_slvl_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
-#[doc = "Field `u0_plda_pcie_axi4_slvl_awfunc` writer - u0_plda_pcie_axi4_slvl_awfunc"]
-pub type U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
-#[doc = "Field `u0_plda_pcie_bus_width_o` reader - u0_plda_pcie_bus_width_o"]
-pub type U0_PLDA_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_bypass_codec` reader - u0_plda_pcie_bypass_codec"]
-pub type U0_PLDA_PCIE_BYPASS_CODEC_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_bypass_codec` writer - u0_plda_pcie_bypass_codec"]
-pub type U0_PLDA_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_ckref_src` reader - u0_plda_pcie_ckref_src"]
-pub type U0_PLDA_PCIE_CKREF_SRC_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_ckref_src` writer - u0_plda_pcie_ckref_src"]
-pub type U0_PLDA_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_clk_sel` reader - u0_plda_pcie_clk_sel"]
-pub type U0_PLDA_PCIE_CLK_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_clk_sel` writer - u0_plda_pcie_clk_sel"]
-pub type U0_PLDA_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_clkreq` reader - u0_plda_pcie_clkreq"]
-pub type U0_PLDA_PCIE_CLKREQ_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_clkreq` writer - u0_plda_pcie_clkreq"]
-pub type U0_PLDA_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi4_slvl_awfunc` reader - u0_pcie_axi4_slvl_awfunc"]
+pub type U0_PCIE_AXI4_SLVL_AWFUNC_R = crate::FieldReader<u16>;
+#[doc = "Field `u0_pcie_axi4_slvl_awfunc` writer - u0_pcie_axi4_slvl_awfunc"]
+pub type U0_PCIE_AXI4_SLVL_AWFUNC_W<'a, REG> = crate::FieldWriter<'a, REG, 15, u16>;
+#[doc = "Field `u0_pcie_bus_width_o` reader - u0_pcie_bus_width_o"]
+pub type U0_PCIE_BUS_WIDTH_O_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_bypass_codec` reader - u0_pcie_bypass_codec"]
+pub type U0_PCIE_BYPASS_CODEC_R = crate::BitReader;
+#[doc = "Field `u0_pcie_bypass_codec` writer - u0_pcie_bypass_codec"]
+pub type U0_PCIE_BYPASS_CODEC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_ckref_src` reader - u0_pcie_ckref_src"]
+pub type U0_PCIE_CKREF_SRC_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_ckref_src` writer - u0_pcie_ckref_src"]
+pub type U0_PCIE_CKREF_SRC_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_clk_sel` reader - u0_pcie_clk_sel"]
+pub type U0_PCIE_CLK_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_clk_sel` writer - u0_pcie_clk_sel"]
+pub type U0_PCIE_CLK_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_clkreq` reader - u0_pcie_clkreq"]
+pub type U0_PCIE_CLKREQ_R = crate::BitReader;
+#[doc = "Field `u0_pcie_clkreq` writer - u0_pcie_clkreq"]
+pub type U0_PCIE_CLKREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
-    pub fn u0_plda_pcie_axi4_slvl_awfunc(&self) -> U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R {
-        U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
+    pub fn u0_pcie_axi4_slvl_awfunc(&self) -> U0_PCIE_AXI4_SLVL_AWFUNC_R {
+        U0_PCIE_AXI4_SLVL_AWFUNC_R::new((self.bits & 0x7fff) as u16)
     }
-    #[doc = "Bits 15:16 - u0_plda_pcie_bus_width_o"]
+    #[doc = "Bits 15:16 - u0_pcie_bus_width_o"]
     #[inline(always)]
-    pub fn u0_plda_pcie_bus_width_o(&self) -> U0_PLDA_PCIE_BUS_WIDTH_O_R {
-        U0_PLDA_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
+    pub fn u0_pcie_bus_width_o(&self) -> U0_PCIE_BUS_WIDTH_O_R {
+        U0_PCIE_BUS_WIDTH_O_R::new(((self.bits >> 15) & 3) as u8)
     }
-    #[doc = "Bit 17 - u0_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u0_pcie_bypass_codec"]
     #[inline(always)]
-    pub fn u0_plda_pcie_bypass_codec(&self) -> U0_PLDA_PCIE_BYPASS_CODEC_R {
-        U0_PLDA_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_pcie_bypass_codec(&self) -> U0_PCIE_BYPASS_CODEC_R {
+        U0_PCIE_BYPASS_CODEC_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bits 18:19 - u0_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u0_pcie_ckref_src"]
     #[inline(always)]
-    pub fn u0_plda_pcie_ckref_src(&self) -> U0_PLDA_PCIE_CKREF_SRC_R {
-        U0_PLDA_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
+    pub fn u0_pcie_ckref_src(&self) -> U0_PCIE_CKREF_SRC_R {
+        U0_PCIE_CKREF_SRC_R::new(((self.bits >> 18) & 3) as u8)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u0_pcie_clk_sel"]
     #[inline(always)]
-    pub fn u0_plda_pcie_clk_sel(&self) -> U0_PLDA_PCIE_CLK_SEL_R {
-        U0_PLDA_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u0_pcie_clk_sel(&self) -> U0_PCIE_CLK_SEL_R {
+        U0_PCIE_CLK_SEL_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u0_pcie_clkreq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_clkreq(&self) -> U0_PLDA_PCIE_CLKREQ_R {
-        U0_PLDA_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_pcie_clkreq(&self) -> U0_PCIE_CLKREQ_R {
+        U0_PCIE_CLKREQ_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:14 - u0_plda_pcie_axi4_slvl_awfunc"]
+    #[doc = "Bits 0:14 - u0_pcie_axi4_slvl_awfunc"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_axi4_slvl_awfunc(
-        &mut self,
-    ) -> U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
+    pub fn u0_pcie_axi4_slvl_awfunc(&mut self) -> U0_PCIE_AXI4_SLVL_AWFUNC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_AXI4_SLVL_AWFUNC_W::new(self, 0)
     }
-    #[doc = "Bit 17 - u0_plda_pcie_bypass_codec"]
+    #[doc = "Bit 17 - u0_pcie_bypass_codec"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_bypass_codec(&mut self) -> U0_PLDA_PCIE_BYPASS_CODEC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_BYPASS_CODEC_W::new(self, 17)
+    pub fn u0_pcie_bypass_codec(&mut self) -> U0_PCIE_BYPASS_CODEC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_BYPASS_CODEC_W::new(self, 17)
     }
-    #[doc = "Bits 18:19 - u0_plda_pcie_ckref_src"]
+    #[doc = "Bits 18:19 - u0_pcie_ckref_src"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_ckref_src(&mut self) -> U0_PLDA_PCIE_CKREF_SRC_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CKREF_SRC_W::new(self, 18)
+    pub fn u0_pcie_ckref_src(&mut self) -> U0_PCIE_CKREF_SRC_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CKREF_SRC_W::new(self, 18)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_clk_sel"]
+    #[doc = "Bits 20:21 - u0_pcie_clk_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_clk_sel(&mut self) -> U0_PLDA_PCIE_CLK_SEL_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CLK_SEL_W::new(self, 20)
+    pub fn u0_pcie_clk_sel(&mut self) -> U0_PCIE_CLK_SEL_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CLK_SEL_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_clkreq"]
+    #[doc = "Bit 22 - u0_pcie_clkreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_clkreq(&mut self) -> U0_PLDA_PCIE_CLKREQ_W<STG_SYSCFG_49_SPEC> {
-        U0_PLDA_PCIE_CLKREQ_W::new(self, 22)
+    pub fn u0_pcie_clkreq(&mut self) -> U0_PCIE_CLKREQ_W<STG_SYSCFG_49_SPEC> {
+        U0_PCIE_CLKREQ_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_5.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_5.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_5_SPEC>;
 #[doc = "Register `stg_syscfg_5` writer"]
 pub type W = crate::W<STG_SYSCFG_5_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_link_state` reader - u0_cdn_usb_xhci_debug_link_state"]
-pub type U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_usb_xhci_debug_link_state` reader - u0_usb_xhci_debug_link_state"]
+pub type U0_USB_XHCI_DEBUG_LINK_STATE_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:30 - u0_cdn_usb_xhci_debug_link_state"]
+    #[doc = "Bits 0:30 - u0_usb_xhci_debug_link_state"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_link_state(&self) -> U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R {
-        U0_CDN_USB_XHCI_DEBUG_LINK_STATE_R::new(self.bits & 0x7fff_ffff)
+    pub fn u0_usb_xhci_debug_link_state(&self) -> U0_USB_XHCI_DEBUG_LINK_STATE_R {
+        U0_USB_XHCI_DEBUG_LINK_STATE_R::new(self.bits & 0x7fff_ffff)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_50.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_50.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_50_SPEC>;
 #[doc = "Register `stg_syscfg_50` writer"]
 pub type W = crate::W<STG_SYSCFG_50_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_31_0` reader - u0_plda_pcie_k_phyparam_31_0"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_31_0` writer - u0_plda_pcie_k_phyparam_31_0"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_31_0` reader - u0_pcie_k_phyparam_31_0"]
+pub type U0_PCIE_K_PHYPARAM_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_31_0` writer - u0_pcie_k_phyparam_31_0"]
+pub type U0_PCIE_K_PHYPARAM_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_31_0(&self) -> U0_PLDA_PCIE_K_PHYPARAM_31_0_R {
-        U0_PLDA_PCIE_K_PHYPARAM_31_0_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_31_0(&self) -> U0_PCIE_K_PHYPARAM_31_0_R {
+        U0_PCIE_K_PHYPARAM_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_31_0(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_31_0_W<STG_SYSCFG_50_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_31_0_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_31_0(&mut self) -> U0_PCIE_K_PHYPARAM_31_0_W<STG_SYSCFG_50_SPEC> {
+        U0_PCIE_K_PHYPARAM_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_51.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_51.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_51_SPEC>;
 #[doc = "Register `stg_syscfg_51` writer"]
 pub type W = crate::W<STG_SYSCFG_51_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_63_32` reader - u0_plda_pcie_k_phyparam_63_32"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_63_32` writer - u0_plda_pcie_k_phyparam_63_32"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_63_32` reader - u0_pcie_k_phyparam_63_32"]
+pub type U0_PCIE_K_PHYPARAM_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_63_32` writer - u0_pcie_k_phyparam_63_32"]
+pub type U0_PCIE_K_PHYPARAM_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_63_32(&self) -> U0_PLDA_PCIE_K_PHYPARAM_63_32_R {
-        U0_PLDA_PCIE_K_PHYPARAM_63_32_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_63_32(&self) -> U0_PCIE_K_PHYPARAM_63_32_R {
+        U0_PCIE_K_PHYPARAM_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_63_32(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_63_32_W<STG_SYSCFG_51_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_63_32_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_63_32(&mut self) -> U0_PCIE_K_PHYPARAM_63_32_W<STG_SYSCFG_51_SPEC> {
+        U0_PCIE_K_PHYPARAM_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_52.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_52.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_52_SPEC>;
 #[doc = "Register `stg_syscfg_52` writer"]
 pub type W = crate::W<STG_SYSCFG_52_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_95_64` reader - u0_plda_pcie_k_phyparam_95_64"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_95_64_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_95_64` writer - u0_plda_pcie_k_phyparam_95_64"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_95_64` reader - u0_pcie_k_phyparam_95_64"]
+pub type U0_PCIE_K_PHYPARAM_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_95_64` writer - u0_pcie_k_phyparam_95_64"]
+pub type U0_PCIE_K_PHYPARAM_95_64_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_95_64(&self) -> U0_PLDA_PCIE_K_PHYPARAM_95_64_R {
-        U0_PLDA_PCIE_K_PHYPARAM_95_64_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_95_64(&self) -> U0_PCIE_K_PHYPARAM_95_64_R {
+        U0_PCIE_K_PHYPARAM_95_64_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_95_64"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_95_64(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_95_64_W<STG_SYSCFG_52_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_95_64_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_95_64(&mut self) -> U0_PCIE_K_PHYPARAM_95_64_W<STG_SYSCFG_52_SPEC> {
+        U0_PCIE_K_PHYPARAM_95_64_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_53.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_53.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_53_SPEC>;
 #[doc = "Register `stg_syscfg_53` writer"]
 pub type W = crate::W<STG_SYSCFG_53_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_127_96` reader - u0_plda_pcie_k_phyparam_127_96"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_127_96_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_127_96` writer - u0_plda_pcie_k_phyparam_127_96"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_127_96` reader - u0_pcie_k_phyparam_127_96"]
+pub type U0_PCIE_K_PHYPARAM_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_127_96` writer - u0_pcie_k_phyparam_127_96"]
+pub type U0_PCIE_K_PHYPARAM_127_96_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_127_96(&self) -> U0_PLDA_PCIE_K_PHYPARAM_127_96_R {
-        U0_PLDA_PCIE_K_PHYPARAM_127_96_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_127_96(&self) -> U0_PCIE_K_PHYPARAM_127_96_R {
+        U0_PCIE_K_PHYPARAM_127_96_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_127_96"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_127_96(
-        &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_127_96_W<STG_SYSCFG_53_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_127_96_W::new(self, 0)
+    pub fn u0_pcie_k_phyparam_127_96(&mut self) -> U0_PCIE_K_PHYPARAM_127_96_W<STG_SYSCFG_53_SPEC> {
+        U0_PCIE_K_PHYPARAM_127_96_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_54.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_54.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_54_SPEC>;
 #[doc = "Register `stg_syscfg_54` writer"]
 pub type W = crate::W<STG_SYSCFG_54_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_159_128` reader - u0_plda_pcie_k_phyparam_159_128"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_159_128_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_159_128` writer - u0_plda_pcie_k_phyparam_159_128"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_159_128` reader - u0_pcie_k_phyparam_159_128"]
+pub type U0_PCIE_K_PHYPARAM_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_159_128` writer - u0_pcie_k_phyparam_159_128"]
+pub type U0_PCIE_K_PHYPARAM_159_128_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_159_128(&self) -> U0_PLDA_PCIE_K_PHYPARAM_159_128_R {
-        U0_PLDA_PCIE_K_PHYPARAM_159_128_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_159_128(&self) -> U0_PCIE_K_PHYPARAM_159_128_R {
+        U0_PCIE_K_PHYPARAM_159_128_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_159_128"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_159_128(
+    pub fn u0_pcie_k_phyparam_159_128(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_159_128_W<STG_SYSCFG_54_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_159_128_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_159_128_W<STG_SYSCFG_54_SPEC> {
+        U0_PCIE_K_PHYPARAM_159_128_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_55.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_55.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_55_SPEC>;
 #[doc = "Register `stg_syscfg_55` writer"]
 pub type W = crate::W<STG_SYSCFG_55_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_191_160` reader - u0_plda_pcie_k_phyparam_191_160"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_191_160_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_191_160` writer - u0_plda_pcie_k_phyparam_191_160"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_191_160` reader - u0_pcie_k_phyparam_191_160"]
+pub type U0_PCIE_K_PHYPARAM_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_191_160` writer - u0_pcie_k_phyparam_191_160"]
+pub type U0_PCIE_K_PHYPARAM_191_160_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_191_160(&self) -> U0_PLDA_PCIE_K_PHYPARAM_191_160_R {
-        U0_PLDA_PCIE_K_PHYPARAM_191_160_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_191_160(&self) -> U0_PCIE_K_PHYPARAM_191_160_R {
+        U0_PCIE_K_PHYPARAM_191_160_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_191_160"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_191_160(
+    pub fn u0_pcie_k_phyparam_191_160(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_191_160_W<STG_SYSCFG_55_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_191_160_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_191_160_W<STG_SYSCFG_55_SPEC> {
+        U0_PCIE_K_PHYPARAM_191_160_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_56.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_56.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_56_SPEC>;
 #[doc = "Register `stg_syscfg_56` writer"]
 pub type W = crate::W<STG_SYSCFG_56_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_223_192` reader - u0_plda_pcie_k_phyparam_223_192"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_223_192_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_223_192` writer - u0_plda_pcie_k_phyparam_223_192"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_223_192` reader - u0_pcie_k_phyparam_223_192"]
+pub type U0_PCIE_K_PHYPARAM_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_223_192` writer - u0_pcie_k_phyparam_223_192"]
+pub type U0_PCIE_K_PHYPARAM_223_192_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_223_192(&self) -> U0_PLDA_PCIE_K_PHYPARAM_223_192_R {
-        U0_PLDA_PCIE_K_PHYPARAM_223_192_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_223_192(&self) -> U0_PCIE_K_PHYPARAM_223_192_R {
+        U0_PCIE_K_PHYPARAM_223_192_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_223_192"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_223_192(
+    pub fn u0_pcie_k_phyparam_223_192(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_223_192_W<STG_SYSCFG_56_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_223_192_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_223_192_W<STG_SYSCFG_56_SPEC> {
+        U0_PCIE_K_PHYPARAM_223_192_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_57.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_57.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_57_SPEC>;
 #[doc = "Register `stg_syscfg_57` writer"]
 pub type W = crate::W<STG_SYSCFG_57_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_255_224` reader - u0_plda_pcie_k_phyparam_255_224"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_255_224_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_255_224` writer - u0_plda_pcie_k_phyparam_255_224"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_255_224` reader - u0_pcie_k_phyparam_255_224"]
+pub type U0_PCIE_K_PHYPARAM_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_255_224` writer - u0_pcie_k_phyparam_255_224"]
+pub type U0_PCIE_K_PHYPARAM_255_224_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_255_224(&self) -> U0_PLDA_PCIE_K_PHYPARAM_255_224_R {
-        U0_PLDA_PCIE_K_PHYPARAM_255_224_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_255_224(&self) -> U0_PCIE_K_PHYPARAM_255_224_R {
+        U0_PCIE_K_PHYPARAM_255_224_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_255_224"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_255_224(
+    pub fn u0_pcie_k_phyparam_255_224(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_255_224_W<STG_SYSCFG_57_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_255_224_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_255_224_W<STG_SYSCFG_57_SPEC> {
+        U0_PCIE_K_PHYPARAM_255_224_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_58.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_58.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_58_SPEC>;
 #[doc = "Register `stg_syscfg_58` writer"]
 pub type W = crate::W<STG_SYSCFG_58_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_287_256` reader - u0_plda_pcie_k_phyparam_287_256"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_287_256_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_287_256` writer - u0_plda_pcie_k_phyparam_287_256"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_287_256` reader - u0_pcie_k_phyparam_287_256"]
+pub type U0_PCIE_K_PHYPARAM_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_287_256` writer - u0_pcie_k_phyparam_287_256"]
+pub type U0_PCIE_K_PHYPARAM_287_256_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_287_256(&self) -> U0_PLDA_PCIE_K_PHYPARAM_287_256_R {
-        U0_PLDA_PCIE_K_PHYPARAM_287_256_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_287_256(&self) -> U0_PCIE_K_PHYPARAM_287_256_R {
+        U0_PCIE_K_PHYPARAM_287_256_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_287_256"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_287_256(
+    pub fn u0_pcie_k_phyparam_287_256(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_287_256_W<STG_SYSCFG_58_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_287_256_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_287_256_W<STG_SYSCFG_58_SPEC> {
+        U0_PCIE_K_PHYPARAM_287_256_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_59.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_59.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_59_SPEC>;
 #[doc = "Register `stg_syscfg_59` writer"]
 pub type W = crate::W<STG_SYSCFG_59_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_319_288` reader - u0_plda_pcie_k_phyparam_319_288"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_319_288_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_319_288` writer - u0_plda_pcie_k_phyparam_319_288"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_319_288` reader - u0_pcie_k_phyparam_319_288"]
+pub type U0_PCIE_K_PHYPARAM_319_288_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_319_288` writer - u0_pcie_k_phyparam_319_288"]
+pub type U0_PCIE_K_PHYPARAM_319_288_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_319_288"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_319_288(&self) -> U0_PLDA_PCIE_K_PHYPARAM_319_288_R {
-        U0_PLDA_PCIE_K_PHYPARAM_319_288_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_319_288(&self) -> U0_PCIE_K_PHYPARAM_319_288_R {
+        U0_PCIE_K_PHYPARAM_319_288_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_319_288"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_319_288"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_319_288(
+    pub fn u0_pcie_k_phyparam_319_288(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_319_288_W<STG_SYSCFG_59_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_319_288_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_319_288_W<STG_SYSCFG_59_SPEC> {
+        U0_PCIE_K_PHYPARAM_319_288_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_6.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_6.rs
@@ -2,161 +2,159 @@
 pub type R = crate::R<STG_SYSCFG_6_SPEC>;
 #[doc = "Register `stg_syscfg_6` writer"]
 pub type W = crate::W<STG_SYSCFG_6_SPEC>;
-#[doc = "Field `u0_cdn_usb_xhci_debug_sel` reader - u0_cdn_usb_xhci_debug_sel"]
-pub type U0_CDN_USB_XHCI_DEBUG_SEL_R = crate::FieldReader;
-#[doc = "Field `u0_cdn_usb_xhci_debug_sel` writer - u0_cdn_usb_xhci_debug_sel"]
-pub type U0_CDN_USB_XHCI_DEBUG_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_off_ack` reader - u0_cdn_usb_xhci_main_power_off_ack"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_off_req` reader - u0_cdn_usb_xhci_main_power_off_req"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_ready` reader - u0_cdn_usb_xhci_main_power_on_ready"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_ready` writer - u0_cdn_usb_xhci_main_power_on_ready"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_req` reader - u0_cdn_usb_xhci_main_power_on_req"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_valid` reader - u0_cdn_usb_xhci_main_power_on_valid"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_main_power_on_valid` writer - u0_cdn_usb_xhci_main_power_on_valid"]
-pub type U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_ack` reader - u0_cdn_usb_xhci_power_off_ack"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_ACK_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_ready` reader - u0_cdn_usb_xhci_power_off_ready"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_req` reader - u0_cdn_usb_xhci_power_off_req"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_off_req` writer - u0_cdn_usb_xhci_power_off_req"]
-pub type U0_CDN_USB_XHCI_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_ready` reader - u0_cdn_usb_xhci_power_on_ready"]
-pub type U0_CDN_USB_XHCI_POWER_ON_READY_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_req` reader - u0_cdn_usb_xhci_power_on_req"]
-pub type U0_CDN_USB_XHCI_POWER_ON_REQ_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_valid` reader - u0_cdn_usb_xhci_power_on_valid"]
-pub type U0_CDN_USB_XHCI_POWER_ON_VALID_R = crate::BitReader;
-#[doc = "Field `u0_cdn_usb_xhci_power_on_valid` writer - u0_cdn_usb_xhci_power_on_valid"]
-pub type U0_CDN_USB_XHCI_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_e2_sft7110_cease_from_tile_0` reader - u0_e2_sft7110_cease_from_tile_0"]
-pub type U0_E2_SFT7110_CEASE_FROM_TILE_0_R = crate::BitReader;
-#[doc = "Field `u0_e2_sft7110_debug_from_tile_0` reader - u0_e2_sft7110_debug_from_tile_0"]
-pub type U0_E2_SFT7110_DEBUG_FROM_TILE_0_R = crate::BitReader;
-#[doc = "Field `u0_e2_sft7110_halt_from_tile_0` reader - u0_e2_sft7110_halt_from_tile_0"]
-pub type U0_E2_SFT7110_HALT_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_debug_sel` reader - u0_usb_xhci_debug_sel"]
+pub type U0_USB_XHCI_DEBUG_SEL_R = crate::FieldReader;
+#[doc = "Field `u0_usb_xhci_debug_sel` writer - u0_usb_xhci_debug_sel"]
+pub type U0_USB_XHCI_DEBUG_SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 5>;
+#[doc = "Field `u0_usb_xhci_main_power_off_ack` reader - u0_usb_xhci_main_power_off_ack"]
+pub type U0_USB_XHCI_MAIN_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_off_req` reader - u0_usb_xhci_main_power_off_req"]
+pub type U0_USB_XHCI_MAIN_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_ready` reader - u0_usb_xhci_main_power_on_ready"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_ready` writer - u0_usb_xhci_main_power_on_ready"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_READY_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_main_power_on_req` reader - u0_usb_xhci_main_power_on_req"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_valid` reader - u0_usb_xhci_main_power_on_valid"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_main_power_on_valid` writer - u0_usb_xhci_main_power_on_valid"]
+pub type U0_USB_XHCI_MAIN_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_power_off_ack` reader - u0_usb_xhci_power_off_ack"]
+pub type U0_USB_XHCI_POWER_OFF_ACK_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_ready` reader - u0_usb_xhci_power_off_ready"]
+pub type U0_USB_XHCI_POWER_OFF_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_req` reader - u0_usb_xhci_power_off_req"]
+pub type U0_USB_XHCI_POWER_OFF_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_off_req` writer - u0_usb_xhci_power_off_req"]
+pub type U0_USB_XHCI_POWER_OFF_REQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_xhci_power_on_ready` reader - u0_usb_xhci_power_on_ready"]
+pub type U0_USB_XHCI_POWER_ON_READY_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_req` reader - u0_usb_xhci_power_on_req"]
+pub type U0_USB_XHCI_POWER_ON_REQ_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_valid` reader - u0_usb_xhci_power_on_valid"]
+pub type U0_USB_XHCI_POWER_ON_VALID_R = crate::BitReader;
+#[doc = "Field `u0_usb_xhci_power_on_valid` writer - u0_usb_xhci_power_on_valid"]
+pub type U0_USB_XHCI_POWER_ON_VALID_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_cease_from_tile_0` reader - u0_e2_cease_from_tile_0"]
+pub type U0_E2_CEASE_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_debug_from_tile_0` reader - u0_e2_debug_from_tile_0"]
+pub type U0_E2_DEBUG_FROM_TILE_0_R = crate::BitReader;
+#[doc = "Field `u0_e2_halt_from_tile_0` reader - u0_e2_halt_from_tile_0"]
+pub type U0_E2_HALT_FROM_TILE_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bits 0:4 - u0_cdn_usb_xhci_debug_sel"]
+    #[doc = "Bits 0:4 - u0_usb_xhci_debug_sel"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_debug_sel(&self) -> U0_CDN_USB_XHCI_DEBUG_SEL_R {
-        U0_CDN_USB_XHCI_DEBUG_SEL_R::new((self.bits & 0x1f) as u8)
+    pub fn u0_usb_xhci_debug_sel(&self) -> U0_USB_XHCI_DEBUG_SEL_R {
+        U0_USB_XHCI_DEBUG_SEL_R::new((self.bits & 0x1f) as u8)
     }
-    #[doc = "Bit 5 - u0_cdn_usb_xhci_main_power_off_ack"]
+    #[doc = "Bit 5 - u0_usb_xhci_main_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_off_ack(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_off_ack(&self) -> U0_USB_XHCI_MAIN_POWER_OFF_ACK_R {
+        U0_USB_XHCI_MAIN_POWER_OFF_ACK_R::new(((self.bits >> 5) & 1) != 0)
     }
-    #[doc = "Bit 6 - u0_cdn_usb_xhci_main_power_off_req"]
+    #[doc = "Bit 6 - u0_usb_xhci_main_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_off_req(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_off_req(&self) -> U0_USB_XHCI_MAIN_POWER_OFF_REQ_R {
+        U0_USB_XHCI_MAIN_POWER_OFF_REQ_R::new(((self.bits >> 6) & 1) != 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_xhci_main_power_on_ready"]
+    #[doc = "Bit 7 - u0_usb_xhci_main_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_ready(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_ready(&self) -> U0_USB_XHCI_MAIN_POWER_ON_READY_R {
+        U0_USB_XHCI_MAIN_POWER_ON_READY_R::new(((self.bits >> 7) & 1) != 0)
     }
-    #[doc = "Bit 8 - u0_cdn_usb_xhci_main_power_on_req"]
+    #[doc = "Bit 8 - u0_usb_xhci_main_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_req(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_REQ_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_req(&self) -> U0_USB_XHCI_MAIN_POWER_ON_REQ_R {
+        U0_USB_XHCI_MAIN_POWER_ON_REQ_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_xhci_main_power_on_valid"]
+    #[doc = "Bit 9 - u0_usb_xhci_main_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_main_power_on_valid(&self) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_xhci_main_power_on_valid(&self) -> U0_USB_XHCI_MAIN_POWER_ON_VALID_R {
+        U0_USB_XHCI_MAIN_POWER_ON_VALID_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_cdn_usb_xhci_power_off_ack"]
+    #[doc = "Bit 10 - u0_usb_xhci_power_off_ack"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_ack(&self) -> U0_CDN_USB_XHCI_POWER_OFF_ACK_R {
-        U0_CDN_USB_XHCI_POWER_OFF_ACK_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_ack(&self) -> U0_USB_XHCI_POWER_OFF_ACK_R {
+        U0_USB_XHCI_POWER_OFF_ACK_R::new(((self.bits >> 10) & 1) != 0)
     }
-    #[doc = "Bit 11 - u0_cdn_usb_xhci_power_off_ready"]
+    #[doc = "Bit 11 - u0_usb_xhci_power_off_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_ready(&self) -> U0_CDN_USB_XHCI_POWER_OFF_READY_R {
-        U0_CDN_USB_XHCI_POWER_OFF_READY_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_ready(&self) -> U0_USB_XHCI_POWER_OFF_READY_R {
+        U0_USB_XHCI_POWER_OFF_READY_R::new(((self.bits >> 11) & 1) != 0)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_xhci_power_off_req"]
+    #[doc = "Bit 12 - u0_usb_xhci_power_off_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_off_req(&self) -> U0_CDN_USB_XHCI_POWER_OFF_REQ_R {
-        U0_CDN_USB_XHCI_POWER_OFF_REQ_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_usb_xhci_power_off_req(&self) -> U0_USB_XHCI_POWER_OFF_REQ_R {
+        U0_USB_XHCI_POWER_OFF_REQ_R::new(((self.bits >> 12) & 1) != 0)
     }
-    #[doc = "Bit 13 - u0_cdn_usb_xhci_power_on_ready"]
+    #[doc = "Bit 13 - u0_usb_xhci_power_on_ready"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_ready(&self) -> U0_CDN_USB_XHCI_POWER_ON_READY_R {
-        U0_CDN_USB_XHCI_POWER_ON_READY_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_ready(&self) -> U0_USB_XHCI_POWER_ON_READY_R {
+        U0_USB_XHCI_POWER_ON_READY_R::new(((self.bits >> 13) & 1) != 0)
     }
-    #[doc = "Bit 14 - u0_cdn_usb_xhci_power_on_req"]
+    #[doc = "Bit 14 - u0_usb_xhci_power_on_req"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_req(&self) -> U0_CDN_USB_XHCI_POWER_ON_REQ_R {
-        U0_CDN_USB_XHCI_POWER_ON_REQ_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_req(&self) -> U0_USB_XHCI_POWER_ON_REQ_R {
+        U0_USB_XHCI_POWER_ON_REQ_R::new(((self.bits >> 14) & 1) != 0)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_xhci_power_on_valid"]
+    #[doc = "Bit 15 - u0_usb_xhci_power_on_valid"]
     #[inline(always)]
-    pub fn u0_cdn_usb_xhci_power_on_valid(&self) -> U0_CDN_USB_XHCI_POWER_ON_VALID_R {
-        U0_CDN_USB_XHCI_POWER_ON_VALID_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_usb_xhci_power_on_valid(&self) -> U0_USB_XHCI_POWER_ON_VALID_R {
+        U0_USB_XHCI_POWER_ON_VALID_R::new(((self.bits >> 15) & 1) != 0)
     }
-    #[doc = "Bit 16 - u0_e2_sft7110_cease_from_tile_0"]
+    #[doc = "Bit 16 - u0_e2_cease_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_cease_from_tile_0(&self) -> U0_E2_SFT7110_CEASE_FROM_TILE_0_R {
-        U0_E2_SFT7110_CEASE_FROM_TILE_0_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_e2_cease_from_tile_0(&self) -> U0_E2_CEASE_FROM_TILE_0_R {
+        U0_E2_CEASE_FROM_TILE_0_R::new(((self.bits >> 16) & 1) != 0)
     }
-    #[doc = "Bit 17 - u0_e2_sft7110_debug_from_tile_0"]
+    #[doc = "Bit 17 - u0_e2_debug_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_debug_from_tile_0(&self) -> U0_E2_SFT7110_DEBUG_FROM_TILE_0_R {
-        U0_E2_SFT7110_DEBUG_FROM_TILE_0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_e2_debug_from_tile_0(&self) -> U0_E2_DEBUG_FROM_TILE_0_R {
+        U0_E2_DEBUG_FROM_TILE_0_R::new(((self.bits >> 17) & 1) != 0)
     }
-    #[doc = "Bit 18 - u0_e2_sft7110_halt_from_tile_0"]
+    #[doc = "Bit 18 - u0_e2_halt_from_tile_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_halt_from_tile_0(&self) -> U0_E2_SFT7110_HALT_FROM_TILE_0_R {
-        U0_E2_SFT7110_HALT_FROM_TILE_0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_e2_halt_from_tile_0(&self) -> U0_E2_HALT_FROM_TILE_0_R {
+        U0_E2_HALT_FROM_TILE_0_R::new(((self.bits >> 18) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:4 - u0_cdn_usb_xhci_debug_sel"]
+    #[doc = "Bits 0:4 - u0_usb_xhci_debug_sel"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_debug_sel(&mut self) -> U0_CDN_USB_XHCI_DEBUG_SEL_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_DEBUG_SEL_W::new(self, 0)
+    pub fn u0_usb_xhci_debug_sel(&mut self) -> U0_USB_XHCI_DEBUG_SEL_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_DEBUG_SEL_W::new(self, 0)
     }
-    #[doc = "Bit 7 - u0_cdn_usb_xhci_main_power_on_ready"]
+    #[doc = "Bit 7 - u0_usb_xhci_main_power_on_ready"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_main_power_on_ready(
+    pub fn u0_usb_xhci_main_power_on_ready(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_READY_W::new(self, 7)
+    ) -> U0_USB_XHCI_MAIN_POWER_ON_READY_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_MAIN_POWER_ON_READY_W::new(self, 7)
     }
-    #[doc = "Bit 9 - u0_cdn_usb_xhci_main_power_on_valid"]
+    #[doc = "Bit 9 - u0_usb_xhci_main_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_main_power_on_valid(
+    pub fn u0_usb_xhci_main_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_MAIN_POWER_ON_VALID_W::new(self, 9)
+    ) -> U0_USB_XHCI_MAIN_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_MAIN_POWER_ON_VALID_W::new(self, 9)
     }
-    #[doc = "Bit 12 - u0_cdn_usb_xhci_power_off_req"]
+    #[doc = "Bit 12 - u0_usb_xhci_power_off_req"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_power_off_req(
-        &mut self,
-    ) -> U0_CDN_USB_XHCI_POWER_OFF_REQ_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_POWER_OFF_REQ_W::new(self, 12)
+    pub fn u0_usb_xhci_power_off_req(&mut self) -> U0_USB_XHCI_POWER_OFF_REQ_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_POWER_OFF_REQ_W::new(self, 12)
     }
-    #[doc = "Bit 15 - u0_cdn_usb_xhci_power_on_valid"]
+    #[doc = "Bit 15 - u0_usb_xhci_power_on_valid"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_cdn_usb_xhci_power_on_valid(
+    pub fn u0_usb_xhci_power_on_valid(
         &mut self,
-    ) -> U0_CDN_USB_XHCI_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
-        U0_CDN_USB_XHCI_POWER_ON_VALID_W::new(self, 15)
+    ) -> U0_USB_XHCI_POWER_ON_VALID_W<STG_SYSCFG_6_SPEC> {
+        U0_USB_XHCI_POWER_ON_VALID_W::new(self, 15)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_60.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_60.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_60_SPEC>;
 #[doc = "Register `stg_syscfg_60` writer"]
 pub type W = crate::W<STG_SYSCFG_60_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_351_320` reader - u0_plda_pcie_k_phyparam_351_320"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_351_320_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_351_320` writer - u0_plda_pcie_k_phyparam_351_320"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_351_320` reader - u0_pcie_k_phyparam_351_320"]
+pub type U0_PCIE_K_PHYPARAM_351_320_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_351_320` writer - u0_pcie_k_phyparam_351_320"]
+pub type U0_PCIE_K_PHYPARAM_351_320_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_351_320"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_351_320(&self) -> U0_PLDA_PCIE_K_PHYPARAM_351_320_R {
-        U0_PLDA_PCIE_K_PHYPARAM_351_320_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_351_320(&self) -> U0_PCIE_K_PHYPARAM_351_320_R {
+        U0_PCIE_K_PHYPARAM_351_320_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_351_320"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_351_320"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_351_320(
+    pub fn u0_pcie_k_phyparam_351_320(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_351_320_W<STG_SYSCFG_60_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_351_320_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_351_320_W<STG_SYSCFG_60_SPEC> {
+        U0_PCIE_K_PHYPARAM_351_320_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_61.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_61.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_61_SPEC>;
 #[doc = "Register `stg_syscfg_61` writer"]
 pub type W = crate::W<STG_SYSCFG_61_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_383_352` reader - u0_plda_pcie_k_phyparam_383_352"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_383_352_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_383_352` writer - u0_plda_pcie_k_phyparam_383_352"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_383_352` reader - u0_pcie_k_phyparam_383_352"]
+pub type U0_PCIE_K_PHYPARAM_383_352_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_383_352` writer - u0_pcie_k_phyparam_383_352"]
+pub type U0_PCIE_K_PHYPARAM_383_352_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_383_352"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_383_352(&self) -> U0_PLDA_PCIE_K_PHYPARAM_383_352_R {
-        U0_PLDA_PCIE_K_PHYPARAM_383_352_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_383_352(&self) -> U0_PCIE_K_PHYPARAM_383_352_R {
+        U0_PCIE_K_PHYPARAM_383_352_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_383_352"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_383_352"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_383_352(
+    pub fn u0_pcie_k_phyparam_383_352(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_383_352_W<STG_SYSCFG_61_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_383_352_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_383_352_W<STG_SYSCFG_61_SPEC> {
+        U0_PCIE_K_PHYPARAM_383_352_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_62.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_62.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_62_SPEC>;
 #[doc = "Register `stg_syscfg_62` writer"]
 pub type W = crate::W<STG_SYSCFG_62_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_415_384` reader - u0_plda_pcie_k_phyparam_415_384"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_415_384_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_415_384` writer - u0_plda_pcie_k_phyparam_415_384"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_415_384` reader - u0_pcie_k_phyparam_415_384"]
+pub type U0_PCIE_K_PHYPARAM_415_384_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_415_384` writer - u0_pcie_k_phyparam_415_384"]
+pub type U0_PCIE_K_PHYPARAM_415_384_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_415_384"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_415_384(&self) -> U0_PLDA_PCIE_K_PHYPARAM_415_384_R {
-        U0_PLDA_PCIE_K_PHYPARAM_415_384_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_415_384(&self) -> U0_PCIE_K_PHYPARAM_415_384_R {
+        U0_PCIE_K_PHYPARAM_415_384_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_415_384"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_415_384"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_415_384(
+    pub fn u0_pcie_k_phyparam_415_384(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_415_384_W<STG_SYSCFG_62_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_415_384_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_415_384_W<STG_SYSCFG_62_SPEC> {
+        U0_PCIE_K_PHYPARAM_415_384_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_63.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_63.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_63_SPEC>;
 #[doc = "Register `stg_syscfg_63` writer"]
 pub type W = crate::W<STG_SYSCFG_63_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_447_416` reader - u0_plda_pcie_k_phyparam_447_416"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_447_416_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_447_416` writer - u0_plda_pcie_k_phyparam_447_416"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_447_416` reader - u0_pcie_k_phyparam_447_416"]
+pub type U0_PCIE_K_PHYPARAM_447_416_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_447_416` writer - u0_pcie_k_phyparam_447_416"]
+pub type U0_PCIE_K_PHYPARAM_447_416_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_447_416"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_447_416(&self) -> U0_PLDA_PCIE_K_PHYPARAM_447_416_R {
-        U0_PLDA_PCIE_K_PHYPARAM_447_416_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_447_416(&self) -> U0_PCIE_K_PHYPARAM_447_416_R {
+        U0_PCIE_K_PHYPARAM_447_416_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_447_416"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_447_416"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_447_416(
+    pub fn u0_pcie_k_phyparam_447_416(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_447_416_W<STG_SYSCFG_63_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_447_416_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_447_416_W<STG_SYSCFG_63_SPEC> {
+        U0_PCIE_K_PHYPARAM_447_416_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_64.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_64.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_64_SPEC>;
 #[doc = "Register `stg_syscfg_64` writer"]
 pub type W = crate::W<STG_SYSCFG_64_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_479_448` reader - u0_plda_pcie_k_phyparam_479_448"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_479_448_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_479_448` writer - u0_plda_pcie_k_phyparam_479_448"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_479_448` reader - u0_pcie_k_phyparam_479_448"]
+pub type U0_PCIE_K_PHYPARAM_479_448_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_479_448` writer - u0_pcie_k_phyparam_479_448"]
+pub type U0_PCIE_K_PHYPARAM_479_448_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_479_448"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_479_448(&self) -> U0_PLDA_PCIE_K_PHYPARAM_479_448_R {
-        U0_PLDA_PCIE_K_PHYPARAM_479_448_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_479_448(&self) -> U0_PCIE_K_PHYPARAM_479_448_R {
+        U0_PCIE_K_PHYPARAM_479_448_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_479_448"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_479_448"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_479_448(
+    pub fn u0_pcie_k_phyparam_479_448(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_479_448_W<STG_SYSCFG_64_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_479_448_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_479_448_W<STG_SYSCFG_64_SPEC> {
+        U0_PCIE_K_PHYPARAM_479_448_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_65.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_65.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_65_SPEC>;
 #[doc = "Register `stg_syscfg_65` writer"]
 pub type W = crate::W<STG_SYSCFG_65_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_511_480` reader - u0_plda_pcie_k_phyparam_511_480"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_511_480_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_511_480` writer - u0_plda_pcie_k_phyparam_511_480"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_511_480` reader - u0_pcie_k_phyparam_511_480"]
+pub type U0_PCIE_K_PHYPARAM_511_480_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_511_480` writer - u0_pcie_k_phyparam_511_480"]
+pub type U0_PCIE_K_PHYPARAM_511_480_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_511_480"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_511_480(&self) -> U0_PLDA_PCIE_K_PHYPARAM_511_480_R {
-        U0_PLDA_PCIE_K_PHYPARAM_511_480_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_511_480(&self) -> U0_PCIE_K_PHYPARAM_511_480_R {
+        U0_PCIE_K_PHYPARAM_511_480_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_511_480"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_511_480"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_511_480(
+    pub fn u0_pcie_k_phyparam_511_480(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_511_480_W<STG_SYSCFG_65_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_511_480_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_511_480_W<STG_SYSCFG_65_SPEC> {
+        U0_PCIE_K_PHYPARAM_511_480_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_66.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_66.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_66_SPEC>;
 #[doc = "Register `stg_syscfg_66` writer"]
 pub type W = crate::W<STG_SYSCFG_66_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_543_512` reader - u0_plda_pcie_k_phyparam_543_512"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_543_512_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_543_512` writer - u0_plda_pcie_k_phyparam_543_512"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_543_512_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_543_512` reader - u0_pcie_k_phyparam_543_512"]
+pub type U0_PCIE_K_PHYPARAM_543_512_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_543_512` writer - u0_pcie_k_phyparam_543_512"]
+pub type U0_PCIE_K_PHYPARAM_543_512_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_543_512"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_543_512"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_543_512(&self) -> U0_PLDA_PCIE_K_PHYPARAM_543_512_R {
-        U0_PLDA_PCIE_K_PHYPARAM_543_512_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_543_512(&self) -> U0_PCIE_K_PHYPARAM_543_512_R {
+        U0_PCIE_K_PHYPARAM_543_512_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_543_512"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_543_512"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_543_512(
+    pub fn u0_pcie_k_phyparam_543_512(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_543_512_W<STG_SYSCFG_66_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_543_512_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_543_512_W<STG_SYSCFG_66_SPEC> {
+        U0_PCIE_K_PHYPARAM_543_512_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_67.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_67.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_67_SPEC>;
 #[doc = "Register `stg_syscfg_67` writer"]
 pub type W = crate::W<STG_SYSCFG_67_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_575_544` reader - u0_plda_pcie_k_phyparam_575_544"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_575_544_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_575_544` writer - u0_plda_pcie_k_phyparam_575_544"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_575_544_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_575_544` reader - u0_pcie_k_phyparam_575_544"]
+pub type U0_PCIE_K_PHYPARAM_575_544_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_575_544` writer - u0_pcie_k_phyparam_575_544"]
+pub type U0_PCIE_K_PHYPARAM_575_544_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_575_544"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_575_544"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_575_544(&self) -> U0_PLDA_PCIE_K_PHYPARAM_575_544_R {
-        U0_PLDA_PCIE_K_PHYPARAM_575_544_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_575_544(&self) -> U0_PCIE_K_PHYPARAM_575_544_R {
+        U0_PCIE_K_PHYPARAM_575_544_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_575_544"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_575_544"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_575_544(
+    pub fn u0_pcie_k_phyparam_575_544(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_575_544_W<STG_SYSCFG_67_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_575_544_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_575_544_W<STG_SYSCFG_67_SPEC> {
+        U0_PCIE_K_PHYPARAM_575_544_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_68.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_68.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_68_SPEC>;
 #[doc = "Register `stg_syscfg_68` writer"]
 pub type W = crate::W<STG_SYSCFG_68_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_607_576` reader - u0_plda_pcie_k_phyparam_607_576"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_607_576_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_607_576` writer - u0_plda_pcie_k_phyparam_607_576"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_607_576_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_607_576` reader - u0_pcie_k_phyparam_607_576"]
+pub type U0_PCIE_K_PHYPARAM_607_576_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_607_576` writer - u0_pcie_k_phyparam_607_576"]
+pub type U0_PCIE_K_PHYPARAM_607_576_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_607_576"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_607_576"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_607_576(&self) -> U0_PLDA_PCIE_K_PHYPARAM_607_576_R {
-        U0_PLDA_PCIE_K_PHYPARAM_607_576_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_607_576(&self) -> U0_PCIE_K_PHYPARAM_607_576_R {
+        U0_PCIE_K_PHYPARAM_607_576_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_607_576"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_607_576"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_607_576(
+    pub fn u0_pcie_k_phyparam_607_576(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_607_576_W<STG_SYSCFG_68_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_607_576_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_607_576_W<STG_SYSCFG_68_SPEC> {
+        U0_PCIE_K_PHYPARAM_607_576_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_69.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_69.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_69_SPEC>;
 #[doc = "Register `stg_syscfg_69` writer"]
 pub type W = crate::W<STG_SYSCFG_69_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_639_608` reader - u0_plda_pcie_k_phyparam_639_608"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_639_608_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_639_608` writer - u0_plda_pcie_k_phyparam_639_608"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_639_608_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_639_608` reader - u0_pcie_k_phyparam_639_608"]
+pub type U0_PCIE_K_PHYPARAM_639_608_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_639_608` writer - u0_pcie_k_phyparam_639_608"]
+pub type U0_PCIE_K_PHYPARAM_639_608_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_639_608"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_639_608"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_639_608(&self) -> U0_PLDA_PCIE_K_PHYPARAM_639_608_R {
-        U0_PLDA_PCIE_K_PHYPARAM_639_608_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_639_608(&self) -> U0_PCIE_K_PHYPARAM_639_608_R {
+        U0_PCIE_K_PHYPARAM_639_608_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_639_608"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_639_608"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_639_608(
+    pub fn u0_pcie_k_phyparam_639_608(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_639_608_W<STG_SYSCFG_69_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_639_608_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_639_608_W<STG_SYSCFG_69_SPEC> {
+        U0_PCIE_K_PHYPARAM_639_608_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_7.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_7.rs
@@ -2,28 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_7_SPEC>;
 #[doc = "Register `stg_syscfg_7` writer"]
 pub type W = crate::W<STG_SYSCFG_7_SPEC>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_exception_vector` reader - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_exception_vector` writer - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_nmi_exception_vector` reader - u0_e2_nmi_exception_vector"]
+pub type U0_E2_NMI_EXCEPTION_VECTOR_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_nmi_exception_vector` writer - u0_e2_nmi_exception_vector"]
+pub type U0_E2_NMI_EXCEPTION_VECTOR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_exception_vector"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_exception_vector(
-        &self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R {
-        U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_R::new(self.bits)
+    pub fn u0_e2_nmi_exception_vector(&self) -> U0_E2_NMI_EXCEPTION_VECTOR_R {
+        U0_E2_NMI_EXCEPTION_VECTOR_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_exception_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_exception_vector"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_exception_vector(
+    pub fn u0_e2_nmi_exception_vector(
         &mut self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W<STG_SYSCFG_7_SPEC> {
-        U0_E2_SFT7110_NMI_0_RNMI_EXCEPTION_VECTOR_W::new(self, 0)
+    ) -> U0_E2_NMI_EXCEPTION_VECTOR_W<STG_SYSCFG_7_SPEC> {
+        U0_E2_NMI_EXCEPTION_VECTOR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_70.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_70.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_70_SPEC>;
 #[doc = "Register `stg_syscfg_70` writer"]
 pub type W = crate::W<STG_SYSCFG_70_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_671_640` reader - u0_plda_pcie_k_phyparam_671_640"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_671_640_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_671_640` writer - u0_plda_pcie_k_phyparam_671_640"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_671_640_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_671_640` reader - u0_pcie_k_phyparam_671_640"]
+pub type U0_PCIE_K_PHYPARAM_671_640_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_671_640` writer - u0_pcie_k_phyparam_671_640"]
+pub type U0_PCIE_K_PHYPARAM_671_640_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_671_640"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_671_640"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_671_640(&self) -> U0_PLDA_PCIE_K_PHYPARAM_671_640_R {
-        U0_PLDA_PCIE_K_PHYPARAM_671_640_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_671_640(&self) -> U0_PCIE_K_PHYPARAM_671_640_R {
+        U0_PCIE_K_PHYPARAM_671_640_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_671_640"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_671_640"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_671_640(
+    pub fn u0_pcie_k_phyparam_671_640(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_671_640_W<STG_SYSCFG_70_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_671_640_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_671_640_W<STG_SYSCFG_70_SPEC> {
+        U0_PCIE_K_PHYPARAM_671_640_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_71.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_71.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_71_SPEC>;
 #[doc = "Register `stg_syscfg_71` writer"]
 pub type W = crate::W<STG_SYSCFG_71_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_703_672` reader - u0_plda_pcie_k_phyparam_703_672"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_703_672_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_703_672` writer - u0_plda_pcie_k_phyparam_703_672"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_703_672_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_703_672` reader - u0_pcie_k_phyparam_703_672"]
+pub type U0_PCIE_K_PHYPARAM_703_672_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_703_672` writer - u0_pcie_k_phyparam_703_672"]
+pub type U0_PCIE_K_PHYPARAM_703_672_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_703_672"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_703_672"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_703_672(&self) -> U0_PLDA_PCIE_K_PHYPARAM_703_672_R {
-        U0_PLDA_PCIE_K_PHYPARAM_703_672_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_703_672(&self) -> U0_PCIE_K_PHYPARAM_703_672_R {
+        U0_PCIE_K_PHYPARAM_703_672_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_703_672"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_703_672"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_703_672(
+    pub fn u0_pcie_k_phyparam_703_672(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_703_672_W<STG_SYSCFG_71_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_703_672_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_703_672_W<STG_SYSCFG_71_SPEC> {
+        U0_PCIE_K_PHYPARAM_703_672_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_72.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_72.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_72_SPEC>;
 #[doc = "Register `stg_syscfg_72` writer"]
 pub type W = crate::W<STG_SYSCFG_72_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_735_704` reader - u0_plda_pcie_k_phyparam_735_704"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_735_704_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_735_704` writer - u0_plda_pcie_k_phyparam_735_704"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_735_704_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_735_704` reader - u0_pcie_k_phyparam_735_704"]
+pub type U0_PCIE_K_PHYPARAM_735_704_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_735_704` writer - u0_pcie_k_phyparam_735_704"]
+pub type U0_PCIE_K_PHYPARAM_735_704_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_735_704"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_735_704"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_735_704(&self) -> U0_PLDA_PCIE_K_PHYPARAM_735_704_R {
-        U0_PLDA_PCIE_K_PHYPARAM_735_704_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_735_704(&self) -> U0_PCIE_K_PHYPARAM_735_704_R {
+        U0_PCIE_K_PHYPARAM_735_704_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_735_704"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_735_704"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_735_704(
+    pub fn u0_pcie_k_phyparam_735_704(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_735_704_W<STG_SYSCFG_72_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_735_704_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_735_704_W<STG_SYSCFG_72_SPEC> {
+        U0_PCIE_K_PHYPARAM_735_704_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_73.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_73.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_73_SPEC>;
 #[doc = "Register `stg_syscfg_73` writer"]
 pub type W = crate::W<STG_SYSCFG_73_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_767_736` reader - u0_plda_pcie_k_phyparam_767_736"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_767_736_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_767_736` writer - u0_plda_pcie_k_phyparam_767_736"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_767_736_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_767_736` reader - u0_pcie_k_phyparam_767_736"]
+pub type U0_PCIE_K_PHYPARAM_767_736_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_767_736` writer - u0_pcie_k_phyparam_767_736"]
+pub type U0_PCIE_K_PHYPARAM_767_736_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_767_736"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_767_736"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_767_736(&self) -> U0_PLDA_PCIE_K_PHYPARAM_767_736_R {
-        U0_PLDA_PCIE_K_PHYPARAM_767_736_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_767_736(&self) -> U0_PCIE_K_PHYPARAM_767_736_R {
+        U0_PCIE_K_PHYPARAM_767_736_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_767_736"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_767_736"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_767_736(
+    pub fn u0_pcie_k_phyparam_767_736(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_767_736_W<STG_SYSCFG_73_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_767_736_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_767_736_W<STG_SYSCFG_73_SPEC> {
+        U0_PCIE_K_PHYPARAM_767_736_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_74.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_74.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_74_SPEC>;
 #[doc = "Register `stg_syscfg_74` writer"]
 pub type W = crate::W<STG_SYSCFG_74_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_799_768` reader - u0_plda_pcie_k_phyparam_799_768"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_799_768_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_799_768` writer - u0_plda_pcie_k_phyparam_799_768"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_799_768_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_799_768` reader - u0_pcie_k_phyparam_799_768"]
+pub type U0_PCIE_K_PHYPARAM_799_768_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_799_768` writer - u0_pcie_k_phyparam_799_768"]
+pub type U0_PCIE_K_PHYPARAM_799_768_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_799_768"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_799_768"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_799_768(&self) -> U0_PLDA_PCIE_K_PHYPARAM_799_768_R {
-        U0_PLDA_PCIE_K_PHYPARAM_799_768_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_799_768(&self) -> U0_PCIE_K_PHYPARAM_799_768_R {
+        U0_PCIE_K_PHYPARAM_799_768_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_799_768"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_799_768"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_799_768(
+    pub fn u0_pcie_k_phyparam_799_768(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_799_768_W<STG_SYSCFG_74_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_799_768_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_799_768_W<STG_SYSCFG_74_SPEC> {
+        U0_PCIE_K_PHYPARAM_799_768_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_75.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_75.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_75_SPEC>;
 #[doc = "Register `stg_syscfg_75` writer"]
 pub type W = crate::W<STG_SYSCFG_75_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_831_800` reader - u0_plda_pcie_k_phyparam_831_800"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_831_800_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_831_800` writer - u0_plda_pcie_k_phyparam_831_800"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_831_800_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_k_phyparam_831_800` reader - u0_pcie_k_phyparam_831_800"]
+pub type U0_PCIE_K_PHYPARAM_831_800_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_k_phyparam_831_800` writer - u0_pcie_k_phyparam_831_800"]
+pub type U0_PCIE_K_PHYPARAM_831_800_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_831_800"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_831_800"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_831_800(&self) -> U0_PLDA_PCIE_K_PHYPARAM_831_800_R {
-        U0_PLDA_PCIE_K_PHYPARAM_831_800_R::new(self.bits)
+    pub fn u0_pcie_k_phyparam_831_800(&self) -> U0_PCIE_K_PHYPARAM_831_800_R {
+        U0_PCIE_K_PHYPARAM_831_800_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_k_phyparam_831_800"]
+    #[doc = "Bits 0:31 - u0_pcie_k_phyparam_831_800"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_831_800(
+    pub fn u0_pcie_k_phyparam_831_800(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_831_800_W<STG_SYSCFG_75_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_831_800_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_831_800_W<STG_SYSCFG_75_SPEC> {
+        U0_PCIE_K_PHYPARAM_831_800_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_76.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_76.rs
@@ -2,62 +2,62 @@
 pub type R = crate::R<STG_SYSCFG_76_SPEC>;
 #[doc = "Register `stg_syscfg_76` writer"]
 pub type W = crate::W<STG_SYSCFG_76_SPEC>;
-#[doc = "Field `u0_plda_pcie_k_phyparam_839_832` reader - u0_plda_pcie_k_phyparam_839_832"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_k_phyparam_839_832` writer - u0_plda_pcie_k_phyparam_839_832"]
-pub type U0_PLDA_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
-#[doc = "Field `u0_plda_pcie_k_rp_nep` reader - u0_plda_pcie_k_rp_nep"]
-pub type U0_PLDA_PCIE_K_RP_NEP_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_k_rp_nep` writer - u0_plda_pcie_k_rp_nep"]
-pub type U0_PLDA_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_l1sub_entack` reader - u0_plda_pcie_l1sub_entack"]
-pub type U0_PLDA_PCIE_L1SUB_ENTACK_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_l1sub_entreq` reader - u0_plda_pcie_l1sub_entreq"]
-pub type U0_PLDA_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_l1sub_entreq` writer - u0_plda_pcie_l1sub_entreq"]
-pub type U0_PLDA_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_k_phyparam_839_832` reader - u0_pcie_k_phyparam_839_832"]
+pub type U0_PCIE_K_PHYPARAM_839_832_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_k_phyparam_839_832` writer - u0_pcie_k_phyparam_839_832"]
+pub type U0_PCIE_K_PHYPARAM_839_832_W<'a, REG> = crate::FieldWriter<'a, REG, 8>;
+#[doc = "Field `u0_pcie_k_rp_nep` reader - u0_pcie_k_rp_nep"]
+pub type U0_PCIE_K_RP_NEP_R = crate::BitReader;
+#[doc = "Field `u0_pcie_k_rp_nep` writer - u0_pcie_k_rp_nep"]
+pub type U0_PCIE_K_RP_NEP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_l1sub_entack` reader - u0_pcie_l1sub_entack"]
+pub type U0_PCIE_L1SUB_ENTACK_R = crate::BitReader;
+#[doc = "Field `u0_pcie_l1sub_entreq` reader - u0_pcie_l1sub_entreq"]
+pub type U0_PCIE_L1SUB_ENTREQ_R = crate::BitReader;
+#[doc = "Field `u0_pcie_l1sub_entreq` writer - u0_pcie_l1sub_entreq"]
+pub type U0_PCIE_L1SUB_ENTREQ_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bits 0:7 - u0_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u0_pcie_k_phyparam_839_832"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_phyparam_839_832(&self) -> U0_PLDA_PCIE_K_PHYPARAM_839_832_R {
-        U0_PLDA_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
+    pub fn u0_pcie_k_phyparam_839_832(&self) -> U0_PCIE_K_PHYPARAM_839_832_R {
+        U0_PCIE_K_PHYPARAM_839_832_R::new((self.bits & 0xff) as u8)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u0_pcie_k_rp_nep"]
     #[inline(always)]
-    pub fn u0_plda_pcie_k_rp_nep(&self) -> U0_PLDA_PCIE_K_RP_NEP_R {
-        U0_PLDA_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_pcie_k_rp_nep(&self) -> U0_PCIE_K_RP_NEP_R {
+        U0_PCIE_K_RP_NEP_R::new(((self.bits >> 8) & 1) != 0)
     }
-    #[doc = "Bit 9 - u0_plda_pcie_l1sub_entack"]
+    #[doc = "Bit 9 - u0_pcie_l1sub_entack"]
     #[inline(always)]
-    pub fn u0_plda_pcie_l1sub_entack(&self) -> U0_PLDA_PCIE_L1SUB_ENTACK_R {
-        U0_PLDA_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_pcie_l1sub_entack(&self) -> U0_PCIE_L1SUB_ENTACK_R {
+        U0_PCIE_L1SUB_ENTACK_R::new(((self.bits >> 9) & 1) != 0)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u0_pcie_l1sub_entreq"]
     #[inline(always)]
-    pub fn u0_plda_pcie_l1sub_entreq(&self) -> U0_PLDA_PCIE_L1SUB_ENTREQ_R {
-        U0_PLDA_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_pcie_l1sub_entreq(&self) -> U0_PCIE_L1SUB_ENTREQ_R {
+        U0_PCIE_L1SUB_ENTREQ_R::new(((self.bits >> 10) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bits 0:7 - u0_plda_pcie_k_phyparam_839_832"]
+    #[doc = "Bits 0:7 - u0_pcie_k_phyparam_839_832"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_phyparam_839_832(
+    pub fn u0_pcie_k_phyparam_839_832(
         &mut self,
-    ) -> U0_PLDA_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
+    ) -> U0_PCIE_K_PHYPARAM_839_832_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_K_PHYPARAM_839_832_W::new(self, 0)
     }
-    #[doc = "Bit 8 - u0_plda_pcie_k_rp_nep"]
+    #[doc = "Bit 8 - u0_pcie_k_rp_nep"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_k_rp_nep(&mut self) -> U0_PLDA_PCIE_K_RP_NEP_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_K_RP_NEP_W::new(self, 8)
+    pub fn u0_pcie_k_rp_nep(&mut self) -> U0_PCIE_K_RP_NEP_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_K_RP_NEP_W::new(self, 8)
     }
-    #[doc = "Bit 10 - u0_plda_pcie_l1sub_entreq"]
+    #[doc = "Bit 10 - u0_pcie_l1sub_entreq"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_l1sub_entreq(&mut self) -> U0_PLDA_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_76_SPEC> {
-        U0_PLDA_PCIE_L1SUB_ENTREQ_W::new(self, 10)
+    pub fn u0_pcie_l1sub_entreq(&mut self) -> U0_PCIE_L1SUB_ENTREQ_W<STG_SYSCFG_76_SPEC> {
+        U0_PCIE_L1SUB_ENTREQ_W::new(self, 10)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_77.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_77.rs
@@ -2,25 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_77_SPEC>;
 #[doc = "Register `stg_syscfg_77` writer"]
 pub type W = crate::W<STG_SYSCFG_77_SPEC>;
-#[doc = "Field `u0_plda_pcie_local_interrupt_in` reader - u0_plda_pcie_local_interrupt_in"]
-pub type U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_local_interrupt_in` writer - u0_plda_pcie_local_interrupt_in"]
-pub type U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_local_interrupt_in` reader - u0_pcie_local_interrupt_in"]
+pub type U0_PCIE_LOCAL_INTERRUPT_IN_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_local_interrupt_in` writer - u0_pcie_local_interrupt_in"]
+pub type U0_PCIE_LOCAL_INTERRUPT_IN_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u0_pcie_local_interrupt_in"]
     #[inline(always)]
-    pub fn u0_plda_pcie_local_interrupt_in(&self) -> U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R {
-        U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
+    pub fn u0_pcie_local_interrupt_in(&self) -> U0_PCIE_LOCAL_INTERRUPT_IN_R {
+        U0_PCIE_LOCAL_INTERRUPT_IN_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_local_interrupt_in"]
+    #[doc = "Bits 0:31 - u0_pcie_local_interrupt_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_local_interrupt_in(
+    pub fn u0_pcie_local_interrupt_in(
         &mut self,
-    ) -> U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_77_SPEC> {
-        U0_PLDA_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
+    ) -> U0_PCIE_LOCAL_INTERRUPT_IN_W<STG_SYSCFG_77_SPEC> {
+        U0_PCIE_LOCAL_INTERRUPT_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_78.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_78.rs
@@ -2,108 +2,100 @@
 pub type R = crate::R<STG_SYSCFG_78_SPEC>;
 #[doc = "Register `stg_syscfg_78` writer"]
 pub type W = crate::W<STG_SYSCFG_78_SPEC>;
-#[doc = "Field `u0_plda_pcie_mperstn` reader - u0_plda_pcie_mperstn"]
-pub type U0_PLDA_PCIE_MPERSTN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_mperstn` writer - u0_plda_pcie_mperstn"]
-pub type U0_PLDA_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_ebuf_mode` reader - u0_plda_pcie_pcie_ebuf_mode"]
-pub type U0_PLDA_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_ebuf_mode` writer - u0_plda_pcie_pcie_ebuf_mode"]
-pub type U0_PLDA_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_phy_test_cfg` reader - u0_plda_pcie_pcie_phy_test_cfg"]
-pub type U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pcie_phy_test_cfg` writer - u0_plda_pcie_pcie_phy_test_cfg"]
-pub type U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
-#[doc = "Field `u0_plda_pcie_pcie_rx_eq_training` reader - u0_plda_pcie_pcie_rx_eq_training"]
-pub type U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_rx_eq_training` writer - u0_plda_pcie_pcie_rx_eq_training"]
-pub type U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_rxterm_en` reader - u0_plda_pcie_pcie_rxterm_en"]
-pub type U0_PLDA_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_rxterm_en` writer - u0_plda_pcie_pcie_rxterm_en"]
-pub type U0_PLDA_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pcie_tx_onezeros` reader - u0_plda_pcie_pcie_tx_onezeros"]
-pub type U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pcie_tx_onezeros` writer - u0_plda_pcie_pcie_tx_onezeros"]
-pub type U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_mperstn` reader - u0_pcie_mperstn"]
+pub type U0_PCIE_MPERSTN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_mperstn` writer - u0_pcie_mperstn"]
+pub type U0_PCIE_MPERSTN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_ebuf_mode` reader - u0_pcie_pcie_ebuf_mode"]
+pub type U0_PCIE_PCIE_EBUF_MODE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_ebuf_mode` writer - u0_pcie_pcie_ebuf_mode"]
+pub type U0_PCIE_PCIE_EBUF_MODE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_phy_test_cfg` reader - u0_pcie_pcie_phy_test_cfg"]
+pub type U0_PCIE_PCIE_PHY_TEST_CFG_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pcie_phy_test_cfg` writer - u0_pcie_pcie_phy_test_cfg"]
+pub type U0_PCIE_PCIE_PHY_TEST_CFG_W<'a, REG> = crate::FieldWriter<'a, REG, 23, u32>;
+#[doc = "Field `u0_pcie_pcie_rx_eq_training` reader - u0_pcie_pcie_rx_eq_training"]
+pub type U0_PCIE_PCIE_RX_EQ_TRAINING_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_rx_eq_training` writer - u0_pcie_pcie_rx_eq_training"]
+pub type U0_PCIE_PCIE_RX_EQ_TRAINING_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_rxterm_en` reader - u0_pcie_pcie_rxterm_en"]
+pub type U0_PCIE_PCIE_RXTERM_EN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_rxterm_en` writer - u0_pcie_pcie_rxterm_en"]
+pub type U0_PCIE_PCIE_RXTERM_EN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie_tx_onezeros` reader - u0_pcie_pcie_tx_onezeros"]
+pub type U0_PCIE_PCIE_TX_ONEZEROS_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie_tx_onezeros` writer - u0_pcie_pcie_tx_onezeros"]
+pub type U0_PCIE_PCIE_TX_ONEZEROS_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
-    #[doc = "Bit 0 - u0_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u0_pcie_mperstn"]
     #[inline(always)]
-    pub fn u0_plda_pcie_mperstn(&self) -> U0_PLDA_PCIE_MPERSTN_R {
-        U0_PLDA_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
+    pub fn u0_pcie_mperstn(&self) -> U0_PCIE_MPERSTN_R {
+        U0_PCIE_MPERSTN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u0_pcie_pcie_ebuf_mode"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_ebuf_mode(&self) -> U0_PLDA_PCIE_PCIE_EBUF_MODE_R {
-        U0_PLDA_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pcie_pcie_ebuf_mode(&self) -> U0_PCIE_PCIE_EBUF_MODE_R {
+        U0_PCIE_PCIE_EBUF_MODE_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bits 2:24 - u0_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u0_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_phy_test_cfg(&self) -> U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R {
-        U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
+    pub fn u0_pcie_pcie_phy_test_cfg(&self) -> U0_PCIE_PCIE_PHY_TEST_CFG_R {
+        U0_PCIE_PCIE_PHY_TEST_CFG_R::new((self.bits >> 2) & 0x007f_ffff)
     }
-    #[doc = "Bit 25 - u0_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u0_pcie_pcie_rx_eq_training"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_rx_eq_training(&self) -> U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R {
-        U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_pcie_pcie_rx_eq_training(&self) -> U0_PCIE_PCIE_RX_EQ_TRAINING_R {
+        U0_PCIE_PCIE_RX_EQ_TRAINING_R::new(((self.bits >> 25) & 1) != 0)
     }
-    #[doc = "Bit 26 - u0_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u0_pcie_pcie_rxterm_en"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_rxterm_en(&self) -> U0_PLDA_PCIE_PCIE_RXTERM_EN_R {
-        U0_PLDA_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_pcie_pcie_rxterm_en(&self) -> U0_PCIE_PCIE_RXTERM_EN_R {
+        U0_PCIE_PCIE_RXTERM_EN_R::new(((self.bits >> 26) & 1) != 0)
     }
-    #[doc = "Bit 27 - u0_plda_pcie_pcie_tx_onezeros"]
+    #[doc = "Bit 27 - u0_pcie_pcie_tx_onezeros"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pcie_tx_onezeros(&self) -> U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R {
-        U0_PLDA_PCIE_PCIE_TX_ONEZEROS_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_pcie_pcie_tx_onezeros(&self) -> U0_PCIE_PCIE_TX_ONEZEROS_R {
+        U0_PCIE_PCIE_TX_ONEZEROS_R::new(((self.bits >> 27) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u0_plda_pcie_mperstn"]
+    #[doc = "Bit 0 - u0_pcie_mperstn"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_mperstn(&mut self) -> U0_PLDA_PCIE_MPERSTN_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_MPERSTN_W::new(self, 0)
+    pub fn u0_pcie_mperstn(&mut self) -> U0_PCIE_MPERSTN_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_MPERSTN_W::new(self, 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pcie_ebuf_mode"]
+    #[doc = "Bit 1 - u0_pcie_pcie_ebuf_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_ebuf_mode(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
+    pub fn u0_pcie_pcie_ebuf_mode(&mut self) -> U0_PCIE_PCIE_EBUF_MODE_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_EBUF_MODE_W::new(self, 1)
     }
-    #[doc = "Bits 2:24 - u0_plda_pcie_pcie_phy_test_cfg"]
+    #[doc = "Bits 2:24 - u0_pcie_pcie_phy_test_cfg"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_phy_test_cfg(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
+    pub fn u0_pcie_pcie_phy_test_cfg(&mut self) -> U0_PCIE_PCIE_PHY_TEST_CFG_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_PHY_TEST_CFG_W::new(self, 2)
     }
-    #[doc = "Bit 25 - u0_plda_pcie_pcie_rx_eq_training"]
+    #[doc = "Bit 25 - u0_pcie_pcie_rx_eq_training"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_rx_eq_training(
+    pub fn u0_pcie_pcie_rx_eq_training(
         &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
+    ) -> U0_PCIE_PCIE_RX_EQ_TRAINING_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_RX_EQ_TRAINING_W::new(self, 25)
     }
-    #[doc = "Bit 26 - u0_plda_pcie_pcie_rxterm_en"]
+    #[doc = "Bit 26 - u0_pcie_pcie_rxterm_en"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_rxterm_en(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
+    pub fn u0_pcie_pcie_rxterm_en(&mut self) -> U0_PCIE_PCIE_RXTERM_EN_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_RXTERM_EN_W::new(self, 26)
     }
-    #[doc = "Bit 27 - u0_plda_pcie_pcie_tx_onezeros"]
+    #[doc = "Bit 27 - u0_pcie_pcie_tx_onezeros"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pcie_tx_onezeros(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W<STG_SYSCFG_78_SPEC> {
-        U0_PLDA_PCIE_PCIE_TX_ONEZEROS_W::new(self, 27)
+    pub fn u0_pcie_pcie_tx_onezeros(&mut self) -> U0_PCIE_PCIE_TX_ONEZEROS_W<STG_SYSCFG_78_SPEC> {
+        U0_PCIE_PCIE_TX_ONEZEROS_W::new(self, 27)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_79.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_79.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_79_SPEC>;
 #[doc = "Register `stg_syscfg_79` writer"]
 pub type W = crate::W<STG_SYSCFG_79_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf0_offset` reader - u0_plda_pcie_pf0_offset"]
-pub type U0_PLDA_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf0_offset` writer - u0_plda_pcie_pf0_offset"]
-pub type U0_PLDA_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf0_offset` reader - u0_pcie_pf0_offset"]
+pub type U0_PCIE_PF0_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf0_offset` writer - u0_pcie_pf0_offset"]
+pub type U0_PCIE_PF0_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf0_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf0_offset(&self) -> U0_PLDA_PCIE_PF0_OFFSET_R {
-        U0_PLDA_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf0_offset(&self) -> U0_PCIE_PF0_OFFSET_R {
+        U0_PCIE_PF0_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf0_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf0_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf0_offset(&mut self) -> U0_PLDA_PCIE_PF0_OFFSET_W<STG_SYSCFG_79_SPEC> {
-        U0_PLDA_PCIE_PF0_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf0_offset(&mut self) -> U0_PCIE_PF0_OFFSET_W<STG_SYSCFG_79_SPEC> {
+        U0_PCIE_PF0_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_8.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_8.rs
@@ -2,28 +2,25 @@
 pub type R = crate::R<STG_SYSCFG_8_SPEC>;
 #[doc = "Register `stg_syscfg_8` writer"]
 pub type W = crate::W<STG_SYSCFG_8_SPEC>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_interrupt_vector` reader - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_nmi_0_rnmi_interrupt_vector` writer - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
-pub type U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W<'a, REG> =
-    crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_nmi_interrupt_vector` reader - u0_e2_nmi_interrupt_vector"]
+pub type U0_E2_NMI_INTERRUPT_VECTOR_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_nmi_interrupt_vector` writer - u0_e2_nmi_interrupt_vector"]
+pub type U0_E2_NMI_INTERRUPT_VECTOR_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_interrupt_vector"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_interrupt_vector(
-        &self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R {
-        U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_R::new(self.bits)
+    pub fn u0_e2_nmi_interrupt_vector(&self) -> U0_E2_NMI_INTERRUPT_VECTOR_R {
+        U0_E2_NMI_INTERRUPT_VECTOR_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_nmi_0_rnmi_interrupt_vector"]
+    #[doc = "Bits 0:31 - u0_e2_nmi_interrupt_vector"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_nmi_0_rnmi_interrupt_vector(
+    pub fn u0_e2_nmi_interrupt_vector(
         &mut self,
-    ) -> U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W<STG_SYSCFG_8_SPEC> {
-        U0_E2_SFT7110_NMI_0_RNMI_INTERRUPT_VECTOR_W::new(self, 0)
+    ) -> U0_E2_NMI_INTERRUPT_VECTOR_W<STG_SYSCFG_8_SPEC> {
+        U0_E2_NMI_INTERRUPT_VECTOR_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_80.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_80.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_80_SPEC>;
 #[doc = "Register `stg_syscfg_80` writer"]
 pub type W = crate::W<STG_SYSCFG_80_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf1_offset` reader - u0_plda_pcie_pf1_offset"]
-pub type U0_PLDA_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf1_offset` writer - u0_plda_pcie_pf1_offset"]
-pub type U0_PLDA_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf1_offset` reader - u0_pcie_pf1_offset"]
+pub type U0_PCIE_PF1_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf1_offset` writer - u0_pcie_pf1_offset"]
+pub type U0_PCIE_PF1_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf1_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf1_offset(&self) -> U0_PLDA_PCIE_PF1_OFFSET_R {
-        U0_PLDA_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf1_offset(&self) -> U0_PCIE_PF1_OFFSET_R {
+        U0_PCIE_PF1_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf1_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf1_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf1_offset(&mut self) -> U0_PLDA_PCIE_PF1_OFFSET_W<STG_SYSCFG_80_SPEC> {
-        U0_PLDA_PCIE_PF1_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf1_offset(&mut self) -> U0_PCIE_PF1_OFFSET_W<STG_SYSCFG_80_SPEC> {
+        U0_PCIE_PF1_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_81.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_81.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_81_SPEC>;
 #[doc = "Register `stg_syscfg_81` writer"]
 pub type W = crate::W<STG_SYSCFG_81_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf2_offset` reader - u0_plda_pcie_pf2_offset"]
-pub type U0_PLDA_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf2_offset` writer - u0_plda_pcie_pf2_offset"]
-pub type U0_PLDA_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_pf2_offset` reader - u0_pcie_pf2_offset"]
+pub type U0_PCIE_PF2_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf2_offset` writer - u0_pcie_pf2_offset"]
+pub type U0_PCIE_PF2_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf2_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf2_offset(&self) -> U0_PLDA_PCIE_PF2_OFFSET_R {
-        U0_PLDA_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf2_offset(&self) -> U0_PCIE_PF2_OFFSET_R {
+        U0_PCIE_PF2_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf2_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf2_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf2_offset(&mut self) -> U0_PLDA_PCIE_PF2_OFFSET_W<STG_SYSCFG_81_SPEC> {
-        U0_PLDA_PCIE_PF2_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf2_offset(&mut self) -> U0_PCIE_PF2_OFFSET_W<STG_SYSCFG_81_SPEC> {
+        U0_PCIE_PF2_OFFSET_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_82.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_82.rs
@@ -2,76 +2,74 @@
 pub type R = crate::R<STG_SYSCFG_82_SPEC>;
 #[doc = "Register `stg_syscfg_82` writer"]
 pub type W = crate::W<STG_SYSCFG_82_SPEC>;
-#[doc = "Field `u0_plda_pcie_pf3_offset` reader - u0_plda_pcie_pf3_offset"]
-pub type U0_PLDA_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_pf3_offset` writer - u0_plda_pcie_pf3_offset"]
-pub type U0_PLDA_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
-#[doc = "Field `u0_plda_pcie_phy_mode` reader - u0_plda_pcie_phy_mode"]
-pub type U0_PLDA_PCIE_PHY_MODE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_phy_mode` writer - u0_plda_pcie_phy_mode"]
-pub type U0_PLDA_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
-#[doc = "Field `u0_plda_pcie_pl_clkrem_allow` reader - u0_plda_pcie_pl_clkrem_allow"]
-pub type U0_PLDA_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_clkrem_allow` writer - u0_plda_pcie_pl_clkrem_allow"]
-pub type U0_PLDA_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pl_clkreq_oen` reader - u0_plda_pcie_pl_clkreq_oen"]
-pub type U0_PLDA_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_equ_phase` reader - u0_plda_pcie_pl_equ_phase"]
-pub type U0_PLDA_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
-#[doc = "Field `u0_plda_pcie_pl_ltssm` reader - u0_plda_pcie_pl_ltssm"]
-pub type U0_PLDA_PCIE_PL_LTSSM_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pf3_offset` reader - u0_pcie_pf3_offset"]
+pub type U0_PCIE_PF3_OFFSET_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pf3_offset` writer - u0_pcie_pf3_offset"]
+pub type U0_PCIE_PF3_OFFSET_W<'a, REG> = crate::FieldWriter<'a, REG, 20, u32>;
+#[doc = "Field `u0_pcie_phy_mode` reader - u0_pcie_phy_mode"]
+pub type U0_PCIE_PHY_MODE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_phy_mode` writer - u0_pcie_phy_mode"]
+pub type U0_PCIE_PHY_MODE_W<'a, REG> = crate::FieldWriter<'a, REG, 2>;
+#[doc = "Field `u0_pcie_pl_clkrem_allow` reader - u0_pcie_pl_clkrem_allow"]
+pub type U0_PCIE_PL_CLKREM_ALLOW_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_clkrem_allow` writer - u0_pcie_pl_clkrem_allow"]
+pub type U0_PCIE_PL_CLKREM_ALLOW_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pl_clkreq_oen` reader - u0_pcie_pl_clkreq_oen"]
+pub type U0_PCIE_PL_CLKREQ_OEN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_equ_phase` reader - u0_pcie_pl_equ_phase"]
+pub type U0_PCIE_PL_EQU_PHASE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pl_ltssm` reader - u0_pcie_pl_ltssm"]
+pub type U0_PCIE_PL_LTSSM_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf3_offset"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pf3_offset(&self) -> U0_PLDA_PCIE_PF3_OFFSET_R {
-        U0_PLDA_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
+    pub fn u0_pcie_pf3_offset(&self) -> U0_PCIE_PF3_OFFSET_R {
+        U0_PCIE_PF3_OFFSET_R::new(self.bits & 0x000f_ffff)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u0_pcie_phy_mode"]
     #[inline(always)]
-    pub fn u0_plda_pcie_phy_mode(&self) -> U0_PLDA_PCIE_PHY_MODE_R {
-        U0_PLDA_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
+    pub fn u0_pcie_phy_mode(&self) -> U0_PCIE_PHY_MODE_R {
+        U0_PCIE_PHY_MODE_R::new(((self.bits >> 20) & 3) as u8)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u0_pcie_pl_clkrem_allow"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_clkrem_allow(&self) -> U0_PLDA_PCIE_PL_CLKREM_ALLOW_R {
-        U0_PLDA_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_pcie_pl_clkrem_allow(&self) -> U0_PCIE_PL_CLKREM_ALLOW_R {
+        U0_PCIE_PL_CLKREM_ALLOW_R::new(((self.bits >> 22) & 1) != 0)
     }
-    #[doc = "Bit 23 - u0_plda_pcie_pl_clkreq_oen"]
+    #[doc = "Bit 23 - u0_pcie_pl_clkreq_oen"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_clkreq_oen(&self) -> U0_PLDA_PCIE_PL_CLKREQ_OEN_R {
-        U0_PLDA_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_pcie_pl_clkreq_oen(&self) -> U0_PCIE_PL_CLKREQ_OEN_R {
+        U0_PCIE_PL_CLKREQ_OEN_R::new(((self.bits >> 23) & 1) != 0)
     }
-    #[doc = "Bits 24:25 - u0_plda_pcie_pl_equ_phase"]
+    #[doc = "Bits 24:25 - u0_pcie_pl_equ_phase"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_equ_phase(&self) -> U0_PLDA_PCIE_PL_EQU_PHASE_R {
-        U0_PLDA_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
+    pub fn u0_pcie_pl_equ_phase(&self) -> U0_PCIE_PL_EQU_PHASE_R {
+        U0_PCIE_PL_EQU_PHASE_R::new(((self.bits >> 24) & 3) as u8)
     }
-    #[doc = "Bits 26:30 - u0_plda_pcie_pl_ltssm"]
+    #[doc = "Bits 26:30 - u0_pcie_pl_ltssm"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_ltssm(&self) -> U0_PLDA_PCIE_PL_LTSSM_R {
-        U0_PLDA_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
+    pub fn u0_pcie_pl_ltssm(&self) -> U0_PCIE_PL_LTSSM_R {
+        U0_PCIE_PL_LTSSM_R::new(((self.bits >> 26) & 0x1f) as u8)
     }
 }
 impl W {
-    #[doc = "Bits 0:19 - u0_plda_pcie_pf3_offset"]
+    #[doc = "Bits 0:19 - u0_pcie_pf3_offset"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pf3_offset(&mut self) -> U0_PLDA_PCIE_PF3_OFFSET_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PF3_OFFSET_W::new(self, 0)
+    pub fn u0_pcie_pf3_offset(&mut self) -> U0_PCIE_PF3_OFFSET_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PF3_OFFSET_W::new(self, 0)
     }
-    #[doc = "Bits 20:21 - u0_plda_pcie_phy_mode"]
+    #[doc = "Bits 20:21 - u0_pcie_phy_mode"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_phy_mode(&mut self) -> U0_PLDA_PCIE_PHY_MODE_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PHY_MODE_W::new(self, 20)
+    pub fn u0_pcie_phy_mode(&mut self) -> U0_PCIE_PHY_MODE_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PHY_MODE_W::new(self, 20)
     }
-    #[doc = "Bit 22 - u0_plda_pcie_pl_clkrem_allow"]
+    #[doc = "Bit 22 - u0_pcie_pl_clkrem_allow"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pl_clkrem_allow(
-        &mut self,
-    ) -> U0_PLDA_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_82_SPEC> {
-        U0_PLDA_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
+    pub fn u0_pcie_pl_clkrem_allow(&mut self) -> U0_PCIE_PL_CLKREM_ALLOW_W<STG_SYSCFG_82_SPEC> {
+        U0_PCIE_PL_CLKREM_ALLOW_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_83.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_83.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_83_SPEC>;
 #[doc = "Register `stg_syscfg_83` writer"]
 pub type W = crate::W<STG_SYSCFG_83_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_pclk_rate` reader - u0_plda_pcie_pl_pclk_rate"]
-pub type U0_PLDA_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
+#[doc = "Field `u0_pcie_pl_pclk_rate` reader - u0_pcie_pl_pclk_rate"]
+pub type U0_PCIE_PL_PCLK_RATE_R = crate::FieldReader;
 impl R {
-    #[doc = "Bits 0:4 - u0_plda_pcie_pl_pclk_rate"]
+    #[doc = "Bits 0:4 - u0_pcie_pl_pclk_rate"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_pclk_rate(&self) -> U0_PLDA_PCIE_PL_PCLK_RATE_R {
-        U0_PLDA_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
+    pub fn u0_pcie_pl_pclk_rate(&self) -> U0_PCIE_PL_PCLK_RATE_R {
+        U0_PCIE_PL_PCLK_RATE_R::new((self.bits & 0x1f) as u8)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_84.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_84.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_84_SPEC>;
 #[doc = "Register `stg_syscfg_84` writer"]
 pub type W = crate::W<STG_SYSCFG_84_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_in_31_0` reader - u0_plda_pcie_pl_sideband_in_31_0"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_in_31_0` reader - u0_pcie_pl_sideband_in_31_0"]
+pub type U0_PCIE_PL_SIDEBAND_IN_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_in_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_in_31_0(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_in_31_0(&self) -> U0_PCIE_PL_SIDEBAND_IN_31_0_R {
+        U0_PCIE_PL_SIDEBAND_IN_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_85.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_85.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_85_SPEC>;
 #[doc = "Register `stg_syscfg_85` writer"]
 pub type W = crate::W<STG_SYSCFG_85_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_in_63_32` reader - u0_plda_pcie_pl_sideband_in_63_32"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_in_63_32` reader - u0_pcie_pl_sideband_in_63_32"]
+pub type U0_PCIE_PL_SIDEBAND_IN_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_in_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_in_63_32(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_in_63_32(&self) -> U0_PCIE_PL_SIDEBAND_IN_63_32_R {
+        U0_PCIE_PL_SIDEBAND_IN_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_86.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_86.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_86_SPEC>;
 #[doc = "Register `stg_syscfg_86` writer"]
 pub type W = crate::W<STG_SYSCFG_86_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_out_31_0` reader - u0_plda_pcie_pl_sideband_out_31_0"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_out_31_0` reader - u0_pcie_pl_sideband_out_31_0"]
+pub type U0_PCIE_PL_SIDEBAND_OUT_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_out_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_out_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_out_31_0(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_out_31_0(&self) -> U0_PCIE_PL_SIDEBAND_OUT_31_0_R {
+        U0_PCIE_PL_SIDEBAND_OUT_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_87.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_87.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_87_SPEC>;
 #[doc = "Register `stg_syscfg_87` writer"]
 pub type W = crate::W<STG_SYSCFG_87_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_sideband_out_63_32` reader - u0_plda_pcie_pl_sideband_out_63_32"]
-pub type U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_pl_sideband_out_63_32` reader - u0_pcie_pl_sideband_out_63_32"]
+pub type U0_PCIE_PL_SIDEBAND_OUT_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_pl_sideband_out_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_pl_sideband_out_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_sideband_out_63_32(&self) -> U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R {
-        U0_PLDA_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
+    pub fn u0_pcie_pl_sideband_out_63_32(&self) -> U0_PCIE_PL_SIDEBAND_OUT_63_32_R {
+        U0_PCIE_PL_SIDEBAND_OUT_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_88.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_88.rs
@@ -2,37 +2,37 @@
 pub type R = crate::R<STG_SYSCFG_88_SPEC>;
 #[doc = "Register `stg_syscfg_88` writer"]
 pub type W = crate::W<STG_SYSCFG_88_SPEC>;
-#[doc = "Field `u0_plda_pcie_pl_wake_in` reader - u0_plda_pcie_pl_wake_in"]
-pub type U0_PLDA_PCIE_PL_WAKE_IN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_pl_wake_in` writer - u0_plda_pcie_pl_wake_in"]
-pub type U0_PLDA_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `u0_plda_pcie_pl_wake_oen` reader - u0_plda_pcie_pl_wake_oen"]
-pub type U0_PLDA_PCIE_PL_WAKE_OEN_R = crate::BitReader;
-#[doc = "Field `u0_plda_pcie_rx_standby_0` reader - u0_plda_pcie_rx_standby_0"]
-pub type U0_PLDA_PCIE_RX_STANDBY_0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_wake_in` reader - u0_pcie_pl_wake_in"]
+pub type U0_PCIE_PL_WAKE_IN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pl_wake_in` writer - u0_pcie_pl_wake_in"]
+pub type U0_PCIE_PL_WAKE_IN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pl_wake_oen` reader - u0_pcie_pl_wake_oen"]
+pub type U0_PCIE_PL_WAKE_OEN_R = crate::BitReader;
+#[doc = "Field `u0_pcie_rx_standby_0` reader - u0_pcie_rx_standby_0"]
+pub type U0_PCIE_RX_STANDBY_0_R = crate::BitReader;
 impl R {
-    #[doc = "Bit 0 - u0_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u0_pcie_pl_wake_in"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_wake_in(&self) -> U0_PLDA_PCIE_PL_WAKE_IN_R {
-        U0_PLDA_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
+    pub fn u0_pcie_pl_wake_in(&self) -> U0_PCIE_PL_WAKE_IN_R {
+        U0_PCIE_PL_WAKE_IN_R::new((self.bits & 1) != 0)
     }
-    #[doc = "Bit 1 - u0_plda_pcie_pl_wake_oen"]
+    #[doc = "Bit 1 - u0_pcie_pl_wake_oen"]
     #[inline(always)]
-    pub fn u0_plda_pcie_pl_wake_oen(&self) -> U0_PLDA_PCIE_PL_WAKE_OEN_R {
-        U0_PLDA_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pcie_pl_wake_oen(&self) -> U0_PCIE_PL_WAKE_OEN_R {
+        U0_PCIE_PL_WAKE_OEN_R::new(((self.bits >> 1) & 1) != 0)
     }
-    #[doc = "Bit 2 - u0_plda_pcie_rx_standby_0"]
+    #[doc = "Bit 2 - u0_pcie_rx_standby_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_rx_standby_0(&self) -> U0_PLDA_PCIE_RX_STANDBY_0_R {
-        U0_PLDA_PCIE_RX_STANDBY_0_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pcie_rx_standby_0(&self) -> U0_PCIE_RX_STANDBY_0_R {
+        U0_PCIE_RX_STANDBY_0_R::new(((self.bits >> 2) & 1) != 0)
     }
 }
 impl W {
-    #[doc = "Bit 0 - u0_plda_pcie_pl_wake_in"]
+    #[doc = "Bit 0 - u0_pcie_pl_wake_in"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_pl_wake_in(&mut self) -> U0_PLDA_PCIE_PL_WAKE_IN_W<STG_SYSCFG_88_SPEC> {
-        U0_PLDA_PCIE_PL_WAKE_IN_W::new(self, 0)
+    pub fn u0_pcie_pl_wake_in(&mut self) -> U0_PCIE_PL_WAKE_IN_W<STG_SYSCFG_88_SPEC> {
+        U0_PCIE_PL_WAKE_IN_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_89.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_89.rs
@@ -2,23 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_89_SPEC>;
 #[doc = "Register `stg_syscfg_89` writer"]
 pub type W = crate::W<STG_SYSCFG_89_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_in_31_0` reader - u0_plda_pcie_test_in_31_0"]
-pub type U0_PLDA_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_test_in_31_0` writer - u0_plda_pcie_test_in_31_0"]
-pub type U0_PLDA_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_test_in_31_0` reader - u0_pcie_test_in_31_0"]
+pub type U0_PCIE_TEST_IN_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_in_31_0` writer - u0_pcie_test_in_31_0"]
+pub type U0_PCIE_TEST_IN_31_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_in_31_0(&self) -> U0_PLDA_PCIE_TEST_IN_31_0_R {
-        U0_PLDA_PCIE_TEST_IN_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_in_31_0(&self) -> U0_PCIE_TEST_IN_31_0_R {
+        U0_PCIE_TEST_IN_31_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_31_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_in_31_0(&mut self) -> U0_PLDA_PCIE_TEST_IN_31_0_W<STG_SYSCFG_89_SPEC> {
-        U0_PLDA_PCIE_TEST_IN_31_0_W::new(self, 0)
+    pub fn u0_pcie_test_in_31_0(&mut self) -> U0_PCIE_TEST_IN_31_0_W<STG_SYSCFG_89_SPEC> {
+        U0_PCIE_TEST_IN_31_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_9.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_9.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_9_SPEC>;
 #[doc = "Register `stg_syscfg_9` writer"]
 pub type W = crate::W<STG_SYSCFG_9_SPEC>;
-#[doc = "Field `u0_e2_sft7110_reset_vector_0` reader - u0_e2_sft7110_reset_vector_0"]
-pub type U0_E2_SFT7110_RESET_VECTOR_0_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_e2_sft7110_reset_vector_0` writer - u0_e2_sft7110_reset_vector_0"]
-pub type U0_E2_SFT7110_RESET_VECTOR_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_e2_reset_vector_0` reader - u0_e2_reset_vector_0"]
+pub type U0_E2_RESET_VECTOR_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_e2_reset_vector_0` writer - u0_e2_reset_vector_0"]
+pub type U0_E2_RESET_VECTOR_0_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_reset_vector_0"]
+    #[doc = "Bits 0:31 - u0_e2_reset_vector_0"]
     #[inline(always)]
-    pub fn u0_e2_sft7110_reset_vector_0(&self) -> U0_E2_SFT7110_RESET_VECTOR_0_R {
-        U0_E2_SFT7110_RESET_VECTOR_0_R::new(self.bits)
+    pub fn u0_e2_reset_vector_0(&self) -> U0_E2_RESET_VECTOR_0_R {
+        U0_E2_RESET_VECTOR_0_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_e2_sft7110_reset_vector_0"]
+    #[doc = "Bits 0:31 - u0_e2_reset_vector_0"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_e2_sft7110_reset_vector_0(
-        &mut self,
-    ) -> U0_E2_SFT7110_RESET_VECTOR_0_W<STG_SYSCFG_9_SPEC> {
-        U0_E2_SFT7110_RESET_VECTOR_0_W::new(self, 0)
+    pub fn u0_e2_reset_vector_0(&mut self) -> U0_E2_RESET_VECTOR_0_W<STG_SYSCFG_9_SPEC> {
+        U0_E2_RESET_VECTOR_0_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_90.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_90.rs
@@ -2,25 +2,23 @@
 pub type R = crate::R<STG_SYSCFG_90_SPEC>;
 #[doc = "Register `stg_syscfg_90` writer"]
 pub type W = crate::W<STG_SYSCFG_90_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_in_63_32` reader - u0_plda_pcie_test_in_63_32"]
-pub type U0_PLDA_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
-#[doc = "Field `u0_plda_pcie_test_in_63_32` writer - u0_plda_pcie_test_in_63_32"]
-pub type U0_PLDA_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
+#[doc = "Field `u0_pcie_test_in_63_32` reader - u0_pcie_test_in_63_32"]
+pub type U0_PCIE_TEST_IN_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_in_63_32` writer - u0_pcie_test_in_63_32"]
+pub type U0_PCIE_TEST_IN_63_32_W<'a, REG> = crate::FieldWriter<'a, REG, 32, u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_in_63_32(&self) -> U0_PLDA_PCIE_TEST_IN_63_32_R {
-        U0_PLDA_PCIE_TEST_IN_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_in_63_32(&self) -> U0_PCIE_TEST_IN_63_32_R {
+        U0_PCIE_TEST_IN_63_32_R::new(self.bits)
     }
 }
 impl W {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_in_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_in_63_32"]
     #[inline(always)]
     #[must_use]
-    pub fn u0_plda_pcie_test_in_63_32(
-        &mut self,
-    ) -> U0_PLDA_PCIE_TEST_IN_63_32_W<STG_SYSCFG_90_SPEC> {
-        U0_PLDA_PCIE_TEST_IN_63_32_W::new(self, 0)
+    pub fn u0_pcie_test_in_63_32(&mut self) -> U0_PCIE_TEST_IN_63_32_W<STG_SYSCFG_90_SPEC> {
+        U0_PCIE_TEST_IN_63_32_W::new(self, 0)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_91.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_91.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_91_SPEC>;
 #[doc = "Register `stg_syscfg_91` writer"]
 pub type W = crate::W<STG_SYSCFG_91_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_31_0` reader - u0_plda_pcie_test_out_bridge_31_0"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_31_0` reader - u0_pcie_test_out_bridge_31_0"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_31_0_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_31_0"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_31_0"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_31_0(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_31_0(&self) -> U0_PCIE_TEST_OUT_BRIDGE_31_0_R {
+        U0_PCIE_TEST_OUT_BRIDGE_31_0_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_92.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_92.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_92_SPEC>;
 #[doc = "Register `stg_syscfg_92` writer"]
 pub type W = crate::W<STG_SYSCFG_92_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_63_32` reader - u0_plda_pcie_test_out_bridge_63_32"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_63_32` reader - u0_pcie_test_out_bridge_63_32"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_63_32_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_63_32"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_63_32"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_63_32(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_63_32(&self) -> U0_PCIE_TEST_OUT_BRIDGE_63_32_R {
+        U0_PCIE_TEST_OUT_BRIDGE_63_32_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_93.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_93.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_93_SPEC>;
 #[doc = "Register `stg_syscfg_93` writer"]
 pub type W = crate::W<STG_SYSCFG_93_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_95_64` reader - u0_plda_pcie_test_out_bridge_95_64"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_95_64` reader - u0_pcie_test_out_bridge_95_64"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_95_64_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_95_64"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_95_64"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_95_64(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_95_64(&self) -> U0_PCIE_TEST_OUT_BRIDGE_95_64_R {
+        U0_PCIE_TEST_OUT_BRIDGE_95_64_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_94.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_94.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_94_SPEC>;
 #[doc = "Register `stg_syscfg_94` writer"]
 pub type W = crate::W<STG_SYSCFG_94_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_127_96` reader - u0_plda_pcie_test_out_bridge_127_96"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_127_96` reader - u0_pcie_test_out_bridge_127_96"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_127_96_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_127_96"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_127_96"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_127_96(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_127_96(&self) -> U0_PCIE_TEST_OUT_BRIDGE_127_96_R {
+        U0_PCIE_TEST_OUT_BRIDGE_127_96_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_95.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_95.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_95_SPEC>;
 #[doc = "Register `stg_syscfg_95` writer"]
 pub type W = crate::W<STG_SYSCFG_95_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_159_128` reader - u0_plda_pcie_test_out_bridge_159_128"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_159_128` reader - u0_pcie_test_out_bridge_159_128"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_159_128_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_159_128"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_159_128"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_159_128(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_159_128(&self) -> U0_PCIE_TEST_OUT_BRIDGE_159_128_R {
+        U0_PCIE_TEST_OUT_BRIDGE_159_128_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_96.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_96.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_96_SPEC>;
 #[doc = "Register `stg_syscfg_96` writer"]
 pub type W = crate::W<STG_SYSCFG_96_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_191_160` reader - u0_plda_pcie_test_out_bridge_191_160"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_191_160` reader - u0_pcie_test_out_bridge_191_160"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_191_160_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_191_160"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_191_160"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_191_160(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_191_160(&self) -> U0_PCIE_TEST_OUT_BRIDGE_191_160_R {
+        U0_PCIE_TEST_OUT_BRIDGE_191_160_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_97.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_97.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_97_SPEC>;
 #[doc = "Register `stg_syscfg_97` writer"]
 pub type W = crate::W<STG_SYSCFG_97_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_223_192` reader - u0_plda_pcie_test_out_bridge_223_192"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_223_192` reader - u0_pcie_test_out_bridge_223_192"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_223_192_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_223_192"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_223_192"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_223_192(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_223_192(&self) -> U0_PCIE_TEST_OUT_BRIDGE_223_192_R {
+        U0_PCIE_TEST_OUT_BRIDGE_223_192_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_98.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_98.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_98_SPEC>;
 #[doc = "Register `stg_syscfg_98` writer"]
 pub type W = crate::W<STG_SYSCFG_98_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_255_224` reader - u0_plda_pcie_test_out_bridge_255_224"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_255_224` reader - u0_pcie_test_out_bridge_255_224"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_255_224_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_255_224"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_255_224"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_255_224(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_255_224(&self) -> U0_PCIE_TEST_OUT_BRIDGE_255_224_R {
+        U0_PCIE_TEST_OUT_BRIDGE_255_224_R::new(self.bits)
     }
 }
 impl W {

--- a/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_99.rs
+++ b/jh7110-vf2-13b-pac/src/stg_syscon/stg_syscfg_99.rs
@@ -2,13 +2,13 @@
 pub type R = crate::R<STG_SYSCFG_99_SPEC>;
 #[doc = "Register `stg_syscfg_99` writer"]
 pub type W = crate::W<STG_SYSCFG_99_SPEC>;
-#[doc = "Field `u0_plda_pcie_test_out_bridge_287_256` reader - u0_plda_pcie_test_out_bridge_287_256"]
-pub type U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
+#[doc = "Field `u0_pcie_test_out_bridge_287_256` reader - u0_pcie_test_out_bridge_287_256"]
+pub type U0_PCIE_TEST_OUT_BRIDGE_287_256_R = crate::FieldReader<u32>;
 impl R {
-    #[doc = "Bits 0:31 - u0_plda_pcie_test_out_bridge_287_256"]
+    #[doc = "Bits 0:31 - u0_pcie_test_out_bridge_287_256"]
     #[inline(always)]
-    pub fn u0_plda_pcie_test_out_bridge_287_256(&self) -> U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R {
-        U0_PLDA_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
+    pub fn u0_pcie_test_out_bridge_287_256(&self) -> U0_PCIE_TEST_OUT_BRIDGE_287_256_R {
+        U0_PCIE_TEST_OUT_BRIDGE_287_256_R::new(self.bits)
     }
 }
 impl W {


### PR DESCRIPTION
Further naming simplification for `stg_syscon` peripheral registers.