### PR TITLE
fixup: reset: naming changes for reset fields

### DIFF
--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -11898,139 +11898,139 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_stg_syscon_presetn</name>
+              <name>u0_stg_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_core</name>
+              <name>u0_hifi4_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_axi</name>
+              <name>u0_hifi4_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sec_top_hreesetn</name>
+              <name>u0_sec_top_hreesetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_e2_sft7110_rst_core</name>
+              <name>u0_e2_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_axi</name>
+              <name>u0_dma_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_ahb</name>
+              <name>u0_dma_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_axi</name>
+              <name>u0_usb_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_usb_apb</name>
+              <name>u0_usb_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_utmi_apb</name>
+              <name>u0_usb_utmi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_pwrup</name>
+              <name>u0_usb_pwrup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_mst0</name>
+              <name>u0_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv0</name>
+              <name>u0_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv</name>
+              <name>u0_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pci_rstn_brg</name>
+              <name>u0_pci_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_pcie</name>
+              <name>u0_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_apb</name>
+              <name>u0_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_mst0</name>
+              <name>u1_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv0</name>
+              <name>u1_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv</name>
+              <name>u1_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_brg</name>
+              <name>u1_pcie_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_pcie</name>
+              <name>u1_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_apb</name>
+              <name>u1_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
@@ -12045,139 +12045,139 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_stg_syscon_presetn</name>
+              <name>u0_stg_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_core</name>
+              <name>u0_hifi4_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_axi</name>
+              <name>u0_hifi4_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sec_top_hreesetn</name>
+              <name>u0_sec_top_hreesetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_e2_sft7110_rst_core</name>
+              <name>u0_e2_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_axi</name>
+              <name>u0_dma_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_ahb</name>
+              <name>u0_dma_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_axi</name>
+              <name>u0_usb_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_usb_apb</name>
+              <name>u0_usb_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_utmi_apb</name>
+              <name>u0_usb_utmi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_pwrup</name>
+              <name>u0_usb_pwrup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_mst0</name>
+              <name>u0_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv0</name>
+              <name>u0_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv</name>
+              <name>u0_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pci_rstn_brg</name>
+              <name>u0_pci_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_pcie</name>
+              <name>u0_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_apb</name>
+              <name>u0_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_mst0</name>
+              <name>u1_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv0</name>
+              <name>u1_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv</name>
+              <name>u1_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_brg</name>
+              <name>u1_pcie_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_pcie</name>
+              <name>u1_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_apb</name>
+              <name>u1_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
@@ -31125,193 +31125,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_jtag2apb_presetn</name>
+              <name>u0_jtag2apb_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_syscon_presetn</name>
+              <name>u0_sys_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_iomux_presetn</name>
+              <name>u0_sys_iomux_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_bus</name>
+              <name>u0_bus</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_debug_reset</name>
+              <name>u0_debug</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0</name>
+              <name>u0_core_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1</name>
+              <name>u0_core_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2</name>
+              <name>u0_core_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3</name>
+              <name>u0_core3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4</name>
+              <name>u0_core4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0_st</name>
+              <name>u0_core_st_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1_st</name>
+              <name>u0_core_st_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2_st</name>
+              <name>u0_core_st_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3_st</name>
+              <name>u0_core_st_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4_st</name>
+              <name>u0_core_st_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst0</name>
+              <name>u0_trace_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst1</name>
+              <name>u0_trace_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst2</name>
+              <name>u0_trace_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst3</name>
+              <name>u0_trace_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst4</name>
+              <name>u0_trace_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_com_rst</name>
+              <name>u0_trace_com</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_apb</name>
+              <name>u0_img_gpu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_doma</name>
+              <name>u0_img_gpu_doma</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n</name>
+              <name>u0_noc_bus_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n</name>
+              <name>u0_noc_bus_axicfg0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n</name>
+              <name>u0_noc_bus_cpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n</name>
+              <name>u0_noc_bus_disp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n</name>
+              <name>u0_noc_bus_gpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n</name>
+              <name>u0_noc_bus_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n</name>
+              <name>u0_noc_bus_ddrc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n</name>
+              <name>u0_noc_bus_stg_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n</name>
+              <name>u0_noc_bus_vdec_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31326,193 +31326,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
+              <name>u0_noc_bus_venc_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_ahb</name>
+              <name>u0_axi_cfg1_dec_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_main</name>
+              <name>u0_axi_cfg1_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main</name>
+              <name>u0_axi_cfg0_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main_div</name>
+              <name>u0_axi_cfg0_dec_main_div</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_hifi4</name>
+              <name>u0_axi_cfg0_dec_hifi4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_axi</name>
+              <name>u0_ddr_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_osc</name>
+              <name>u0_ddr_osc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_apb</name>
+              <name>u0_ddr_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n</name>
+              <name>u0_isp_top</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi</name>
+              <name>u0_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src</name>
+              <name>u0_vout_src</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_axi</name>
+              <name>u0_codaj12_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_core</name>
+              <name>u0_codaj12_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_apb</name>
+              <name>u0_codaj12_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_axi</name>
+              <name>u0_wave511_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_bpu</name>
+              <name>u0_wave511_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_vce</name>
+              <name>u0_wave511_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_apb</name>
+              <name>u0_wave511_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_jpgresetn</name>
+              <name>u0_vdec_jpg_arb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_mainresetn</name>
+              <name>u0_vdec_jpg_arb_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_aximem_128b_rstn_axi</name>
+              <name>u0_aximem_128b_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_axi</name>
+              <name>u0_wave420l_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_bpu</name>
+              <name>u0_wave420l_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_vce</name>
+              <name>u0_wave420l_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_apb</name>
+              <name>u0_wave420l_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_aximem_128b_rstn_axi</name>
+              <name>u1_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_aximem_128b_rstn_axi</name>
+              <name>u2_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_intmem_rom_sram_rstn_rom</name>
+              <name>u0_intmem_rom_sram</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ahb</name>
+              <name>u0_qspi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_apb</name>
+              <name>u0_qspi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ref</name>
+              <name>u0_qspi_ref</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31527,193 +31527,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sdio_rstn_ahb</name>
+              <name>u0_sdio_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_sdi_rstn_ahb</name>
+              <name>u1_sdi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_aresetn_i</name>
+              <name>u1_gmac5_axi64</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_hresetn_n</name>
+              <name>u1_gmac5_axi64_hresetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_mailbox_presetn</name>
+              <name>u0_mailbox_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ssp_spi_rstn_apb</name>
+              <name>u0_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_ssp_spi_rstn_apb</name>
+              <name>u1_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_ssp_spi_rstn_apb</name>
+              <name>u2_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_ssp_spi_rstn_apb</name>
+              <name>u3_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_ssp_spi_rstn_apb</name>
+              <name>u4_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_ssp_spi_rstn_apb</name>
+              <name>u5_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_ssp_spi_rstn_apb</name>
+              <name>u6_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2c_rstn_apb</name>
+              <name>u0_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2c_rstn_apb</name>
+              <name>u1_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_i2c_rstn_apb</name>
+              <name>u2_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_i2c_rstn_apb</name>
+              <name>u3_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_i2c_rstn_apb</name>
+              <name>u4_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_i2c_rstn_apb</name>
+              <name>u5_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_i2c_rstn_apb</name>
+              <name>u6_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_apb</name>
+              <name>u0_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_core</name>
+              <name>u0_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_apb</name>
+              <name>u1_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_core</name>
+              <name>u1_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_apb</name>
+              <name>u2_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_core</name>
+              <name>u2_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_apb</name>
+              <name>u3_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_core</name>
+              <name>u3_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_apb</name>
+              <name>u4_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_core</name>
+              <name>u4_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_uart_rstn_apb</name>
+              <name>u5_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_uart_rstn_core</name>
+              <name>u6_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_spdif_rstn_apb</name>
+              <name>u0_spdif_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31728,181 +31728,181 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_pwmdac_rstn_apb</name>
+              <name>u0_pwmdac_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_dmic</name>
+              <name>u0_pdm_4mic_dmic</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_apb</name>
+              <name>u0_pdm_4mic_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_apb</name>
+              <name>u0_i2srx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_bclk</name>
+              <name>u0_i2srx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_apb</name>
+              <name>u0_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_bclk</name>
+              <name>u0_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_apb</name>
+              <name>u1_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_bclk</name>
+              <name>u1_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_ahb</name>
+              <name>u0_tdm16slot_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_tdm</name>
+              <name>u0_tdm16slot_tdm</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_apb</name>
+              <name>u0_tdm16slot_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pwm_8ch_rstn_apb</name>
+              <name>u0_pwm_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_apb</name>
+              <name>u0_dskit_wdt_rstn_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_wdt</name>
+              <name>u0_dskit_wdt</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_apb</name>
+              <name>u0_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_can</name>
+              <name>u0_can_ctrl</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_timer</name>
+              <name>u0_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_apb</name>
+              <name>u1_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_can</name>
+              <name>u1_can_ctrl_can</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_timer</name>
+              <name>u1_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_apb</name>
+              <name>u0_si5_timer_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer0</name>
+              <name>u0_si5_timer_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_time10</name>
+              <name>u0_si5_timer_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer2</name>
+              <name>u0_si5_timer_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer3</name>
+              <name>u0_si5_timer_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_int_ctrl_rstn_apb</name>
+              <name>u0_int_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_apb</name>
+              <name>u0_temp_sensor_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_temp</name>
+              <name>u0_temp_sensor</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_jtag_certification_rst_n</name>
+              <name>u0_jtag_rst</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
@@ -31917,193 +31917,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_jtag2apb_presetn</name>
+              <name>u0_jtag2apb_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_syscon_presetn</name>
+              <name>u0_sys_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_iomux_presetn</name>
+              <name>u0_sys_iomux_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_bus</name>
+              <name>u0_bus</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_debug_reset</name>
+              <name>u0_debug</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0</name>
+              <name>u0_core_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1</name>
+              <name>u0_core_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2</name>
+              <name>u0_core_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3</name>
+              <name>u0_core3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4</name>
+              <name>u0_core4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0_st</name>
+              <name>u0_core_st_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1_st</name>
+              <name>u0_core_st_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2_st</name>
+              <name>u0_core_st_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3_st</name>
+              <name>u0_core_st_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4_st</name>
+              <name>u0_core_st_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst0</name>
+              <name>u0_trace_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst1</name>
+              <name>u0_trace_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst2</name>
+              <name>u0_trace_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst3</name>
+              <name>u0_trace_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst4</name>
+              <name>u0_trace_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_com_rst</name>
+              <name>u0_trace_com</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_apb</name>
+              <name>u0_img_gpu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_doma</name>
+              <name>u0_img_gpu_doma</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n</name>
+              <name>u0_noc_bus_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n</name>
+              <name>u0_noc_bus_axicfg0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n</name>
+              <name>u0_noc_bus_cpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n</name>
+              <name>u0_noc_bus_disp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n</name>
+              <name>u0_noc_bus_gpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n</name>
+              <name>u0_noc_bus_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n</name>
+              <name>u0_noc_bus_ddrc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n</name>
+              <name>u0_noc_bus_stg_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n</name>
+              <name>u0_noc_bus_vdec_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32118,193 +32118,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
+              <name>u0_noc_bus_venc_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_ahb</name>
+              <name>u0_axi_cfg1_dec_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_main</name>
+              <name>u0_axi_cfg1_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main</name>
+              <name>u0_axi_cfg0_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main_div</name>
+              <name>u0_axi_cfg0_dec_main_div</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_hifi4</name>
+              <name>u0_axi_cfg0_dec_hifi4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_axi</name>
+              <name>u0_ddr_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_osc</name>
+              <name>u0_ddr_osc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_apb</name>
+              <name>u0_ddr_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n</name>
+              <name>u0_isp_top</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi</name>
+              <name>u0_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src</name>
+              <name>u0_vout_src</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_axi</name>
+              <name>u0_codaj12_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_core</name>
+              <name>u0_codaj12_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_apb</name>
+              <name>u0_codaj12_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_axi</name>
+              <name>u0_wave511_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_bpu</name>
+              <name>u0_wave511_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_vce</name>
+              <name>u0_wave511_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_apb</name>
+              <name>u0_wave511_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_jpgresetn</name>
+              <name>u0_vdec_jpg_arb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_mainresetn</name>
+              <name>u0_vdec_jpg_arb_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_aximem_128b_rstn_axi</name>
+              <name>u0_aximem_128b_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_axi</name>
+              <name>u0_wave420l_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_bpu</name>
+              <name>u0_wave420l_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_vce</name>
+              <name>u0_wave420l_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_apb</name>
+              <name>u0_wave420l_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_aximem_128b_rstn_axi</name>
+              <name>u1_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_aximem_128b_rstn_axi</name>
+              <name>u2_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_intmem_rom_sram_rstn_rom</name>
+              <name>u0_intmem_rom_sram</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ahb</name>
+              <name>u0_qspi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_apb</name>
+              <name>u0_qspi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ref</name>
+              <name>u0_qspi_ref</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32319,193 +32319,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sdio_rstn_ahb</name>
+              <name>u0_sdio_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_sdi_rstn_ahb</name>
+              <name>u1_sdi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_aresetn_i</name>
+              <name>u1_gmac5_axi64</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_hresetn_n</name>
+              <name>u1_gmac5_axi64_hresetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_mailbox_presetn</name>
+              <name>u0_mailbox_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ssp_spi_rstn_apb</name>
+              <name>u0_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_ssp_spi_rstn_apb</name>
+              <name>u1_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_ssp_spi_rstn_apb</name>
+              <name>u2_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_ssp_spi_rstn_apb</name>
+              <name>u3_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_ssp_spi_rstn_apb</name>
+              <name>u4_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_ssp_spi_rstn_apb</name>
+              <name>u5_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_ssp_spi_rstn_apb</name>
+              <name>u6_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2c_rstn_apb</name>
+              <name>u0_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2c_rstn_apb</name>
+              <name>u1_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_i2c_rstn_apb</name>
+              <name>u2_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_i2c_rstn_apb</name>
+              <name>u3_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_i2c_rstn_apb</name>
+              <name>u4_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_i2c_rstn_apb</name>
+              <name>u5_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_i2c_rstn_apb</name>
+              <name>u6_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_apb</name>
+              <name>u0_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_core</name>
+              <name>u0_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_apb</name>
+              <name>u1_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_core</name>
+              <name>u1_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_apb</name>
+              <name>u2_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_core</name>
+              <name>u2_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_apb</name>
+              <name>u3_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_core</name>
+              <name>u3_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_apb</name>
+              <name>u4_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_core</name>
+              <name>u4_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_uart_rstn_apb</name>
+              <name>u5_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_uart_rstn_core</name>
+              <name>u6_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_spdif_rstn_apb</name>
+              <name>u0_spdif_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32520,181 +32520,181 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_pwmdac_rstn_apb</name>
+              <name>u0_pwmdac_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_dmic</name>
+              <name>u0_pdm_4mic_dmic</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_apb</name>
+              <name>u0_pdm_4mic_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_apb</name>
+              <name>u0_i2srx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_bclk</name>
+              <name>u0_i2srx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_apb</name>
+              <name>u0_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_bclk</name>
+              <name>u0_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_apb</name>
+              <name>u1_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_bclk</name>
+              <name>u1_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_ahb</name>
+              <name>u0_tdm16slot_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_tdm</name>
+              <name>u0_tdm16slot_tdm</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_apb</name>
+              <name>u0_tdm16slot_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pwm_8ch_rstn_apb</name>
+              <name>u0_pwm_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_apb</name>
+              <name>u0_dskit_wdt_rstn_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_wdt</name>
+              <name>u0_dskit_wdt</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_apb</name>
+              <name>u0_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_can</name>
+              <name>u0_can_ctrl</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_timer</name>
+              <name>u0_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_apb</name>
+              <name>u1_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_can</name>
+              <name>u1_can_ctrl_can</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_timer</name>
+              <name>u1_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_apb</name>
+              <name>u0_si5_timer_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer0</name>
+              <name>u0_si5_timer_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_time10</name>
+              <name>u0_si5_timer_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer2</name>
+              <name>u0_si5_timer_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer3</name>
+              <name>u0_si5_timer_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_int_ctrl_rstn_apb</name>
+              <name>u0_int_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_apb</name>
+              <name>u0_temp_sensor_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_temp</name>
+              <name>u0_temp_sensor</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_jtag_certification_rst_n</name>
+              <name>u0_jtag_rst</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
@@ -42919,13 +42919,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>gmac5_axi64_rstn_axi</name>
+              <name>gmac5_axi64_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>gmac5_axi64_rstn_ahb</name>
+              <name>gmac5_axi64_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
@@ -42937,31 +42937,31 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_apb</name>
+              <name>pmu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_wkup</name>
+              <name>pmu_wkup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_apb</name>
+              <name>rtc_hms_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_cal</name>
+              <name>rtc_hms_cal</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_osc32k</name>
+              <name>rtc_hms_osc32k</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
@@ -42976,13 +42976,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>gmac5_axi64_rstn_axi</name>
+              <name>gmac5_axi64_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>gmac5_axi64_rstn_ahb</name>
+              <name>gmac5_axi64_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
@@ -42994,31 +42994,31 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_apb</name>
+              <name>pmu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_wkup</name>
+              <name>pmu_wkup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_apb</name>
+              <name>rtc_hms_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_cal</name>
+              <name>rtc_hms_cal</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_osc32k</name>
+              <name>rtc_hms_osc32k</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>

--- a/jh7110-vf2-12a-pac/src/aoncrg/aoncrg_rst_status.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/aoncrg_rst_status.rs
@@ -2,48 +2,48 @@
 pub type R = crate::R<AONCRG_RST_STATUS_SPEC>;
 #[doc = "Register `aoncrg_rst_status` writer"]
 pub type W = crate::W<AONCRG_RST_STATUS_SPEC>;
-#[doc = "Field `gmac5_axi64_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `gmac5_axi64_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `aon_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_R = crate::BitReader;
 #[doc = "Field `aon_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_wkup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_wkup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_cal` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_cal` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_R = crate::BitReader;
+#[doc = "Field `pmu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_wkup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_R = crate::BitReader;
+#[doc = "Field `pmu_wkup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_R = crate::BitReader;
+#[doc = "Field `rtc_hms_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_cal` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_R = crate::BitReader;
+#[doc = "Field `rtc_hms_cal` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_R = crate::BitReader;
+#[doc = "Field `rtc_hms_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_axi(&self) -> GMAC5_AXI64_RSTN_AXI_R {
-        GMAC5_AXI64_RSTN_AXI_R::new((self.bits & 1) != 0)
+    pub fn gmac5_axi64_axi(&self) -> GMAC5_AXI64_AXI_R {
+        GMAC5_AXI64_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_ahb(&self) -> GMAC5_AXI64_RSTN_AHB_R {
-        GMAC5_AXI64_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn gmac5_axi64_ahb(&self) -> GMAC5_AXI64_AHB_R {
+        GMAC5_AXI64_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -52,42 +52,42 @@ impl R {
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_apb(&self) -> PMU_RSTN_APB_R {
-        PMU_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn pmu_apb(&self) -> PMU_APB_R {
+        PMU_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_wkup(&self) -> PMU_RSTN_WKUP_R {
-        PMU_RSTN_WKUP_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn pmu_wkup(&self) -> PMU_WKUP_R {
+        PMU_WKUP_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_apb(&self) -> RTC_HMS_RSTN_APB_R {
-        RTC_HMS_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn rtc_hms_apb(&self) -> RTC_HMS_APB_R {
+        RTC_HMS_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_cal(&self) -> RTC_HMS_RSTN_CAL_R {
-        RTC_HMS_RSTN_CAL_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn rtc_hms_cal(&self) -> RTC_HMS_CAL_R {
+        RTC_HMS_CAL_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_osc32k(&self) -> RTC_HMS_RSTN_OSC32K_R {
-        RTC_HMS_RSTN_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn rtc_hms_osc32k(&self) -> RTC_HMS_OSC32K_R {
+        RTC_HMS_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_axi(&mut self) -> GMAC5_AXI64_RSTN_AXI_W<AONCRG_RST_STATUS_SPEC> {
-        GMAC5_AXI64_RSTN_AXI_W::new(self, 0)
+    pub fn gmac5_axi64_axi(&mut self) -> GMAC5_AXI64_AXI_W<AONCRG_RST_STATUS_SPEC> {
+        GMAC5_AXI64_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_ahb(&mut self) -> GMAC5_AXI64_RSTN_AHB_W<AONCRG_RST_STATUS_SPEC> {
-        GMAC5_AXI64_RSTN_AHB_W::new(self, 1)
+    pub fn gmac5_axi64_ahb(&mut self) -> GMAC5_AXI64_AHB_W<AONCRG_RST_STATUS_SPEC> {
+        GMAC5_AXI64_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -98,32 +98,32 @@ impl W {
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_apb(&mut self) -> PMU_RSTN_APB_W<AONCRG_RST_STATUS_SPEC> {
-        PMU_RSTN_APB_W::new(self, 3)
+    pub fn pmu_apb(&mut self) -> PMU_APB_W<AONCRG_RST_STATUS_SPEC> {
+        PMU_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_wkup(&mut self) -> PMU_RSTN_WKUP_W<AONCRG_RST_STATUS_SPEC> {
-        PMU_RSTN_WKUP_W::new(self, 4)
+    pub fn pmu_wkup(&mut self) -> PMU_WKUP_W<AONCRG_RST_STATUS_SPEC> {
+        PMU_WKUP_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_apb(&mut self) -> RTC_HMS_RSTN_APB_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_APB_W::new(self, 5)
+    pub fn rtc_hms_apb(&mut self) -> RTC_HMS_APB_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_cal(&mut self) -> RTC_HMS_RSTN_CAL_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_CAL_W::new(self, 6)
+    pub fn rtc_hms_cal(&mut self) -> RTC_HMS_CAL_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_CAL_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_osc32k(&mut self) -> RTC_HMS_RSTN_OSC32K_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_OSC32K_W::new(self, 7)
+    pub fn rtc_hms_osc32k(&mut self) -> RTC_HMS_OSC32K_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_OSC32K_W::new(self, 7)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/aoncrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/aoncrg/soft_rst_addr_sel.rs
@@ -2,48 +2,48 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Register `soft_rst_addr_sel` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_SPEC>;
-#[doc = "Field `gmac5_axi64_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `gmac5_axi64_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `aon_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_R = crate::BitReader;
 #[doc = "Field `aon_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_wkup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_wkup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_cal` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_cal` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_R = crate::BitReader;
+#[doc = "Field `pmu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_wkup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_R = crate::BitReader;
+#[doc = "Field `pmu_wkup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_R = crate::BitReader;
+#[doc = "Field `rtc_hms_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_cal` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_R = crate::BitReader;
+#[doc = "Field `rtc_hms_cal` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_R = crate::BitReader;
+#[doc = "Field `rtc_hms_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_axi(&self) -> GMAC5_AXI64_RSTN_AXI_R {
-        GMAC5_AXI64_RSTN_AXI_R::new((self.bits & 1) != 0)
+    pub fn gmac5_axi64_axi(&self) -> GMAC5_AXI64_AXI_R {
+        GMAC5_AXI64_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_ahb(&self) -> GMAC5_AXI64_RSTN_AHB_R {
-        GMAC5_AXI64_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn gmac5_axi64_ahb(&self) -> GMAC5_AXI64_AHB_R {
+        GMAC5_AXI64_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -52,42 +52,42 @@ impl R {
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_apb(&self) -> PMU_RSTN_APB_R {
-        PMU_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn pmu_apb(&self) -> PMU_APB_R {
+        PMU_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_wkup(&self) -> PMU_RSTN_WKUP_R {
-        PMU_RSTN_WKUP_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn pmu_wkup(&self) -> PMU_WKUP_R {
+        PMU_WKUP_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_apb(&self) -> RTC_HMS_RSTN_APB_R {
-        RTC_HMS_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn rtc_hms_apb(&self) -> RTC_HMS_APB_R {
+        RTC_HMS_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_cal(&self) -> RTC_HMS_RSTN_CAL_R {
-        RTC_HMS_RSTN_CAL_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn rtc_hms_cal(&self) -> RTC_HMS_CAL_R {
+        RTC_HMS_CAL_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_osc32k(&self) -> RTC_HMS_RSTN_OSC32K_R {
-        RTC_HMS_RSTN_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn rtc_hms_osc32k(&self) -> RTC_HMS_OSC32K_R {
+        RTC_HMS_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_axi(&mut self) -> GMAC5_AXI64_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        GMAC5_AXI64_RSTN_AXI_W::new(self, 0)
+    pub fn gmac5_axi64_axi(&mut self) -> GMAC5_AXI64_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        GMAC5_AXI64_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_ahb(&mut self) -> GMAC5_AXI64_RSTN_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        GMAC5_AXI64_RSTN_AHB_W::new(self, 1)
+    pub fn gmac5_axi64_ahb(&mut self) -> GMAC5_AXI64_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        GMAC5_AXI64_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -98,32 +98,32 @@ impl W {
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_apb(&mut self) -> PMU_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        PMU_RSTN_APB_W::new(self, 3)
+    pub fn pmu_apb(&mut self) -> PMU_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        PMU_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_wkup(&mut self) -> PMU_RSTN_WKUP_W<SOFT_RST_ADDR_SEL_SPEC> {
-        PMU_RSTN_WKUP_W::new(self, 4)
+    pub fn pmu_wkup(&mut self) -> PMU_WKUP_W<SOFT_RST_ADDR_SEL_SPEC> {
+        PMU_WKUP_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_apb(&mut self) -> RTC_HMS_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_APB_W::new(self, 5)
+    pub fn rtc_hms_apb(&mut self) -> RTC_HMS_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_cal(&mut self) -> RTC_HMS_RSTN_CAL_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_CAL_W::new(self, 6)
+    pub fn rtc_hms_cal(&mut self) -> RTC_HMS_CAL_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_CAL_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_osc32k(&mut self) -> RTC_HMS_RSTN_OSC32K_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_OSC32K_W::new(self, 7)
+    pub fn rtc_hms_osc32k(&mut self) -> RTC_HMS_OSC32K_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_OSC32K_W::new(self, 7)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stgcrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/soft_rst_addr_sel.rs
@@ -2,395 +2,353 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Register `soft_rst_addr_sel` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_SPEC>;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_R = crate::BitReader;
+#[doc = "Field `u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_R = crate::BitReader;
+#[doc = "Field `u0_e2_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_R = crate::BitReader;
+#[doc = "Field `u0_dma_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_R = crate::BitReader;
+#[doc = "Field `u0_dma_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_R = crate::BitReader;
+#[doc = "Field `u0_usb_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pci_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_R = crate::BitReader;
+#[doc = "Field `u0_pci_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u0_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_R = crate::BitReader;
+#[doc = "Field `u1_pcie_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u1_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_stg_syscon_presetn(&self) -> RSTN_U0_STG_SYSCON_PRESETN_R {
-        RSTN_U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_stg_syscon_presetn(&self) -> U0_STG_SYSCON_PRESETN_R {
+        U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_core(&self) -> RST_U0_HIFI4_RST_CORE_R {
-        RST_U0_HIFI4_RST_CORE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_hifi4_core(&self) -> U0_HIFI4_CORE_R {
+        U0_HIFI4_CORE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_axi(&self) -> RST_U0_HIFI4_RST_AXI_R {
-        RST_U0_HIFI4_RST_AXI_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_hifi4_axi(&self) -> U0_HIFI4_AXI_R {
+        U0_HIFI4_AXI_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sec_top_hreesetn(&self) -> RSTN_U0_SEC_TOP_HREESETN_R {
-        RSTN_U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_sec_top_hreesetn(&self) -> U0_SEC_TOP_HREESETN_R {
+        U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_e2_sft7110_rst_core(&self) -> RST_U0_E2_SFT7110_RST_CORE_R {
-        RST_U0_E2_SFT7110_RST_CORE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_e2_core(&self) -> U0_E2_CORE_R {
+        U0_E2_CORE_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_dma_axi(&self) -> U0_DMA_AXI_R {
+        U0_DMA_AXI_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_dma_ahb(&self) -> U0_DMA_AHB_R {
+        U0_DMA_AHB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&self) -> RSTN_U0_CDN_USB_RSTN_AXI_R {
-        RSTN_U0_CDN_USB_RSTN_AXI_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_axi(&self) -> U0_USB_AXI_R {
+        U0_USB_AXI_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(&self) -> RSTN_U0_CDN_USB_RSTN_USB_APB_R {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_apb(&self) -> U0_USB_APB_R {
+        U0_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(&self) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_R {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_apb(&self) -> U0_USB_UTMI_APB_R {
+        U0_USB_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(&self) -> RSTN_U0_CDN_USB_RSTN_PWRUP_R {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_pwrup(&self) -> U0_USB_PWRUP_R {
+        U0_USB_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_pcie_axi_mst0(&self) -> U0_PCIE_AXI_MST0_R {
+        U0_PCIE_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pcie_axi_slv0(&self) -> U0_PCIE_AXI_SLV0_R {
+        U0_PCIE_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_pcie_axi_slv(&self) -> U0_PCIE_AXI_SLV_R {
+        U0_PCIE_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pci_rstn_brg(&self) -> RSTN_U0_PLDA_PCI_RSTN_BRG_R {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_pci_brg(&self) -> U0_PCI_BRG_R {
+        U0_PCI_BRG_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(&self) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_pcie_pcie(&self) -> U0_PCIE_PCIE_R {
+        U0_PCIE_PCIE_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_apb(&self) -> RSTN_U0_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_apb(&self) -> U0_PCIE_APB_R {
+        U0_PCIE_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_axi_mst0(&self) -> U1_PCIE_AXI_MST0_R {
+        U1_PCIE_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_pcie_axi_slv0(&self) -> U1_PCIE_AXI_SLV0_R {
+        U1_PCIE_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_pcie_axi_slv(&self) -> U1_PCIE_AXI_SLV_R {
+        U1_PCIE_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_brg(&self) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_R {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_pcie_brg(&self) -> U1_PCIE_BRG_R {
+        U1_PCIE_BRG_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(&self) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_pcie_pcie(&self) -> U1_PCIE_PCIE_R {
+        U1_PCIE_PCIE_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_apb(&self) -> RSTN_U1_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_apb(&self) -> U1_PCIE_APB_R {
+        U1_PCIE_APB_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_stg_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_STG_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_STG_SYSCON_PRESETN_W::new(self, 0)
+    pub fn u0_stg_syscon_presetn(&mut self) -> U0_STG_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_STG_SYSCON_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_core(&mut self) -> RST_U0_HIFI4_RST_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_HIFI4_RST_CORE_W::new(self, 1)
+    pub fn u0_hifi4_core(&mut self) -> U0_HIFI4_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_HIFI4_CORE_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_axi(&mut self) -> RST_U0_HIFI4_RST_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_HIFI4_RST_AXI_W::new(self, 2)
+    pub fn u0_hifi4_axi(&mut self) -> U0_HIFI4_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_HIFI4_AXI_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sec_top_hreesetn(
-        &mut self,
-    ) -> RSTN_U0_SEC_TOP_HREESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_SEC_TOP_HREESETN_W::new(self, 3)
+    pub fn u0_sec_top_hreesetn(&mut self) -> U0_SEC_TOP_HREESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_SEC_TOP_HREESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_e2_sft7110_rst_core(
-        &mut self,
-    ) -> RST_U0_E2_SFT7110_RST_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_E2_SFT7110_RST_CORE_W::new(self, 4)
+    pub fn u0_e2_core(&mut self) -> U0_E2_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_E2_CORE_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W::new(self, 5)
+    pub fn u0_dma_axi(&mut self) -> U0_DMA_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_DMA_AXI_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W::new(self, 6)
+    pub fn u0_dma_ahb(&mut self) -> U0_DMA_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_DMA_AHB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_AXI_W::new(self, 7)
+    pub fn u0_usb_axi(&mut self) -> U0_USB_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_AXI_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_USB_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_W::new(self, 8)
+    pub fn u0_usb_apb(&mut self) -> U0_USB_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_W::new(self, 9)
+    pub fn u0_usb_utmi_apb(&mut self) -> U0_USB_UTMI_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_UTMI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_PWRUP_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_W::new(self, 10)
+    pub fn u0_usb_pwrup(&mut self) -> U0_USB_PWRUP_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_PWRUP_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 11)
+    pub fn u0_pcie_axi_mst0(&mut self) -> U0_PCIE_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_MST0_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 12)
+    pub fn u0_pcie_axi_slv0(&mut self) -> U0_PCIE_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_SLV0_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 13)
+    pub fn u0_pcie_axi_slv(&mut self) -> U0_PCIE_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_SLV_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pci_rstn_brg(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCI_RSTN_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_W::new(self, 14)
+    pub fn u0_pci_brg(&mut self) -> U0_PCI_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCI_BRG_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_W::new(self, 15)
+    pub fn u0_pcie_pcie(&mut self) -> U0_PCIE_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_PCIE_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_W::new(self, 16)
+    pub fn u0_pcie_apb(&mut self) -> U0_PCIE_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 17)
+    pub fn u1_pcie_axi_mst0(&mut self) -> U1_PCIE_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_MST0_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 18)
+    pub fn u1_pcie_axi_slv0(&mut self) -> U1_PCIE_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_SLV0_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 19)
+    pub fn u1_pcie_axi_slv(&mut self) -> U1_PCIE_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_SLV_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_brg(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_W::new(self, 20)
+    pub fn u1_pcie_brg(&mut self) -> U1_PCIE_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_BRG_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_W::new(self, 21)
+    pub fn u1_pcie_pcie(&mut self) -> U1_PCIE_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_PCIE_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_W::new(self, 22)
+    pub fn u1_pcie_apb(&mut self) -> U1_PCIE_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_APB_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/stgcrg/stgcrg_rst_stat.rs
+++ b/jh7110-vf2-12a-pac/src/stgcrg/stgcrg_rst_stat.rs
@@ -2,391 +2,353 @@
 pub type R = crate::R<STGCRG_RST_STAT_SPEC>;
 #[doc = "Register `stgcrg_rst_stat` writer"]
 pub type W = crate::W<STGCRG_RST_STAT_SPEC>;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_R = crate::BitReader;
+#[doc = "Field `u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_R = crate::BitReader;
+#[doc = "Field `u0_e2_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_R = crate::BitReader;
+#[doc = "Field `u0_dma_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_R = crate::BitReader;
+#[doc = "Field `u0_dma_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_R = crate::BitReader;
+#[doc = "Field `u0_usb_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pci_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_R = crate::BitReader;
+#[doc = "Field `u0_pci_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u0_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_R = crate::BitReader;
+#[doc = "Field `u1_pcie_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u1_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_stg_syscon_presetn(&self) -> RSTN_U0_STG_SYSCON_PRESETN_R {
-        RSTN_U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_stg_syscon_presetn(&self) -> U0_STG_SYSCON_PRESETN_R {
+        U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_core(&self) -> RST_U0_HIFI4_RST_CORE_R {
-        RST_U0_HIFI4_RST_CORE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_hifi4_core(&self) -> U0_HIFI4_CORE_R {
+        U0_HIFI4_CORE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_axi(&self) -> RST_U0_HIFI4_RST_AXI_R {
-        RST_U0_HIFI4_RST_AXI_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_hifi4_axi(&self) -> U0_HIFI4_AXI_R {
+        U0_HIFI4_AXI_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sec_top_hreesetn(&self) -> RSTN_U0_SEC_TOP_HREESETN_R {
-        RSTN_U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_sec_top_hreesetn(&self) -> U0_SEC_TOP_HREESETN_R {
+        U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_e2_sft7110_rst_core(&self) -> RST_U0_E2_SFT7110_RST_CORE_R {
-        RST_U0_E2_SFT7110_RST_CORE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_e2_core(&self) -> U0_E2_CORE_R {
+        U0_E2_CORE_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_dma_axi(&self) -> U0_DMA_AXI_R {
+        U0_DMA_AXI_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_dma_ahb(&self) -> U0_DMA_AHB_R {
+        U0_DMA_AHB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&self) -> RSTN_U0_CDN_USB_RSTN_AXI_R {
-        RSTN_U0_CDN_USB_RSTN_AXI_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_axi(&self) -> U0_USB_AXI_R {
+        U0_USB_AXI_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(&self) -> RSTN_U0_CDN_USB_RSTN_USB_APB_R {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_apb(&self) -> U0_USB_APB_R {
+        U0_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(&self) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_R {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_apb(&self) -> U0_USB_UTMI_APB_R {
+        U0_USB_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(&self) -> RSTN_U0_CDN_USB_RSTN_PWRUP_R {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_pwrup(&self) -> U0_USB_PWRUP_R {
+        U0_USB_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_pcie_axi_mst0(&self) -> U0_PCIE_AXI_MST0_R {
+        U0_PCIE_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pcie_axi_slv0(&self) -> U0_PCIE_AXI_SLV0_R {
+        U0_PCIE_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_pcie_axi_slv(&self) -> U0_PCIE_AXI_SLV_R {
+        U0_PCIE_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pci_rstn_brg(&self) -> RSTN_U0_PLDA_PCI_RSTN_BRG_R {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_pci_brg(&self) -> U0_PCI_BRG_R {
+        U0_PCI_BRG_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(&self) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_pcie_pcie(&self) -> U0_PCIE_PCIE_R {
+        U0_PCIE_PCIE_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_apb(&self) -> RSTN_U0_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_apb(&self) -> U0_PCIE_APB_R {
+        U0_PCIE_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_axi_mst0(&self) -> U1_PCIE_AXI_MST0_R {
+        U1_PCIE_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_pcie_axi_slv0(&self) -> U1_PCIE_AXI_SLV0_R {
+        U1_PCIE_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_pcie_axi_slv(&self) -> U1_PCIE_AXI_SLV_R {
+        U1_PCIE_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_brg(&self) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_R {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_pcie_brg(&self) -> U1_PCIE_BRG_R {
+        U1_PCIE_BRG_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(&self) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_pcie_pcie(&self) -> U1_PCIE_PCIE_R {
+        U1_PCIE_PCIE_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_apb(&self) -> RSTN_U1_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_apb(&self) -> U1_PCIE_APB_R {
+        U1_PCIE_APB_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_stg_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_STG_SYSCON_PRESETN_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_STG_SYSCON_PRESETN_W::new(self, 0)
+    pub fn u0_stg_syscon_presetn(&mut self) -> U0_STG_SYSCON_PRESETN_W<STGCRG_RST_STAT_SPEC> {
+        U0_STG_SYSCON_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_core(&mut self) -> RST_U0_HIFI4_RST_CORE_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_HIFI4_RST_CORE_W::new(self, 1)
+    pub fn u0_hifi4_core(&mut self) -> U0_HIFI4_CORE_W<STGCRG_RST_STAT_SPEC> {
+        U0_HIFI4_CORE_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_axi(&mut self) -> RST_U0_HIFI4_RST_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_HIFI4_RST_AXI_W::new(self, 2)
+    pub fn u0_hifi4_axi(&mut self) -> U0_HIFI4_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_HIFI4_AXI_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sec_top_hreesetn(&mut self) -> RSTN_U0_SEC_TOP_HREESETN_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_SEC_TOP_HREESETN_W::new(self, 3)
+    pub fn u0_sec_top_hreesetn(&mut self) -> U0_SEC_TOP_HREESETN_W<STGCRG_RST_STAT_SPEC> {
+        U0_SEC_TOP_HREESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_e2_sft7110_rst_core(
-        &mut self,
-    ) -> RST_U0_E2_SFT7110_RST_CORE_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_E2_SFT7110_RST_CORE_W::new(self, 4)
+    pub fn u0_e2_core(&mut self) -> U0_E2_CORE_W<STGCRG_RST_STAT_SPEC> {
+        U0_E2_CORE_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W::new(self, 5)
+    pub fn u0_dma_axi(&mut self) -> U0_DMA_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_DMA_AXI_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W::new(self, 6)
+    pub fn u0_dma_ahb(&mut self) -> U0_DMA_AHB_W<STGCRG_RST_STAT_SPEC> {
+        U0_DMA_AHB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&mut self) -> RSTN_U0_CDN_USB_RSTN_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_AXI_W::new(self, 7)
+    pub fn u0_usb_axi(&mut self) -> U0_USB_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_AXI_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_USB_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_W::new(self, 8)
+    pub fn u0_usb_apb(&mut self) -> U0_USB_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_W::new(self, 9)
+    pub fn u0_usb_utmi_apb(&mut self) -> U0_USB_UTMI_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_UTMI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_PWRUP_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_W::new(self, 10)
+    pub fn u0_usb_pwrup(&mut self) -> U0_USB_PWRUP_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_PWRUP_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 11)
+    pub fn u0_pcie_axi_mst0(&mut self) -> U0_PCIE_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_MST0_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 12)
+    pub fn u0_pcie_axi_slv0(&mut self) -> U0_PCIE_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_SLV0_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 13)
+    pub fn u0_pcie_axi_slv(&mut self) -> U0_PCIE_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_SLV_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pci_rstn_brg(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCI_RSTN_BRG_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_W::new(self, 14)
+    pub fn u0_pci_brg(&mut self) -> U0_PCI_BRG_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCI_BRG_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_W::new(self, 15)
+    pub fn u0_pcie_pcie(&mut self) -> U0_PCIE_PCIE_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_PCIE_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_W::new(self, 16)
+    pub fn u0_pcie_apb(&mut self) -> U0_PCIE_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 17)
+    pub fn u1_pcie_axi_mst0(&mut self) -> U1_PCIE_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_MST0_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 18)
+    pub fn u1_pcie_axi_slv0(&mut self) -> U1_PCIE_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_SLV0_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 19)
+    pub fn u1_pcie_axi_slv(&mut self) -> U1_PCIE_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_SLV_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_brg(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_W::new(self, 20)
+    pub fn u1_pcie_brg(&mut self) -> U1_PCIE_BRG_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_BRG_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_W::new(self, 21)
+    pub fn u1_pcie_pcie(&mut self) -> U1_PCIE_PCIE_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_PCIE_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_W::new(self, 22)
+    pub fn u1_pcie_apb(&mut self) -> U1_PCIE_APB_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_APB_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_0.rs
@@ -2,570 +2,488 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_0_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_0` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_0_SPEC>;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_bus` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_R = crate::BitReader;
+#[doc = "Field `u0_bus` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_debug` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_R = crate::BitReader;
+#[doc = "Field `u0_debug` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_R = crate::BitReader;
+#[doc = "Field `u0_core_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_R = crate::BitReader;
+#[doc = "Field `u0_core_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_R = crate::BitReader;
+#[doc = "Field `u0_core_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_R = crate::BitReader;
+#[doc = "Field `u0_core3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_R = crate::BitReader;
+#[doc = "Field `u0_core4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_R = crate::BitReader;
+#[doc = "Field `u0_core_st_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_R = crate::BitReader;
+#[doc = "Field `u0_core_st_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_R = crate::BitReader;
+#[doc = "Field `u0_core_st_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_R = crate::BitReader;
+#[doc = "Field `u0_core_st_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_R = crate::BitReader;
+#[doc = "Field `u0_core_st_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_R = crate::BitReader;
+#[doc = "Field `u0_trace_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_R = crate::BitReader;
+#[doc = "Field `u0_trace_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_R = crate::BitReader;
+#[doc = "Field `u0_trace_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_R = crate::BitReader;
+#[doc = "Field `u0_trace_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_R = crate::BitReader;
+#[doc = "Field `u0_trace_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_com` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_R = crate::BitReader;
+#[doc = "Field `u0_trace_com` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_doma` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_doma` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_axicfg0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_axicfg0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_cpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_cpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_disp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_disp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_gpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_gpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_ddrc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_ddrc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_stg_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_stg_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_vdec_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_vdec_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag2apb_presetn(&self) -> RSTN_U0_JTAG2APB_PRESETN_R {
-        RSTN_U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_jtag2apb_presetn(&self) -> U0_JTAG2APB_PRESETN_R {
+        U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_syscon_presetn(&self) -> RSTN_U0_SYS_SYSCON_PRESETN_R {
-        RSTN_U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_sys_syscon_presetn(&self) -> U0_SYS_SYSCON_PRESETN_R {
+        U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_iomux_presetn(&self) -> RSTN_U0_SYS_IOMUX_PRESETN_R {
-        RSTN_U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_sys_iomux_presetn(&self) -> U0_SYS_IOMUX_PRESETN_R {
+        U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(&self) -> RST_U0_U7MC_SFT7110_RST_BUS_R {
-        RST_U0_U7MC_SFT7110_RST_BUS_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_bus(&self) -> U0_BUS_R {
+        U0_BUS_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(&self) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_R {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_debug(&self) -> U0_DEBUG_R {
+        U0_DEBUG_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_core_0(&self) -> U0_CORE_0_R {
+        U0_CORE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_core_1(&self) -> U0_CORE_1_R {
+        U0_CORE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_core_2(&self) -> U0_CORE_2_R {
+        U0_CORE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_core3(&self) -> U0_CORE3_R {
+        U0_CORE3_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_core4(&self) -> U0_CORE4_R {
+        U0_CORE4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_core_st_0(&self) -> U0_CORE_ST_0_R {
+        U0_CORE_ST_0_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_core_st_1(&self) -> U0_CORE_ST_1_R {
+        U0_CORE_ST_1_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_core_st_2(&self) -> U0_CORE_ST_2_R {
+        U0_CORE_ST_2_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_core_st_3(&self) -> U0_CORE_ST_3_R {
+        U0_CORE_ST_3_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_core_st_4(&self) -> U0_CORE_ST_4_R {
+        U0_CORE_ST_4_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST0_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_trace_0(&self) -> U0_TRACE_0_R {
+        U0_TRACE_0_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST1_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_trace_1(&self) -> U0_TRACE_1_R {
+        U0_TRACE_1_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST2_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_trace_2(&self) -> U0_TRACE_2_R {
+        U0_TRACE_2_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST3_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_trace_3(&self) -> U0_TRACE_3_R {
+        U0_TRACE_3_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST4_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_trace_4(&self) -> U0_TRACE_4_R {
+        U0_TRACE_4_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(&self) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_R {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_trace_com(&self) -> U0_TRACE_COM_R {
+        U0_TRACE_COM_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_apb(&self) -> RST_U0_IMG_GPU_RSTN_APB_R {
-        RST_U0_IMG_GPU_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_img_gpu_apb(&self) -> U0_IMG_GPU_APB_R {
+        U0_IMG_GPU_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_doma(&self) -> RST_U0_IMG_GPU_RSTN_DOMA_R {
-        RST_U0_IMG_GPU_RSTN_DOMA_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_img_gpu_doma(&self) -> U0_IMG_GPU_DOMA_R {
+        U0_IMG_GPU_DOMA_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_noc_bus_apb(&self) -> U0_NOC_BUS_APB_R {
+        U0_NOC_BUS_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_noc_bus_axicfg0(&self) -> U0_NOC_BUS_AXICFG0_R {
+        U0_NOC_BUS_AXICFG0_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_noc_bus_cpu_axi(&self) -> U0_NOC_BUS_CPU_AXI_R {
+        U0_NOC_BUS_CPU_AXI_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_noc_bus_disp_axi(&self) -> U0_NOC_BUS_DISP_AXI_R {
+        U0_NOC_BUS_DISP_AXI_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_noc_bus_gpu_axi(&self) -> U0_NOC_BUS_GPU_AXI_R {
+        U0_NOC_BUS_GPU_AXI_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_noc_bus_isp_axi(&self) -> U0_NOC_BUS_ISP_AXI_R {
+        U0_NOC_BUS_ISP_AXI_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_noc_bus_ddrc(&self) -> U0_NOC_BUS_DDRC_R {
+        U0_NOC_BUS_DDRC_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_noc_bus_stg_axi(&self) -> U0_NOC_BUS_STG_AXI_R {
+        U0_NOC_BUS_STG_AXI_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_noc_bus_vdec_axi(&self) -> U0_NOC_BUS_VDEC_AXI_R {
+        U0_NOC_BUS_VDEC_AXI_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag2apb_presetn(
-        &mut self,
-    ) -> RSTN_U0_JTAG2APB_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_JTAG2APB_PRESETN_W::new(self, 0)
+    pub fn u0_jtag2apb_presetn(&mut self) -> U0_JTAG2APB_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_JTAG2APB_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_SYS_SYSCON_PRESETN_W::new(self, 1)
+    pub fn u0_sys_syscon_presetn(&mut self) -> U0_SYS_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_SYS_SYSCON_PRESETN_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_iomux_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_IOMUX_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_SYS_IOMUX_PRESETN_W::new(self, 2)
+    pub fn u0_sys_iomux_presetn(&mut self) -> U0_SYS_IOMUX_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_SYS_IOMUX_PRESETN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_BUS_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_BUS_W::new(self, 3)
+    pub fn u0_bus(&mut self) -> U0_BUS_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_BUS_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_W::new(self, 4)
+    pub fn u0_debug(&mut self) -> U0_DEBUG_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_DEBUG_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_W::new(self, 5)
+    pub fn u0_core_0(&mut self) -> U0_CORE_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_0_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_W::new(self, 6)
+    pub fn u0_core_1(&mut self) -> U0_CORE_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_W::new(self, 7)
+    pub fn u0_core_2(&mut self) -> U0_CORE_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_2_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_W::new(self, 8)
+    pub fn u0_core3(&mut self) -> U0_CORE3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE3_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_W::new(self, 9)
+    pub fn u0_core4(&mut self) -> U0_CORE4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE4_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_W::new(self, 10)
+    pub fn u0_core_st_0(&mut self) -> U0_CORE_ST_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_0_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_W::new(self, 11)
+    pub fn u0_core_st_1(&mut self) -> U0_CORE_ST_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_1_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_W::new(self, 12)
+    pub fn u0_core_st_2(&mut self) -> U0_CORE_ST_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_2_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_W::new(self, 13)
+    pub fn u0_core_st_3(&mut self) -> U0_CORE_ST_3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_3_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_W::new(self, 14)
+    pub fn u0_core_st_4(&mut self) -> U0_CORE_ST_4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_4_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_W::new(self, 15)
+    pub fn u0_trace_0(&mut self) -> U0_TRACE_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_0_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_W::new(self, 16)
+    pub fn u0_trace_1(&mut self) -> U0_TRACE_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_1_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_W::new(self, 17)
+    pub fn u0_trace_2(&mut self) -> U0_TRACE_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_2_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_W::new(self, 18)
+    pub fn u0_trace_3(&mut self) -> U0_TRACE_3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_3_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_W::new(self, 19)
+    pub fn u0_trace_4(&mut self) -> U0_TRACE_4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_4_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_W::new(self, 20)
+    pub fn u0_trace_com(&mut self) -> U0_TRACE_COM_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_COM_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_apb(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_APB_W::new(self, 21)
+    pub fn u0_img_gpu_apb(&mut self) -> U0_IMG_GPU_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_IMG_GPU_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_doma(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_DOMA_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_DOMA_W::new(self, 22)
+    pub fn u0_img_gpu_doma(&mut self) -> U0_IMG_GPU_DOMA_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_IMG_GPU_DOMA_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W::new(self, 23)
+    pub fn u0_noc_bus_apb(&mut self) -> U0_NOC_BUS_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W::new(self, 24)
+    pub fn u0_noc_bus_axicfg0(&mut self) -> U0_NOC_BUS_AXICFG0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_AXICFG0_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W::new(self, 25)
+    pub fn u0_noc_bus_cpu_axi(&mut self) -> U0_NOC_BUS_CPU_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_CPU_AXI_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W::new(self, 26)
+    pub fn u0_noc_bus_disp_axi(&mut self) -> U0_NOC_BUS_DISP_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_DISP_AXI_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W::new(self, 27)
+    pub fn u0_noc_bus_gpu_axi(&mut self) -> U0_NOC_BUS_GPU_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_GPU_AXI_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W::new(self, 28)
+    pub fn u0_noc_bus_isp_axi(&mut self) -> U0_NOC_BUS_ISP_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_ISP_AXI_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W::new(self, 29)
+    pub fn u0_noc_bus_ddrc(&mut self) -> U0_NOC_BUS_DDRC_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_DDRC_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W::new(self, 30)
+    pub fn u0_noc_bus_stg_axi(&mut self) -> U0_NOC_BUS_STG_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_STG_AXI_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W::new(self, 31)
+    pub fn u0_noc_bus_vdec_axi(&mut self) -> U0_NOC_BUS_VDEC_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_VDEC_AXI_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_1.rs
@@ -2,561 +2,490 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_1_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_1` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_1_SPEC>;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<'a, REG> =
-    crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_venc_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_venc_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_R = crate::BitReader;
+#[doc = "Field `u0_ddr_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_osc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_R = crate::BitReader;
+#[doc = "Field `u0_ddr_osc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_R = crate::BitReader;
+#[doc = "Field `u0_ddr_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_top` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_R = crate::BitReader;
+#[doc = "Field `u0_isp_top` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_R = crate::BitReader;
+#[doc = "Field `u0_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave511_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave511_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave511_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave511_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_aximem_128b_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_R = crate::BitReader;
+#[doc = "Field `u0_aximem_128b_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u1_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u2_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_intmem_rom_sram` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_R = crate::BitReader;
+#[doc = "Field `u0_intmem_rom_sram` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ref` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ref` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R::new((self.bits & 1) != 0)
+    pub fn u0_noc_bus_venc_axi(&self) -> U0_NOC_BUS_VENC_AXI_R {
+        U0_NOC_BUS_VENC_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_ahb(&self) -> U0_AXI_CFG1_DEC_AHB_R {
+        U0_AXI_CFG1_DEC_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_main(&self) -> U0_AXI_CFG1_DEC_MAIN_R {
+        U0_AXI_CFG1_DEC_MAIN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main(&self) -> U0_AXI_CFG0_DEC_MAIN_R {
+        U0_AXI_CFG0_DEC_MAIN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main_div(&self) -> U0_AXI_CFG0_DEC_MAIN_DIV_R {
+        U0_AXI_CFG0_DEC_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_hifi4(&self) -> U0_AXI_CFG0_DEC_HIFI4_R {
+        U0_AXI_CFG0_DEC_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(&self) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_R {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_ddr_axi(&self) -> U0_DDR_AXI_R {
+        U0_DDR_AXI_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(&self) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_R {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_ddr_osc(&self) -> U0_DDR_OSC_R {
+        U0_DDR_OSC_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(&self) -> RSTN_U0_DDR_SFT7110_RSTN_APB_R {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_ddr_apb(&self) -> U0_DDR_APB_R {
+        U0_DDR_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_isp_top(&self) -> U0_ISP_TOP_R {
+        U0_ISP_TOP_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_isp_axi(&self) -> U0_ISP_AXI_R {
+        U0_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_vout_src(&self) -> U0_VOUT_SRC_R {
+        U0_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_axi(&self) -> RSTN_U0_CODAJ12_RSTN_AXI_R {
-        RSTN_U0_CODAJ12_RSTN_AXI_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_codaj12_axi(&self) -> U0_CODAJ12_AXI_R {
+        U0_CODAJ12_AXI_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_core(&self) -> RSTN_U0_CODAJ12_RSTN_CORE_R {
-        RSTN_U0_CODAJ12_RSTN_CORE_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_codaj12_core(&self) -> U0_CODAJ12_CORE_R {
+        U0_CODAJ12_CORE_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_apb(&self) -> RSTN_U0_CODAJ12_RSTN_APB_R {
-        RSTN_U0_CODAJ12_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_codaj12_apb(&self) -> U0_CODAJ12_APB_R {
+        U0_CODAJ12_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_axi(&self) -> RSTN_U0_WAVE511_RSTN_AXI_R {
-        RSTN_U0_WAVE511_RSTN_AXI_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_wave511_axi(&self) -> U0_WAVE511_AXI_R {
+        U0_WAVE511_AXI_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_bpu(&self) -> RSTN_U0_WAVE511_RSTN_BPU_R {
-        RSTN_U0_WAVE511_RSTN_BPU_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_wave511_bpu(&self) -> U0_WAVE511_BPU_R {
+        U0_WAVE511_BPU_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_vce(&self) -> RSTN_U0_WAVE511_RSTN_VCE_R {
-        RSTN_U0_WAVE511_RSTN_VCE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_wave511_vce(&self) -> U0_WAVE511_VCE_R {
+        U0_WAVE511_VCE_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_apb(&self) -> RSTN_U0_WAVE511_RSTN_APB_R {
-        RSTN_U0_WAVE511_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_wave511_apb(&self) -> U0_WAVE511_APB_R {
+        U0_WAVE511_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_vdec_jpg_arb(&self) -> U0_VDEC_JPG_ARB_R {
+        U0_VDEC_JPG_ARB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_vdec_jpg_arb_main(&self) -> U0_VDEC_JPG_ARB_MAIN_R {
+        U0_VDEC_JPG_ARB_MAIN_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_aximem_128b_rstn_axi(&self) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_aximem_128b_axi(&self) -> U0_AXIMEM_128B_AXI_R {
+        U0_AXIMEM_128B_AXI_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_axi(&self) -> RSTN_U0_WAVE420L_RSTN_AXI_R {
-        RSTN_U0_WAVE420L_RSTN_AXI_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_wave420l_axi(&self) -> U0_WAVE420L_AXI_R {
+        U0_WAVE420L_AXI_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_bpu(&self) -> RSTN_U0_WAVE420L_RSTN_BPU_R {
-        RSTN_U0_WAVE420L_RSTN_BPU_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_wave420l_bpu(&self) -> U0_WAVE420L_BPU_R {
+        U0_WAVE420L_BPU_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_vce(&self) -> RSTN_U0_WAVE420L_RSTN_VCE_R {
-        RSTN_U0_WAVE420L_RSTN_VCE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_wave420l_vce(&self) -> U0_WAVE420L_VCE_R {
+        U0_WAVE420L_VCE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_apb(&self) -> RSTN_U0_WAVE420L_RSTN_APB_R {
-        RSTN_U0_WAVE420L_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_wave420l_apb(&self) -> U0_WAVE420L_APB_R {
+        U0_WAVE420L_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_aximem_128b_rstn_axi(&self) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_aximem(&self) -> U1_AXIMEM_R {
+        U1_AXIMEM_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_aximem_128b_rstn_axi(&self) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u2_aximem(&self) -> U2_AXIMEM_R {
+        U2_AXIMEM_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(&self) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_intmem_rom_sram(&self) -> U0_INTMEM_ROM_SRAM_R {
+        U0_INTMEM_ROM_SRAM_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_qspi_ahb(&self) -> U0_QSPI_AHB_R {
+        U0_QSPI_AHB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_APB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_qspi_apb(&self) -> U0_QSPI_APB_R {
+        U0_QSPI_APB_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(&self) -> RSTN_U0_CDNS_QSPI_RSTN_REF_R {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_qspi_ref(&self) -> U0_QSPI_REF_R {
+        U0_QSPI_REF_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &mut self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W::new(self, 0)
+    pub fn u0_noc_bus_venc_axi(&mut self) -> U0_NOC_BUS_VENC_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_NOC_BUS_VENC_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W::new(self, 1)
+    pub fn u0_axi_cfg1_dec_ahb(&mut self) -> U0_AXI_CFG1_DEC_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG1_DEC_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W::new(self, 2)
+    pub fn u0_axi_cfg1_dec_main(&mut self) -> U0_AXI_CFG1_DEC_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG1_DEC_MAIN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W::new(self, 3)
+    pub fn u0_axi_cfg0_dec_main(&mut self) -> U0_AXI_CFG0_DEC_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(
+    pub fn u0_axi_cfg0_dec_main_div(
         &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W::new(self, 4)
+    ) -> U0_AXI_CFG0_DEC_MAIN_DIV_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_DIV_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W::new(self, 5)
+    pub fn u0_axi_cfg0_dec_hifi4(&mut self) -> U0_AXI_CFG0_DEC_HIFI4_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_HIFI4_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_W::new(self, 6)
+    pub fn u0_ddr_axi(&mut self) -> U0_DDR_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_AXI_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_W::new(self, 7)
+    pub fn u0_ddr_osc(&mut self) -> U0_DDR_OSC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_OSC_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_W::new(self, 8)
+    pub fn u0_ddr_apb(&mut self) -> U0_DDR_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W::new(self, 9)
+    pub fn u0_isp_top(&mut self) -> U0_ISP_TOP_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_ISP_TOP_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W::new(self, 10)
+    pub fn u0_isp_axi(&mut self) -> U0_ISP_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_ISP_AXI_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &mut self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W::new(self, 11)
+    pub fn u0_vout_src(&mut self) -> U0_VOUT_SRC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VOUT_SRC_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_AXI_W::new(self, 12)
+    pub fn u0_codaj12_axi(&mut self) -> U0_CODAJ12_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_AXI_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_core(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_CORE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_CORE_W::new(self, 13)
+    pub fn u0_codaj12_core(&mut self) -> U0_CODAJ12_CORE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_CORE_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_APB_W::new(self, 14)
+    pub fn u0_codaj12_apb(&mut self) -> U0_CODAJ12_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_AXI_W::new(self, 15)
+    pub fn u0_wave511_axi(&mut self) -> U0_WAVE511_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_AXI_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_BPU_W::new(self, 16)
+    pub fn u0_wave511_bpu(&mut self) -> U0_WAVE511_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_BPU_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_VCE_W::new(self, 17)
+    pub fn u0_wave511_vce(&mut self) -> U0_WAVE511_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_VCE_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_APB_W::new(self, 18)
+    pub fn u0_wave511_apb(&mut self) -> U0_WAVE511_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W::new(self, 19)
+    pub fn u0_vdec_jpg_arb(&mut self) -> U0_VDEC_JPG_ARB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VDEC_JPG_ARB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W::new(self, 20)
+    pub fn u0_vdec_jpg_arb_main(&mut self) -> U0_VDEC_JPG_ARB_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VDEC_JPG_ARB_MAIN_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_W::new(self, 21)
+    pub fn u0_aximem_128b_axi(&mut self) -> U0_AXIMEM_128B_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXIMEM_128B_AXI_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_AXI_W::new(self, 22)
+    pub fn u0_wave420l_axi(&mut self) -> U0_WAVE420L_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_AXI_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_BPU_W::new(self, 23)
+    pub fn u0_wave420l_bpu(&mut self) -> U0_WAVE420L_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_BPU_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_VCE_W::new(self, 24)
+    pub fn u0_wave420l_vce(&mut self) -> U0_WAVE420L_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_VCE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_APB_W::new(self, 25)
+    pub fn u0_wave420l_apb(&mut self) -> U0_WAVE420L_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_W::new(self, 26)
+    pub fn u1_aximem(&mut self) -> U1_AXIMEM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U1_AXIMEM_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_W::new(self, 27)
+    pub fn u2_aximem(&mut self) -> U2_AXIMEM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U2_AXIMEM_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(
-        &mut self,
-    ) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W::new(self, 28)
+    pub fn u0_intmem_rom_sram(&mut self) -> U0_INTMEM_ROM_SRAM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_INTMEM_ROM_SRAM_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_W::new(self, 29)
+    pub fn u0_qspi_ahb(&mut self) -> U0_QSPI_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_AHB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_W::new(self, 30)
+    pub fn u0_qspi_apb(&mut self) -> U0_QSPI_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_APB_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_REF_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_W::new(self, 31)
+    pub fn u0_qspi_ref(&mut self) -> U0_QSPI_REF_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_REF_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_2.rs
@@ -2,510 +2,488 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_2_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_2` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_2_SPEC>;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u6_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sdio_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_R = crate::BitReader;
+#[doc = "Field `u0_sdio_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_sdi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_R = crate::BitReader;
+#[doc = "Field `u1_sdi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64_hresetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64_hresetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u1_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u2_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u3_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u4_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u5_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u6_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u2_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u3_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u4_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u5_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u6_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_R = crate::BitReader;
+#[doc = "Field `u0_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u0_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_R = crate::BitReader;
+#[doc = "Field `u1_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u1_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_R = crate::BitReader;
+#[doc = "Field `u2_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u2_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_R = crate::BitReader;
+#[doc = "Field `u3_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u3_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_R = crate::BitReader;
+#[doc = "Field `u4_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u4_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_R = crate::BitReader;
+#[doc = "Field `u5_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u6_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spdif_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_R = crate::BitReader;
+#[doc = "Field `u0_spdif_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sdio_rstn_ahb(&self) -> RSTN_U0_SDIO_RSTN_AHB_R {
-        RSTN_U0_SDIO_RSTN_AHB_R::new((self.bits & 1) != 0)
+    pub fn u0_sdio_ahb(&self) -> U0_SDIO_AHB_R {
+        U0_SDIO_AHB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_sdi_rstn_ahb(&self) -> RSTN_U1_SDI_RSTN_AHB_R {
-        RSTN_U1_SDI_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_sdi_ahb(&self) -> U1_SDI_AHB_R {
+        U1_SDI_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(&self) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_R {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_gmac5_axi64(&self) -> U1_GMAC5_AXI64_R {
+        U1_GMAC5_AXI64_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(&self) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_R {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u1_gmac5_axi64_hresetn(&self) -> U1_GMAC5_AXI64_HRESETN_R {
+        U1_GMAC5_AXI64_HRESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_mailbox_presetn(&self) -> RSTN_U0_MAILBOX_PRESETN_R {
-        RSTN_U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_mailbox_presetn(&self) -> U0_MAILBOX_PRESETN_R {
+        U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ssp_spi_rstn_apb(&self) -> RSTN_U0_SSP_SPI_RSTN_APB_R {
-        RSTN_U0_SSP_SPI_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_spi_apb(&self) -> U0_SPI_APB_R {
+        U0_SPI_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_ssp_spi_rstn_apb(&self) -> RSTN_U1_SSP_SPI_RSTN_APB_R {
-        RSTN_U1_SSP_SPI_RSTN_APB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u1_spi_apb(&self) -> U1_SPI_APB_R {
+        U1_SPI_APB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_ssp_spi_rstn_apb(&self) -> RSTN_U2_SSP_SPI_RSTN_APB_R {
-        RSTN_U2_SSP_SPI_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u2_spi_apb(&self) -> U2_SPI_APB_R {
+        U2_SPI_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_ssp_spi_rstn_apb(&self) -> RSTN_U3_SSP_SPI_RSTN_APB_R {
-        RSTN_U3_SSP_SPI_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u3_spi_apb(&self) -> U3_SPI_APB_R {
+        U3_SPI_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_ssp_spi_rstn_apb(&self) -> RSTN_U4_SSP_SPI_RSTN_APB_R {
-        RSTN_U4_SSP_SPI_RSTN_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u4_spi_apb(&self) -> U4_SPI_APB_R {
+        U4_SPI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_ssp_spi_rstn_apb(&self) -> RSTN_U5_SSP_SPI_RSTN_APB_R {
-        RSTN_U5_SSP_SPI_RSTN_APB_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u5_spi_apb(&self) -> U5_SPI_APB_R {
+        U5_SPI_APB_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_ssp_spi_rstn_apb(&self) -> RSTN_U6_SSP_SPI_RSTN_APB_R {
-        RSTN_U6_SSP_SPI_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u6_spi_apb(&self) -> U6_SPI_APB_R {
+        U6_SPI_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2c_rstn_apb(&self) -> RSTN_U0_I2C_RSTN_APB_R {
-        RSTN_U0_I2C_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_i2c_apb(&self) -> U0_I2C_APB_R {
+        U0_I2C_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2c_rstn_apb(&self) -> RSTN_U1_I2C_RSTN_APB_R {
-        RSTN_U1_I2C_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u1_i2c_apb(&self) -> U1_I2C_APB_R {
+        U1_I2C_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_i2c_rstn_apb(&self) -> RSTN_U2_I2C_RSTN_APB_R {
-        RSTN_U2_I2C_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u2_i2c_apb(&self) -> U2_I2C_APB_R {
+        U2_I2C_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_i2c_rstn_apb(&self) -> RSTN_U3_I2C_RSTN_APB_R {
-        RSTN_U3_I2C_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u3_i2c_apb(&self) -> U3_I2C_APB_R {
+        U3_I2C_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_i2c_rstn_apb(&self) -> RSTN_U4_I2C_RSTN_APB_R {
-        RSTN_U4_I2C_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u4_i2c_apb(&self) -> U4_I2C_APB_R {
+        U4_I2C_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_i2c_rstn_apb(&self) -> RSTN_U5_I2C_RSTN_APB_R {
-        RSTN_U5_I2C_RSTN_APB_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u5_i2c_apb(&self) -> U5_I2C_APB_R {
+        U5_I2C_APB_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_i2c_rstn_apb(&self) -> RSTN_U6_I2C_RSTN_APB_R {
-        RSTN_U6_I2C_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u6_i2c_apb(&self) -> U6_I2C_APB_R {
+        U6_I2C_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_apb(&self) -> RSTN_U0_UART_RSTN_APB_R {
-        RSTN_U0_UART_RSTN_APB_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_uart_apb(&self) -> U0_UART_APB_R {
+        U0_UART_APB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_core(&self) -> RSTN_U0_UART_RSTN_CORE_R {
-        RSTN_U0_UART_RSTN_CORE_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_uart_core(&self) -> U0_UART_CORE_R {
+        U0_UART_CORE_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_apb(&self) -> RSTN_U1_UART_RSTN_APB_R {
-        RSTN_U1_UART_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_uart_apb(&self) -> U1_UART_APB_R {
+        U1_UART_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_core(&self) -> RSTN_U1_UART_RSTN_CORE_R {
-        RSTN_U1_UART_RSTN_CORE_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_uart_core(&self) -> U1_UART_CORE_R {
+        U1_UART_CORE_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_apb(&self) -> RSTN_U2_UART_RSTN_APB_R {
-        RSTN_U2_UART_RSTN_APB_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u2_uart_apb(&self) -> U2_UART_APB_R {
+        U2_UART_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_core(&self) -> RSTN_U2_UART_RSTN_CORE_R {
-        RSTN_U2_UART_RSTN_CORE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u2_uart_core(&self) -> U2_UART_CORE_R {
+        U2_UART_CORE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_apb(&self) -> RSTN_U3_UART_RSTN_APB_R {
-        RSTN_U3_UART_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u3_uart_apb(&self) -> U3_UART_APB_R {
+        U3_UART_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_core(&self) -> RSTN_U3_UART_RSTN_CORE_R {
-        RSTN_U3_UART_RSTN_CORE_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u3_uart_core(&self) -> U3_UART_CORE_R {
+        U3_UART_CORE_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_apb(&self) -> RSTN_U4_UART_RSTN_APB_R {
-        RSTN_U4_UART_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u4_uart_apb(&self) -> U4_UART_APB_R {
+        U4_UART_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_core(&self) -> RSTN_U4_UART_RSTN_CORE_R {
-        RSTN_U4_UART_RSTN_CORE_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u4_uart_core(&self) -> U4_UART_CORE_R {
+        U4_UART_CORE_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_uart_rstn_apb(&self) -> RSTN_U5_UART_RSTN_APB_R {
-        RSTN_U5_UART_RSTN_APB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u5_uart_apb(&self) -> U5_UART_APB_R {
+        U5_UART_APB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_uart_rstn_core(&self) -> RSTN_U6_UART_RSTN_CORE_R {
-        RSTN_U6_UART_RSTN_CORE_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u6_uart_core(&self) -> U6_UART_CORE_R {
+        U6_UART_CORE_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(&self) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_R {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_spdif_apb(&self) -> U0_SPDIF_APB_R {
+        U0_SPDIF_APB_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sdio_rstn_ahb(&mut self) -> RSTN_U0_SDIO_RSTN_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_SDIO_RSTN_AHB_W::new(self, 0)
+    pub fn u0_sdio_ahb(&mut self) -> U0_SDIO_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SDIO_AHB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_sdi_rstn_ahb(&mut self) -> RSTN_U1_SDI_RSTN_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_SDI_RSTN_AHB_W::new(self, 1)
+    pub fn u1_sdi_ahb(&mut self) -> U1_SDI_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_SDI_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_W::new(self, 2)
+    pub fn u1_gmac5_axi64(&mut self) -> U1_GMAC5_AXI64_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_GMAC5_AXI64_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_W::new(self, 3)
+    pub fn u1_gmac5_axi64_hresetn(&mut self) -> U1_GMAC5_AXI64_HRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_GMAC5_AXI64_HRESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_mailbox_presetn(
-        &mut self,
-    ) -> RSTN_U0_MAILBOX_PRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_MAILBOX_PRESETN_W::new(self, 4)
+    pub fn u0_mailbox_presetn(&mut self) -> U0_MAILBOX_PRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_MAILBOX_PRESETN_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_SSP_SPI_RSTN_APB_W::new(self, 5)
+    pub fn u0_spi_apb(&mut self) -> U0_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SPI_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_SSP_SPI_RSTN_APB_W::new(self, 6)
+    pub fn u1_spi_apb(&mut self) -> U1_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_SPI_APB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U2_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_SSP_SPI_RSTN_APB_W::new(self, 7)
+    pub fn u2_spi_apb(&mut self) -> U2_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_SPI_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U3_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_SSP_SPI_RSTN_APB_W::new(self, 8)
+    pub fn u3_spi_apb(&mut self) -> U3_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_SPI_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U4_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_SSP_SPI_RSTN_APB_W::new(self, 9)
+    pub fn u4_spi_apb(&mut self) -> U4_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_SPI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U5_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_SSP_SPI_RSTN_APB_W::new(self, 10)
+    pub fn u5_spi_apb(&mut self) -> U5_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_SPI_APB_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U6_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_SSP_SPI_RSTN_APB_W::new(self, 11)
+    pub fn u6_spi_apb(&mut self) -> U6_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_SPI_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2c_rstn_apb(&mut self) -> RSTN_U0_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_I2C_RSTN_APB_W::new(self, 12)
+    pub fn u0_i2c_apb(&mut self) -> U0_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_I2C_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2c_rstn_apb(&mut self) -> RSTN_U1_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_I2C_RSTN_APB_W::new(self, 13)
+    pub fn u1_i2c_apb(&mut self) -> U1_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_I2C_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_i2c_rstn_apb(&mut self) -> RSTN_U2_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_I2C_RSTN_APB_W::new(self, 14)
+    pub fn u2_i2c_apb(&mut self) -> U2_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_I2C_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_i2c_rstn_apb(&mut self) -> RSTN_U3_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_I2C_RSTN_APB_W::new(self, 15)
+    pub fn u3_i2c_apb(&mut self) -> U3_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_I2C_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_i2c_rstn_apb(&mut self) -> RSTN_U4_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_I2C_RSTN_APB_W::new(self, 16)
+    pub fn u4_i2c_apb(&mut self) -> U4_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_I2C_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_i2c_rstn_apb(&mut self) -> RSTN_U5_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_I2C_RSTN_APB_W::new(self, 17)
+    pub fn u5_i2c_apb(&mut self) -> U5_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_I2C_APB_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_i2c_rstn_apb(&mut self) -> RSTN_U6_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_I2C_RSTN_APB_W::new(self, 18)
+    pub fn u6_i2c_apb(&mut self) -> U6_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_I2C_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_apb(&mut self) -> RSTN_U0_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_UART_RSTN_APB_W::new(self, 19)
+    pub fn u0_uart_apb(&mut self) -> U0_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_UART_APB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_core(&mut self) -> RSTN_U0_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_UART_RSTN_CORE_W::new(self, 20)
+    pub fn u0_uart_core(&mut self) -> U0_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_UART_CORE_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_apb(&mut self) -> RSTN_U1_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_UART_RSTN_APB_W::new(self, 21)
+    pub fn u1_uart_apb(&mut self) -> U1_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_UART_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_core(&mut self) -> RSTN_U1_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_UART_RSTN_CORE_W::new(self, 22)
+    pub fn u1_uart_core(&mut self) -> U1_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_UART_CORE_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_apb(&mut self) -> RSTN_U2_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_UART_RSTN_APB_W::new(self, 23)
+    pub fn u2_uart_apb(&mut self) -> U2_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_UART_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_core(&mut self) -> RSTN_U2_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_UART_RSTN_CORE_W::new(self, 24)
+    pub fn u2_uart_core(&mut self) -> U2_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_UART_CORE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_apb(&mut self) -> RSTN_U3_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_UART_RSTN_APB_W::new(self, 25)
+    pub fn u3_uart_apb(&mut self) -> U3_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_UART_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_core(&mut self) -> RSTN_U3_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_UART_RSTN_CORE_W::new(self, 26)
+    pub fn u3_uart_core(&mut self) -> U3_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_UART_CORE_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_apb(&mut self) -> RSTN_U4_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_UART_RSTN_APB_W::new(self, 27)
+    pub fn u4_uart_apb(&mut self) -> U4_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_UART_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_core(&mut self) -> RSTN_U4_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_UART_RSTN_CORE_W::new(self, 28)
+    pub fn u4_uart_core(&mut self) -> U4_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_UART_CORE_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_uart_rstn_apb(&mut self) -> RSTN_U5_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_UART_RSTN_APB_W::new(self, 29)
+    pub fn u5_uart_apb(&mut self) -> U5_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_UART_APB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_uart_rstn_core(&mut self) -> RSTN_U6_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_UART_RSTN_CORE_W::new(self, 30)
+    pub fn u6_uart_core(&mut self) -> U6_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_UART_CORE_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_W::new(self, 31)
+    pub fn u0_spdif_apb(&mut self) -> U0_SPDIF_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SPDIF_APB_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_3.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/soft_rst_addr_sel_3.rs
@@ -2,518 +2,458 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_3_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_3` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_3_SPEC>;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwmdac_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwmdac_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_dmic` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_dmic` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_tdm` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_tdm` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwm_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwm_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_can` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_can` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_int_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_int_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag_rst` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_R = crate::BitReader;
+#[doc = "Field `u0_jtag_rst` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwmdac_rstn_apb(&self) -> RSTN_U0_PWMDAC_RSTN_APB_R {
-        RSTN_U0_PWMDAC_RSTN_APB_R::new((self.bits & 1) != 0)
+    pub fn u0_pwmdac_apb(&self) -> U0_PWMDAC_APB_R {
+        U0_PWMDAC_APB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(&self) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_R {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pdm_4mic_dmic(&self) -> U0_PDM_4MIC_DMIC_R {
+        U0_PDM_4MIC_DMIC_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(&self) -> RSTN_U0_PDM_4MIC_RSTN_APB_R {
-        RSTN_U0_PDM_4MIC_RSTN_APB_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pdm_4mic_apb(&self) -> U0_PDM_4MIC_APB_R {
+        U0_PDM_4MIC_APB_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(&self) -> RSTN_U0_I2SRX_3CH_RSTN_APB_R {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_i2srx_apb(&self) -> U0_I2SRX_APB_R {
+        U0_I2SRX_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(&self) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_R {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_i2srx_bclk(&self) -> U0_I2SRX_BCLK_R {
+        U0_I2SRX_BCLK_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(&self) -> RSTN_U0_I2STX_4CH_RSTN_APB_R {
-        RSTN_U0_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_i2stx_apb(&self) -> U0_I2STX_APB_R {
+        U0_I2STX_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(&self) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_i2stx_bclk(&self) -> U0_I2STX_BCLK_R {
+        U0_I2STX_BCLK_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(&self) -> RSTN_U1_I2STX_4CH_RSTN_APB_R {
-        RSTN_U1_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_i2stx_apb(&self) -> U1_I2STX_APB_R {
+        U1_I2STX_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(&self) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_i2stx_bclk(&self) -> U1_I2STX_BCLK_R {
+        U1_I2STX_BCLK_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(&self) -> RSTN_U0_TDM16SLOT_RSTN_AHB_R {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_tdm16slot_ahb(&self) -> U0_TDM16SLOT_AHB_R {
+        U0_TDM16SLOT_AHB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(&self) -> RSTN_U0_TDM16SLOT_RSTN_TDM_R {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_tdm16slot_tdm(&self) -> U0_TDM16SLOT_TDM_R {
+        U0_TDM16SLOT_TDM_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_apb(&self) -> RSTN_U0_TDM16SLOT_RSTN_APB_R {
-        RSTN_U0_TDM16SLOT_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_tdm16slot_apb(&self) -> U0_TDM16SLOT_APB_R {
+        U0_TDM16SLOT_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(&self) -> RSTN_U0_PWM_8CH_RSTN_APB_R {
-        RSTN_U0_PWM_8CH_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pwm_apb(&self) -> U0_PWM_APB_R {
+        U0_PWM_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(&self) -> RSTN_U0_DSKIT_WDT_RSTN_APB_R {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_dskit_wdt_rstn_apb(&self) -> U0_DSKIT_WDT_RSTN_APB_R {
+        U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(&self) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_R {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_dskit_wdt(&self) -> U0_DSKIT_WDT_R {
+        U0_DSKIT_WDT_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_apb(&self) -> RSTN_U0_CAN_CTRL_RSTN_APB_R {
-        RSTN_U0_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_can_ctrl_apb(&self) -> U0_CAN_CTRL_APB_R {
+        U0_CAN_CTRL_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_can(&self) -> RSTN_U0_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_can_ctrl(&self) -> U0_CAN_CTRL_R {
+        U0_CAN_CTRL_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_timer(&self) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_can_ctrl_timer(&self) -> U0_CAN_CTRL_TIMER_R {
+        U0_CAN_CTRL_TIMER_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_apb(&self) -> RSTN_U1_CAN_CTRL_RSTN_APB_R {
-        RSTN_U1_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_can_ctrl_apb(&self) -> U1_CAN_CTRL_APB_R {
+        U1_CAN_CTRL_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_can(&self) -> RSTN_U1_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_can_ctrl_can(&self) -> U1_CAN_CTRL_CAN_R {
+        U1_CAN_CTRL_CAN_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_timer(&self) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_can_ctrl_timer(&self) -> U1_CAN_CTRL_TIMER_R {
+        U1_CAN_CTRL_TIMER_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_apb(&self) -> RSTN_U0_SI5_TIMER_RSTN_APB_R {
-        RSTN_U0_SI5_TIMER_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_si5_timer_apb(&self) -> U0_SI5_TIMER_APB_R {
+        U0_SI5_TIMER_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer0(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_si5_timer_0(&self) -> U0_SI5_TIMER_0_R {
+        U0_SI5_TIMER_0_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_time10(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_si5_timer_1(&self) -> U0_SI5_TIMER_1_R {
+        U0_SI5_TIMER_1_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer2(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_si5_timer_2(&self) -> U0_SI5_TIMER_2_R {
+        U0_SI5_TIMER_2_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer3(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_si5_timer_3(&self) -> U0_SI5_TIMER_3_R {
+        U0_SI5_TIMER_3_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_int_ctrl_rstn_apb(&self) -> RSTN_U0_INT_CTRL_RSTN_APB_R {
-        RSTN_U0_INT_CTRL_RSTN_APB_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_int_ctrl_apb(&self) -> U0_INT_CTRL_APB_R {
+        U0_INT_CTRL_APB_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_apb(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_temp_sensor_apb(&self) -> U0_TEMP_SENSOR_APB_R {
+        U0_TEMP_SENSOR_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_temp(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_temp_sensor(&self) -> U0_TEMP_SENSOR_R {
+        U0_TEMP_SENSOR_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag_certification_rst_n(&self) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_R {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_jtag_rst(&self) -> U0_JTAG_RST_R {
+        U0_JTAG_RST_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwmdac_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWMDAC_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PWMDAC_RSTN_APB_W::new(self, 0)
+    pub fn u0_pwmdac_apb(&mut self) -> U0_PWMDAC_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PWMDAC_APB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_W::new(self, 1)
+    pub fn u0_pdm_4mic_dmic(&mut self) -> U0_PDM_4MIC_DMIC_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PDM_4MIC_DMIC_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_APB_W::new(self, 2)
+    pub fn u0_pdm_4mic_apb(&mut self) -> U0_PDM_4MIC_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PDM_4MIC_APB_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_W::new(self, 3)
+    pub fn u0_i2srx_apb(&mut self) -> U0_I2SRX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2SRX_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_W::new(self, 4)
+    pub fn u0_i2srx_bclk(&mut self) -> U0_I2SRX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2SRX_BCLK_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_APB_W::new(self, 5)
+    pub fn u0_i2stx_apb(&mut self) -> U0_I2STX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2STX_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_W::new(self, 6)
+    pub fn u0_i2stx_bclk(&mut self) -> U0_I2STX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2STX_BCLK_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_APB_W::new(self, 7)
+    pub fn u1_i2stx_apb(&mut self) -> U1_I2STX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_I2STX_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_W::new(self, 8)
+    pub fn u1_i2stx_bclk(&mut self) -> U1_I2STX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_I2STX_BCLK_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_AHB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_W::new(self, 9)
+    pub fn u0_tdm16slot_ahb(&mut self) -> U0_TDM16SLOT_AHB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_AHB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_TDM_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_W::new(self, 10)
+    pub fn u0_tdm16slot_tdm(&mut self) -> U0_TDM16SLOT_TDM_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_TDM_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_APB_W::new(self, 11)
+    pub fn u0_tdm16slot_apb(&mut self) -> U0_TDM16SLOT_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWM_8CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PWM_8CH_RSTN_APB_W::new(self, 12)
+    pub fn u0_pwm_apb(&mut self) -> U0_PWM_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PWM_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
+    pub fn u0_dskit_wdt_rstn_apb(&mut self) -> U0_DSKIT_WDT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_W::new(self, 14)
+    pub fn u0_dskit_wdt(&mut self) -> U0_DSKIT_WDT_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_DSKIT_WDT_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_APB_W::new(self, 15)
+    pub fn u0_can_ctrl_apb(&mut self) -> U0_CAN_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_W::new(self, 16)
+    pub fn u0_can_ctrl(&mut self) -> U0_CAN_CTRL_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_W::new(self, 17)
+    pub fn u0_can_ctrl_timer(&mut self) -> U0_CAN_CTRL_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_TIMER_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_APB_W::new(self, 18)
+    pub fn u1_can_ctrl_apb(&mut self) -> U1_CAN_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_W::new(self, 19)
+    pub fn u1_can_ctrl_can(&mut self) -> U1_CAN_CTRL_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_CAN_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_W::new(self, 20)
+    pub fn u1_can_ctrl_timer(&mut self) -> U1_CAN_CTRL_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_TIMER_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_APB_W::new(self, 21)
+    pub fn u0_si5_timer_apb(&mut self) -> U0_SI5_TIMER_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer0(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_W::new(self, 22)
+    pub fn u0_si5_timer_0(&mut self) -> U0_SI5_TIMER_0_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_0_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_time10(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_W::new(self, 23)
+    pub fn u0_si5_timer_1(&mut self) -> U0_SI5_TIMER_1_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_1_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer2(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_W::new(self, 24)
+    pub fn u0_si5_timer_2(&mut self) -> U0_SI5_TIMER_2_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_2_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer3(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_W::new(self, 25)
+    pub fn u0_si5_timer_3(&mut self) -> U0_SI5_TIMER_3_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_3_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_int_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_INT_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_INT_CTRL_RSTN_APB_W::new(self, 26)
+    pub fn u0_int_ctrl_apb(&mut self) -> U0_INT_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_INT_CTRL_APB_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_W::new(self, 27)
+    pub fn u0_temp_sensor_apb(&mut self) -> U0_TEMP_SENSOR_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TEMP_SENSOR_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_temp(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W::new(self, 28)
+    pub fn u0_temp_sensor(&mut self) -> U0_TEMP_SENSOR_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TEMP_SENSOR_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag_certification_rst_n(
-        &mut self,
-    ) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_W::new(self, 29)
+    pub fn u0_jtag_rst(&mut self) -> U0_JTAG_RST_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_JTAG_RST_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_0.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_0.rs
@@ -2,570 +2,488 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_0_SPEC>;
 #[doc = "Register `syscrg_rst_status_0` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_0_SPEC>;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_bus` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_R = crate::BitReader;
+#[doc = "Field `u0_bus` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_debug` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_R = crate::BitReader;
+#[doc = "Field `u0_debug` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_R = crate::BitReader;
+#[doc = "Field `u0_core_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_R = crate::BitReader;
+#[doc = "Field `u0_core_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_R = crate::BitReader;
+#[doc = "Field `u0_core_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_R = crate::BitReader;
+#[doc = "Field `u0_core3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_R = crate::BitReader;
+#[doc = "Field `u0_core4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_R = crate::BitReader;
+#[doc = "Field `u0_core_st_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_R = crate::BitReader;
+#[doc = "Field `u0_core_st_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_R = crate::BitReader;
+#[doc = "Field `u0_core_st_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_R = crate::BitReader;
+#[doc = "Field `u0_core_st_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_R = crate::BitReader;
+#[doc = "Field `u0_core_st_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_R = crate::BitReader;
+#[doc = "Field `u0_trace_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_R = crate::BitReader;
+#[doc = "Field `u0_trace_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_R = crate::BitReader;
+#[doc = "Field `u0_trace_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_R = crate::BitReader;
+#[doc = "Field `u0_trace_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_R = crate::BitReader;
+#[doc = "Field `u0_trace_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_com` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_R = crate::BitReader;
+#[doc = "Field `u0_trace_com` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_doma` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_doma` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_axicfg0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_axicfg0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_cpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_cpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_disp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_disp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_gpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_gpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_ddrc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_ddrc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_stg_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_stg_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_vdec_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_vdec_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag2apb_presetn(&self) -> RSTN_U0_JTAG2APB_PRESETN_R {
-        RSTN_U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_jtag2apb_presetn(&self) -> U0_JTAG2APB_PRESETN_R {
+        U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_syscon_presetn(&self) -> RSTN_U0_SYS_SYSCON_PRESETN_R {
-        RSTN_U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_sys_syscon_presetn(&self) -> U0_SYS_SYSCON_PRESETN_R {
+        U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_iomux_presetn(&self) -> RSTN_U0_SYS_IOMUX_PRESETN_R {
-        RSTN_U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_sys_iomux_presetn(&self) -> U0_SYS_IOMUX_PRESETN_R {
+        U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(&self) -> RST_U0_U7MC_SFT7110_RST_BUS_R {
-        RST_U0_U7MC_SFT7110_RST_BUS_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_bus(&self) -> U0_BUS_R {
+        U0_BUS_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(&self) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_R {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_debug(&self) -> U0_DEBUG_R {
+        U0_DEBUG_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_core_0(&self) -> U0_CORE_0_R {
+        U0_CORE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_core_1(&self) -> U0_CORE_1_R {
+        U0_CORE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_core_2(&self) -> U0_CORE_2_R {
+        U0_CORE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_core3(&self) -> U0_CORE3_R {
+        U0_CORE3_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_core4(&self) -> U0_CORE4_R {
+        U0_CORE4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_core_st_0(&self) -> U0_CORE_ST_0_R {
+        U0_CORE_ST_0_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_core_st_1(&self) -> U0_CORE_ST_1_R {
+        U0_CORE_ST_1_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_core_st_2(&self) -> U0_CORE_ST_2_R {
+        U0_CORE_ST_2_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_core_st_3(&self) -> U0_CORE_ST_3_R {
+        U0_CORE_ST_3_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_core_st_4(&self) -> U0_CORE_ST_4_R {
+        U0_CORE_ST_4_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST0_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_trace_0(&self) -> U0_TRACE_0_R {
+        U0_TRACE_0_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST1_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_trace_1(&self) -> U0_TRACE_1_R {
+        U0_TRACE_1_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST2_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_trace_2(&self) -> U0_TRACE_2_R {
+        U0_TRACE_2_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST3_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_trace_3(&self) -> U0_TRACE_3_R {
+        U0_TRACE_3_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST4_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_trace_4(&self) -> U0_TRACE_4_R {
+        U0_TRACE_4_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(&self) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_R {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_trace_com(&self) -> U0_TRACE_COM_R {
+        U0_TRACE_COM_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_apb(&self) -> RST_U0_IMG_GPU_RSTN_APB_R {
-        RST_U0_IMG_GPU_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_img_gpu_apb(&self) -> U0_IMG_GPU_APB_R {
+        U0_IMG_GPU_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_doma(&self) -> RST_U0_IMG_GPU_RSTN_DOMA_R {
-        RST_U0_IMG_GPU_RSTN_DOMA_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_img_gpu_doma(&self) -> U0_IMG_GPU_DOMA_R {
+        U0_IMG_GPU_DOMA_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_noc_bus_apb(&self) -> U0_NOC_BUS_APB_R {
+        U0_NOC_BUS_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_noc_bus_axicfg0(&self) -> U0_NOC_BUS_AXICFG0_R {
+        U0_NOC_BUS_AXICFG0_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_noc_bus_cpu_axi(&self) -> U0_NOC_BUS_CPU_AXI_R {
+        U0_NOC_BUS_CPU_AXI_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_noc_bus_disp_axi(&self) -> U0_NOC_BUS_DISP_AXI_R {
+        U0_NOC_BUS_DISP_AXI_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_noc_bus_gpu_axi(&self) -> U0_NOC_BUS_GPU_AXI_R {
+        U0_NOC_BUS_GPU_AXI_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_noc_bus_isp_axi(&self) -> U0_NOC_BUS_ISP_AXI_R {
+        U0_NOC_BUS_ISP_AXI_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_noc_bus_ddrc(&self) -> U0_NOC_BUS_DDRC_R {
+        U0_NOC_BUS_DDRC_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_noc_bus_stg_axi(&self) -> U0_NOC_BUS_STG_AXI_R {
+        U0_NOC_BUS_STG_AXI_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_noc_bus_vdec_axi(&self) -> U0_NOC_BUS_VDEC_AXI_R {
+        U0_NOC_BUS_VDEC_AXI_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag2apb_presetn(
-        &mut self,
-    ) -> RSTN_U0_JTAG2APB_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_JTAG2APB_PRESETN_W::new(self, 0)
+    pub fn u0_jtag2apb_presetn(&mut self) -> U0_JTAG2APB_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_JTAG2APB_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_SYSCON_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_SYS_SYSCON_PRESETN_W::new(self, 1)
+    pub fn u0_sys_syscon_presetn(&mut self) -> U0_SYS_SYSCON_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_SYS_SYSCON_PRESETN_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_iomux_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_IOMUX_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_SYS_IOMUX_PRESETN_W::new(self, 2)
+    pub fn u0_sys_iomux_presetn(&mut self) -> U0_SYS_IOMUX_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_SYS_IOMUX_PRESETN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_BUS_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_BUS_W::new(self, 3)
+    pub fn u0_bus(&mut self) -> U0_BUS_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_BUS_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_W::new(self, 4)
+    pub fn u0_debug(&mut self) -> U0_DEBUG_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_DEBUG_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_W::new(self, 5)
+    pub fn u0_core_0(&mut self) -> U0_CORE_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_0_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_W::new(self, 6)
+    pub fn u0_core_1(&mut self) -> U0_CORE_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_W::new(self, 7)
+    pub fn u0_core_2(&mut self) -> U0_CORE_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_2_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_W::new(self, 8)
+    pub fn u0_core3(&mut self) -> U0_CORE3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE3_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_W::new(self, 9)
+    pub fn u0_core4(&mut self) -> U0_CORE4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE4_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_W::new(self, 10)
+    pub fn u0_core_st_0(&mut self) -> U0_CORE_ST_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_0_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_W::new(self, 11)
+    pub fn u0_core_st_1(&mut self) -> U0_CORE_ST_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_1_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_W::new(self, 12)
+    pub fn u0_core_st_2(&mut self) -> U0_CORE_ST_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_2_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_W::new(self, 13)
+    pub fn u0_core_st_3(&mut self) -> U0_CORE_ST_3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_3_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_W::new(self, 14)
+    pub fn u0_core_st_4(&mut self) -> U0_CORE_ST_4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_4_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST0_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_W::new(self, 15)
+    pub fn u0_trace_0(&mut self) -> U0_TRACE_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_0_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST1_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_W::new(self, 16)
+    pub fn u0_trace_1(&mut self) -> U0_TRACE_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_1_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST2_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_W::new(self, 17)
+    pub fn u0_trace_2(&mut self) -> U0_TRACE_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_2_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST3_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_W::new(self, 18)
+    pub fn u0_trace_3(&mut self) -> U0_TRACE_3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_3_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST4_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_W::new(self, 19)
+    pub fn u0_trace_4(&mut self) -> U0_TRACE_4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_4_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_W::new(self, 20)
+    pub fn u0_trace_com(&mut self) -> U0_TRACE_COM_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_COM_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_apb(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_APB_W::new(self, 21)
+    pub fn u0_img_gpu_apb(&mut self) -> U0_IMG_GPU_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_IMG_GPU_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_doma(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_DOMA_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_DOMA_W::new(self, 22)
+    pub fn u0_img_gpu_doma(&mut self) -> U0_IMG_GPU_DOMA_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_IMG_GPU_DOMA_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W::new(self, 23)
+    pub fn u0_noc_bus_apb(&mut self) -> U0_NOC_BUS_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W::new(self, 24)
+    pub fn u0_noc_bus_axicfg0(&mut self) -> U0_NOC_BUS_AXICFG0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_AXICFG0_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W::new(self, 25)
+    pub fn u0_noc_bus_cpu_axi(&mut self) -> U0_NOC_BUS_CPU_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_CPU_AXI_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W::new(self, 26)
+    pub fn u0_noc_bus_disp_axi(&mut self) -> U0_NOC_BUS_DISP_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_DISP_AXI_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W::new(self, 27)
+    pub fn u0_noc_bus_gpu_axi(&mut self) -> U0_NOC_BUS_GPU_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_GPU_AXI_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W::new(self, 28)
+    pub fn u0_noc_bus_isp_axi(&mut self) -> U0_NOC_BUS_ISP_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_ISP_AXI_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W::new(self, 29)
+    pub fn u0_noc_bus_ddrc(&mut self) -> U0_NOC_BUS_DDRC_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_DDRC_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W::new(self, 30)
+    pub fn u0_noc_bus_stg_axi(&mut self) -> U0_NOC_BUS_STG_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_STG_AXI_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W::new(self, 31)
+    pub fn u0_noc_bus_vdec_axi(&mut self) -> U0_NOC_BUS_VDEC_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_VDEC_AXI_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_1.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_1.rs
@@ -2,561 +2,490 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_1_SPEC>;
 #[doc = "Register `syscrg_rst_status_1` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_1_SPEC>;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<'a, REG> =
-    crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_venc_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_venc_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_R = crate::BitReader;
+#[doc = "Field `u0_ddr_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_osc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_R = crate::BitReader;
+#[doc = "Field `u0_ddr_osc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_R = crate::BitReader;
+#[doc = "Field `u0_ddr_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_top` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_R = crate::BitReader;
+#[doc = "Field `u0_isp_top` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_R = crate::BitReader;
+#[doc = "Field `u0_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave511_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave511_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave511_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave511_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_aximem_128b_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_R = crate::BitReader;
+#[doc = "Field `u0_aximem_128b_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u1_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u2_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_intmem_rom_sram` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_R = crate::BitReader;
+#[doc = "Field `u0_intmem_rom_sram` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ref` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ref` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R::new((self.bits & 1) != 0)
+    pub fn u0_noc_bus_venc_axi(&self) -> U0_NOC_BUS_VENC_AXI_R {
+        U0_NOC_BUS_VENC_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_ahb(&self) -> U0_AXI_CFG1_DEC_AHB_R {
+        U0_AXI_CFG1_DEC_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_main(&self) -> U0_AXI_CFG1_DEC_MAIN_R {
+        U0_AXI_CFG1_DEC_MAIN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main(&self) -> U0_AXI_CFG0_DEC_MAIN_R {
+        U0_AXI_CFG0_DEC_MAIN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main_div(&self) -> U0_AXI_CFG0_DEC_MAIN_DIV_R {
+        U0_AXI_CFG0_DEC_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_hifi4(&self) -> U0_AXI_CFG0_DEC_HIFI4_R {
+        U0_AXI_CFG0_DEC_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(&self) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_R {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_ddr_axi(&self) -> U0_DDR_AXI_R {
+        U0_DDR_AXI_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(&self) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_R {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_ddr_osc(&self) -> U0_DDR_OSC_R {
+        U0_DDR_OSC_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(&self) -> RSTN_U0_DDR_SFT7110_RSTN_APB_R {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_ddr_apb(&self) -> U0_DDR_APB_R {
+        U0_DDR_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_isp_top(&self) -> U0_ISP_TOP_R {
+        U0_ISP_TOP_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_isp_axi(&self) -> U0_ISP_AXI_R {
+        U0_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_vout_src(&self) -> U0_VOUT_SRC_R {
+        U0_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_axi(&self) -> RSTN_U0_CODAJ12_RSTN_AXI_R {
-        RSTN_U0_CODAJ12_RSTN_AXI_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_codaj12_axi(&self) -> U0_CODAJ12_AXI_R {
+        U0_CODAJ12_AXI_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_core(&self) -> RSTN_U0_CODAJ12_RSTN_CORE_R {
-        RSTN_U0_CODAJ12_RSTN_CORE_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_codaj12_core(&self) -> U0_CODAJ12_CORE_R {
+        U0_CODAJ12_CORE_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_apb(&self) -> RSTN_U0_CODAJ12_RSTN_APB_R {
-        RSTN_U0_CODAJ12_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_codaj12_apb(&self) -> U0_CODAJ12_APB_R {
+        U0_CODAJ12_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_axi(&self) -> RSTN_U0_WAVE511_RSTN_AXI_R {
-        RSTN_U0_WAVE511_RSTN_AXI_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_wave511_axi(&self) -> U0_WAVE511_AXI_R {
+        U0_WAVE511_AXI_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_bpu(&self) -> RSTN_U0_WAVE511_RSTN_BPU_R {
-        RSTN_U0_WAVE511_RSTN_BPU_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_wave511_bpu(&self) -> U0_WAVE511_BPU_R {
+        U0_WAVE511_BPU_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_vce(&self) -> RSTN_U0_WAVE511_RSTN_VCE_R {
-        RSTN_U0_WAVE511_RSTN_VCE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_wave511_vce(&self) -> U0_WAVE511_VCE_R {
+        U0_WAVE511_VCE_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_apb(&self) -> RSTN_U0_WAVE511_RSTN_APB_R {
-        RSTN_U0_WAVE511_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_wave511_apb(&self) -> U0_WAVE511_APB_R {
+        U0_WAVE511_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_vdec_jpg_arb(&self) -> U0_VDEC_JPG_ARB_R {
+        U0_VDEC_JPG_ARB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_vdec_jpg_arb_main(&self) -> U0_VDEC_JPG_ARB_MAIN_R {
+        U0_VDEC_JPG_ARB_MAIN_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_aximem_128b_rstn_axi(&self) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_aximem_128b_axi(&self) -> U0_AXIMEM_128B_AXI_R {
+        U0_AXIMEM_128B_AXI_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_axi(&self) -> RSTN_U0_WAVE420L_RSTN_AXI_R {
-        RSTN_U0_WAVE420L_RSTN_AXI_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_wave420l_axi(&self) -> U0_WAVE420L_AXI_R {
+        U0_WAVE420L_AXI_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_bpu(&self) -> RSTN_U0_WAVE420L_RSTN_BPU_R {
-        RSTN_U0_WAVE420L_RSTN_BPU_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_wave420l_bpu(&self) -> U0_WAVE420L_BPU_R {
+        U0_WAVE420L_BPU_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_vce(&self) -> RSTN_U0_WAVE420L_RSTN_VCE_R {
-        RSTN_U0_WAVE420L_RSTN_VCE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_wave420l_vce(&self) -> U0_WAVE420L_VCE_R {
+        U0_WAVE420L_VCE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_apb(&self) -> RSTN_U0_WAVE420L_RSTN_APB_R {
-        RSTN_U0_WAVE420L_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_wave420l_apb(&self) -> U0_WAVE420L_APB_R {
+        U0_WAVE420L_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_aximem_128b_rstn_axi(&self) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_aximem(&self) -> U1_AXIMEM_R {
+        U1_AXIMEM_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_aximem_128b_rstn_axi(&self) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u2_aximem(&self) -> U2_AXIMEM_R {
+        U2_AXIMEM_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(&self) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_intmem_rom_sram(&self) -> U0_INTMEM_ROM_SRAM_R {
+        U0_INTMEM_ROM_SRAM_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_qspi_ahb(&self) -> U0_QSPI_AHB_R {
+        U0_QSPI_AHB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_APB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_qspi_apb(&self) -> U0_QSPI_APB_R {
+        U0_QSPI_APB_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(&self) -> RSTN_U0_CDNS_QSPI_RSTN_REF_R {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_qspi_ref(&self) -> U0_QSPI_REF_R {
+        U0_QSPI_REF_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &mut self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W::new(self, 0)
+    pub fn u0_noc_bus_venc_axi(&mut self) -> U0_NOC_BUS_VENC_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_NOC_BUS_VENC_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W::new(self, 1)
+    pub fn u0_axi_cfg1_dec_ahb(&mut self) -> U0_AXI_CFG1_DEC_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG1_DEC_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W::new(self, 2)
+    pub fn u0_axi_cfg1_dec_main(&mut self) -> U0_AXI_CFG1_DEC_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG1_DEC_MAIN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W::new(self, 3)
+    pub fn u0_axi_cfg0_dec_main(&mut self) -> U0_AXI_CFG0_DEC_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(
+    pub fn u0_axi_cfg0_dec_main_div(
         &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W::new(self, 4)
+    ) -> U0_AXI_CFG0_DEC_MAIN_DIV_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_DIV_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W::new(self, 5)
+    pub fn u0_axi_cfg0_dec_hifi4(&mut self) -> U0_AXI_CFG0_DEC_HIFI4_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_HIFI4_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_W::new(self, 6)
+    pub fn u0_ddr_axi(&mut self) -> U0_DDR_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_AXI_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_W::new(self, 7)
+    pub fn u0_ddr_osc(&mut self) -> U0_DDR_OSC_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_OSC_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_W::new(self, 8)
+    pub fn u0_ddr_apb(&mut self) -> U0_DDR_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W::new(self, 9)
+    pub fn u0_isp_top(&mut self) -> U0_ISP_TOP_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_ISP_TOP_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W::new(self, 10)
+    pub fn u0_isp_axi(&mut self) -> U0_ISP_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_ISP_AXI_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &mut self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W::new(self, 11)
+    pub fn u0_vout_src(&mut self) -> U0_VOUT_SRC_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VOUT_SRC_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_AXI_W::new(self, 12)
+    pub fn u0_codaj12_axi(&mut self) -> U0_CODAJ12_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_AXI_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_core(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_CORE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_CORE_W::new(self, 13)
+    pub fn u0_codaj12_core(&mut self) -> U0_CODAJ12_CORE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_CORE_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_APB_W::new(self, 14)
+    pub fn u0_codaj12_apb(&mut self) -> U0_CODAJ12_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_AXI_W::new(self, 15)
+    pub fn u0_wave511_axi(&mut self) -> U0_WAVE511_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_AXI_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_BPU_W::new(self, 16)
+    pub fn u0_wave511_bpu(&mut self) -> U0_WAVE511_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_BPU_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_VCE_W::new(self, 17)
+    pub fn u0_wave511_vce(&mut self) -> U0_WAVE511_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_VCE_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_APB_W::new(self, 18)
+    pub fn u0_wave511_apb(&mut self) -> U0_WAVE511_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W::new(self, 19)
+    pub fn u0_vdec_jpg_arb(&mut self) -> U0_VDEC_JPG_ARB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VDEC_JPG_ARB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W::new(self, 20)
+    pub fn u0_vdec_jpg_arb_main(&mut self) -> U0_VDEC_JPG_ARB_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VDEC_JPG_ARB_MAIN_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_W::new(self, 21)
+    pub fn u0_aximem_128b_axi(&mut self) -> U0_AXIMEM_128B_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXIMEM_128B_AXI_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_AXI_W::new(self, 22)
+    pub fn u0_wave420l_axi(&mut self) -> U0_WAVE420L_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_AXI_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_BPU_W::new(self, 23)
+    pub fn u0_wave420l_bpu(&mut self) -> U0_WAVE420L_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_BPU_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_VCE_W::new(self, 24)
+    pub fn u0_wave420l_vce(&mut self) -> U0_WAVE420L_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_VCE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_APB_W::new(self, 25)
+    pub fn u0_wave420l_apb(&mut self) -> U0_WAVE420L_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_W::new(self, 26)
+    pub fn u1_aximem(&mut self) -> U1_AXIMEM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U1_AXIMEM_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_W::new(self, 27)
+    pub fn u2_aximem(&mut self) -> U2_AXIMEM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U2_AXIMEM_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(
-        &mut self,
-    ) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W::new(self, 28)
+    pub fn u0_intmem_rom_sram(&mut self) -> U0_INTMEM_ROM_SRAM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_INTMEM_ROM_SRAM_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_W::new(self, 29)
+    pub fn u0_qspi_ahb(&mut self) -> U0_QSPI_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_AHB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_W::new(self, 30)
+    pub fn u0_qspi_apb(&mut self) -> U0_QSPI_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_APB_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_REF_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_W::new(self, 31)
+    pub fn u0_qspi_ref(&mut self) -> U0_QSPI_REF_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_REF_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_2.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_2.rs
@@ -2,510 +2,488 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_2_SPEC>;
 #[doc = "Register `syscrg_rst_status_2` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_2_SPEC>;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u6_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sdio_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_R = crate::BitReader;
+#[doc = "Field `u0_sdio_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_sdi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_R = crate::BitReader;
+#[doc = "Field `u1_sdi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64_hresetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64_hresetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u1_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u2_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u3_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u4_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u5_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u6_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u2_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u3_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u4_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u5_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u6_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_R = crate::BitReader;
+#[doc = "Field `u0_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u0_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_R = crate::BitReader;
+#[doc = "Field `u1_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u1_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_R = crate::BitReader;
+#[doc = "Field `u2_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u2_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_R = crate::BitReader;
+#[doc = "Field `u3_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u3_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_R = crate::BitReader;
+#[doc = "Field `u4_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u4_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_R = crate::BitReader;
+#[doc = "Field `u5_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u6_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spdif_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_R = crate::BitReader;
+#[doc = "Field `u0_spdif_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sdio_rstn_ahb(&self) -> RSTN_U0_SDIO_RSTN_AHB_R {
-        RSTN_U0_SDIO_RSTN_AHB_R::new((self.bits & 1) != 0)
+    pub fn u0_sdio_ahb(&self) -> U0_SDIO_AHB_R {
+        U0_SDIO_AHB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_sdi_rstn_ahb(&self) -> RSTN_U1_SDI_RSTN_AHB_R {
-        RSTN_U1_SDI_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_sdi_ahb(&self) -> U1_SDI_AHB_R {
+        U1_SDI_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(&self) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_R {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_gmac5_axi64(&self) -> U1_GMAC5_AXI64_R {
+        U1_GMAC5_AXI64_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(&self) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_R {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u1_gmac5_axi64_hresetn(&self) -> U1_GMAC5_AXI64_HRESETN_R {
+        U1_GMAC5_AXI64_HRESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_mailbox_presetn(&self) -> RSTN_U0_MAILBOX_PRESETN_R {
-        RSTN_U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_mailbox_presetn(&self) -> U0_MAILBOX_PRESETN_R {
+        U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ssp_spi_rstn_apb(&self) -> RSTN_U0_SSP_SPI_RSTN_APB_R {
-        RSTN_U0_SSP_SPI_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_spi_apb(&self) -> U0_SPI_APB_R {
+        U0_SPI_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_ssp_spi_rstn_apb(&self) -> RSTN_U1_SSP_SPI_RSTN_APB_R {
-        RSTN_U1_SSP_SPI_RSTN_APB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u1_spi_apb(&self) -> U1_SPI_APB_R {
+        U1_SPI_APB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_ssp_spi_rstn_apb(&self) -> RSTN_U2_SSP_SPI_RSTN_APB_R {
-        RSTN_U2_SSP_SPI_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u2_spi_apb(&self) -> U2_SPI_APB_R {
+        U2_SPI_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_ssp_spi_rstn_apb(&self) -> RSTN_U3_SSP_SPI_RSTN_APB_R {
-        RSTN_U3_SSP_SPI_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u3_spi_apb(&self) -> U3_SPI_APB_R {
+        U3_SPI_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_ssp_spi_rstn_apb(&self) -> RSTN_U4_SSP_SPI_RSTN_APB_R {
-        RSTN_U4_SSP_SPI_RSTN_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u4_spi_apb(&self) -> U4_SPI_APB_R {
+        U4_SPI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_ssp_spi_rstn_apb(&self) -> RSTN_U5_SSP_SPI_RSTN_APB_R {
-        RSTN_U5_SSP_SPI_RSTN_APB_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u5_spi_apb(&self) -> U5_SPI_APB_R {
+        U5_SPI_APB_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_ssp_spi_rstn_apb(&self) -> RSTN_U6_SSP_SPI_RSTN_APB_R {
-        RSTN_U6_SSP_SPI_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u6_spi_apb(&self) -> U6_SPI_APB_R {
+        U6_SPI_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2c_rstn_apb(&self) -> RSTN_U0_I2C_RSTN_APB_R {
-        RSTN_U0_I2C_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_i2c_apb(&self) -> U0_I2C_APB_R {
+        U0_I2C_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2c_rstn_apb(&self) -> RSTN_U1_I2C_RSTN_APB_R {
-        RSTN_U1_I2C_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u1_i2c_apb(&self) -> U1_I2C_APB_R {
+        U1_I2C_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_i2c_rstn_apb(&self) -> RSTN_U2_I2C_RSTN_APB_R {
-        RSTN_U2_I2C_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u2_i2c_apb(&self) -> U2_I2C_APB_R {
+        U2_I2C_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_i2c_rstn_apb(&self) -> RSTN_U3_I2C_RSTN_APB_R {
-        RSTN_U3_I2C_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u3_i2c_apb(&self) -> U3_I2C_APB_R {
+        U3_I2C_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_i2c_rstn_apb(&self) -> RSTN_U4_I2C_RSTN_APB_R {
-        RSTN_U4_I2C_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u4_i2c_apb(&self) -> U4_I2C_APB_R {
+        U4_I2C_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_i2c_rstn_apb(&self) -> RSTN_U5_I2C_RSTN_APB_R {
-        RSTN_U5_I2C_RSTN_APB_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u5_i2c_apb(&self) -> U5_I2C_APB_R {
+        U5_I2C_APB_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_i2c_rstn_apb(&self) -> RSTN_U6_I2C_RSTN_APB_R {
-        RSTN_U6_I2C_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u6_i2c_apb(&self) -> U6_I2C_APB_R {
+        U6_I2C_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_apb(&self) -> RSTN_U0_UART_RSTN_APB_R {
-        RSTN_U0_UART_RSTN_APB_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_uart_apb(&self) -> U0_UART_APB_R {
+        U0_UART_APB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_core(&self) -> RSTN_U0_UART_RSTN_CORE_R {
-        RSTN_U0_UART_RSTN_CORE_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_uart_core(&self) -> U0_UART_CORE_R {
+        U0_UART_CORE_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_apb(&self) -> RSTN_U1_UART_RSTN_APB_R {
-        RSTN_U1_UART_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_uart_apb(&self) -> U1_UART_APB_R {
+        U1_UART_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_core(&self) -> RSTN_U1_UART_RSTN_CORE_R {
-        RSTN_U1_UART_RSTN_CORE_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_uart_core(&self) -> U1_UART_CORE_R {
+        U1_UART_CORE_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_apb(&self) -> RSTN_U2_UART_RSTN_APB_R {
-        RSTN_U2_UART_RSTN_APB_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u2_uart_apb(&self) -> U2_UART_APB_R {
+        U2_UART_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_core(&self) -> RSTN_U2_UART_RSTN_CORE_R {
-        RSTN_U2_UART_RSTN_CORE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u2_uart_core(&self) -> U2_UART_CORE_R {
+        U2_UART_CORE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_apb(&self) -> RSTN_U3_UART_RSTN_APB_R {
-        RSTN_U3_UART_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u3_uart_apb(&self) -> U3_UART_APB_R {
+        U3_UART_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_core(&self) -> RSTN_U3_UART_RSTN_CORE_R {
-        RSTN_U3_UART_RSTN_CORE_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u3_uart_core(&self) -> U3_UART_CORE_R {
+        U3_UART_CORE_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_apb(&self) -> RSTN_U4_UART_RSTN_APB_R {
-        RSTN_U4_UART_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u4_uart_apb(&self) -> U4_UART_APB_R {
+        U4_UART_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_core(&self) -> RSTN_U4_UART_RSTN_CORE_R {
-        RSTN_U4_UART_RSTN_CORE_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u4_uart_core(&self) -> U4_UART_CORE_R {
+        U4_UART_CORE_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_uart_rstn_apb(&self) -> RSTN_U5_UART_RSTN_APB_R {
-        RSTN_U5_UART_RSTN_APB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u5_uart_apb(&self) -> U5_UART_APB_R {
+        U5_UART_APB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_uart_rstn_core(&self) -> RSTN_U6_UART_RSTN_CORE_R {
-        RSTN_U6_UART_RSTN_CORE_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u6_uart_core(&self) -> U6_UART_CORE_R {
+        U6_UART_CORE_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(&self) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_R {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_spdif_apb(&self) -> U0_SPDIF_APB_R {
+        U0_SPDIF_APB_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sdio_rstn_ahb(&mut self) -> RSTN_U0_SDIO_RSTN_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_SDIO_RSTN_AHB_W::new(self, 0)
+    pub fn u0_sdio_ahb(&mut self) -> U0_SDIO_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SDIO_AHB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_sdi_rstn_ahb(&mut self) -> RSTN_U1_SDI_RSTN_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_SDI_RSTN_AHB_W::new(self, 1)
+    pub fn u1_sdi_ahb(&mut self) -> U1_SDI_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_SDI_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_W::new(self, 2)
+    pub fn u1_gmac5_axi64(&mut self) -> U1_GMAC5_AXI64_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_GMAC5_AXI64_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_W::new(self, 3)
+    pub fn u1_gmac5_axi64_hresetn(&mut self) -> U1_GMAC5_AXI64_HRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_GMAC5_AXI64_HRESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_mailbox_presetn(
-        &mut self,
-    ) -> RSTN_U0_MAILBOX_PRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_MAILBOX_PRESETN_W::new(self, 4)
+    pub fn u0_mailbox_presetn(&mut self) -> U0_MAILBOX_PRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_MAILBOX_PRESETN_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_SSP_SPI_RSTN_APB_W::new(self, 5)
+    pub fn u0_spi_apb(&mut self) -> U0_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SPI_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_SSP_SPI_RSTN_APB_W::new(self, 6)
+    pub fn u1_spi_apb(&mut self) -> U1_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_SPI_APB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U2_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_SSP_SPI_RSTN_APB_W::new(self, 7)
+    pub fn u2_spi_apb(&mut self) -> U2_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_SPI_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U3_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_SSP_SPI_RSTN_APB_W::new(self, 8)
+    pub fn u3_spi_apb(&mut self) -> U3_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_SPI_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U4_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_SSP_SPI_RSTN_APB_W::new(self, 9)
+    pub fn u4_spi_apb(&mut self) -> U4_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_SPI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U5_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_SSP_SPI_RSTN_APB_W::new(self, 10)
+    pub fn u5_spi_apb(&mut self) -> U5_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_SPI_APB_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U6_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_SSP_SPI_RSTN_APB_W::new(self, 11)
+    pub fn u6_spi_apb(&mut self) -> U6_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_SPI_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2c_rstn_apb(&mut self) -> RSTN_U0_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_I2C_RSTN_APB_W::new(self, 12)
+    pub fn u0_i2c_apb(&mut self) -> U0_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_I2C_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2c_rstn_apb(&mut self) -> RSTN_U1_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_I2C_RSTN_APB_W::new(self, 13)
+    pub fn u1_i2c_apb(&mut self) -> U1_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_I2C_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_i2c_rstn_apb(&mut self) -> RSTN_U2_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_I2C_RSTN_APB_W::new(self, 14)
+    pub fn u2_i2c_apb(&mut self) -> U2_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_I2C_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_i2c_rstn_apb(&mut self) -> RSTN_U3_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_I2C_RSTN_APB_W::new(self, 15)
+    pub fn u3_i2c_apb(&mut self) -> U3_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_I2C_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_i2c_rstn_apb(&mut self) -> RSTN_U4_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_I2C_RSTN_APB_W::new(self, 16)
+    pub fn u4_i2c_apb(&mut self) -> U4_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_I2C_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_i2c_rstn_apb(&mut self) -> RSTN_U5_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_I2C_RSTN_APB_W::new(self, 17)
+    pub fn u5_i2c_apb(&mut self) -> U5_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_I2C_APB_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_i2c_rstn_apb(&mut self) -> RSTN_U6_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_I2C_RSTN_APB_W::new(self, 18)
+    pub fn u6_i2c_apb(&mut self) -> U6_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_I2C_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_apb(&mut self) -> RSTN_U0_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_UART_RSTN_APB_W::new(self, 19)
+    pub fn u0_uart_apb(&mut self) -> U0_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_UART_APB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_core(&mut self) -> RSTN_U0_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_UART_RSTN_CORE_W::new(self, 20)
+    pub fn u0_uart_core(&mut self) -> U0_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_UART_CORE_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_apb(&mut self) -> RSTN_U1_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_UART_RSTN_APB_W::new(self, 21)
+    pub fn u1_uart_apb(&mut self) -> U1_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_UART_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_core(&mut self) -> RSTN_U1_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_UART_RSTN_CORE_W::new(self, 22)
+    pub fn u1_uart_core(&mut self) -> U1_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_UART_CORE_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_apb(&mut self) -> RSTN_U2_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_UART_RSTN_APB_W::new(self, 23)
+    pub fn u2_uart_apb(&mut self) -> U2_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_UART_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_core(&mut self) -> RSTN_U2_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_UART_RSTN_CORE_W::new(self, 24)
+    pub fn u2_uart_core(&mut self) -> U2_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_UART_CORE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_apb(&mut self) -> RSTN_U3_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_UART_RSTN_APB_W::new(self, 25)
+    pub fn u3_uart_apb(&mut self) -> U3_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_UART_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_core(&mut self) -> RSTN_U3_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_UART_RSTN_CORE_W::new(self, 26)
+    pub fn u3_uart_core(&mut self) -> U3_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_UART_CORE_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_apb(&mut self) -> RSTN_U4_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_UART_RSTN_APB_W::new(self, 27)
+    pub fn u4_uart_apb(&mut self) -> U4_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_UART_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_core(&mut self) -> RSTN_U4_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_UART_RSTN_CORE_W::new(self, 28)
+    pub fn u4_uart_core(&mut self) -> U4_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_UART_CORE_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_uart_rstn_apb(&mut self) -> RSTN_U5_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_UART_RSTN_APB_W::new(self, 29)
+    pub fn u5_uart_apb(&mut self) -> U5_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_UART_APB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_uart_rstn_core(&mut self) -> RSTN_U6_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_UART_RSTN_CORE_W::new(self, 30)
+    pub fn u6_uart_core(&mut self) -> U6_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_UART_CORE_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_W::new(self, 31)
+    pub fn u0_spdif_apb(&mut self) -> U0_SPDIF_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SPDIF_APB_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_3.rs
+++ b/jh7110-vf2-12a-pac/src/syscrg/syscrg_rst_status_3.rs
@@ -2,518 +2,458 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_3_SPEC>;
 #[doc = "Register `syscrg_rst_status_3` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_3_SPEC>;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwmdac_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwmdac_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_dmic` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_dmic` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_tdm` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_tdm` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwm_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwm_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_can` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_can` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_int_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_int_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag_rst` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_R = crate::BitReader;
+#[doc = "Field `u0_jtag_rst` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwmdac_rstn_apb(&self) -> RSTN_U0_PWMDAC_RSTN_APB_R {
-        RSTN_U0_PWMDAC_RSTN_APB_R::new((self.bits & 1) != 0)
+    pub fn u0_pwmdac_apb(&self) -> U0_PWMDAC_APB_R {
+        U0_PWMDAC_APB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(&self) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_R {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pdm_4mic_dmic(&self) -> U0_PDM_4MIC_DMIC_R {
+        U0_PDM_4MIC_DMIC_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(&self) -> RSTN_U0_PDM_4MIC_RSTN_APB_R {
-        RSTN_U0_PDM_4MIC_RSTN_APB_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pdm_4mic_apb(&self) -> U0_PDM_4MIC_APB_R {
+        U0_PDM_4MIC_APB_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(&self) -> RSTN_U0_I2SRX_3CH_RSTN_APB_R {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_i2srx_apb(&self) -> U0_I2SRX_APB_R {
+        U0_I2SRX_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(&self) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_R {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_i2srx_bclk(&self) -> U0_I2SRX_BCLK_R {
+        U0_I2SRX_BCLK_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(&self) -> RSTN_U0_I2STX_4CH_RSTN_APB_R {
-        RSTN_U0_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_i2stx_apb(&self) -> U0_I2STX_APB_R {
+        U0_I2STX_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(&self) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_i2stx_bclk(&self) -> U0_I2STX_BCLK_R {
+        U0_I2STX_BCLK_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(&self) -> RSTN_U1_I2STX_4CH_RSTN_APB_R {
-        RSTN_U1_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_i2stx_apb(&self) -> U1_I2STX_APB_R {
+        U1_I2STX_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(&self) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_i2stx_bclk(&self) -> U1_I2STX_BCLK_R {
+        U1_I2STX_BCLK_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(&self) -> RSTN_U0_TDM16SLOT_RSTN_AHB_R {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_tdm16slot_ahb(&self) -> U0_TDM16SLOT_AHB_R {
+        U0_TDM16SLOT_AHB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(&self) -> RSTN_U0_TDM16SLOT_RSTN_TDM_R {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_tdm16slot_tdm(&self) -> U0_TDM16SLOT_TDM_R {
+        U0_TDM16SLOT_TDM_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_apb(&self) -> RSTN_U0_TDM16SLOT_RSTN_APB_R {
-        RSTN_U0_TDM16SLOT_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_tdm16slot_apb(&self) -> U0_TDM16SLOT_APB_R {
+        U0_TDM16SLOT_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(&self) -> RSTN_U0_PWM_8CH_RSTN_APB_R {
-        RSTN_U0_PWM_8CH_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pwm_apb(&self) -> U0_PWM_APB_R {
+        U0_PWM_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(&self) -> RSTN_U0_DSKIT_WDT_RSTN_APB_R {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_dskit_wdt_rstn_apb(&self) -> U0_DSKIT_WDT_RSTN_APB_R {
+        U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(&self) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_R {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_dskit_wdt(&self) -> U0_DSKIT_WDT_R {
+        U0_DSKIT_WDT_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_apb(&self) -> RSTN_U0_CAN_CTRL_RSTN_APB_R {
-        RSTN_U0_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_can_ctrl_apb(&self) -> U0_CAN_CTRL_APB_R {
+        U0_CAN_CTRL_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_can(&self) -> RSTN_U0_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_can_ctrl(&self) -> U0_CAN_CTRL_R {
+        U0_CAN_CTRL_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_timer(&self) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_can_ctrl_timer(&self) -> U0_CAN_CTRL_TIMER_R {
+        U0_CAN_CTRL_TIMER_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_apb(&self) -> RSTN_U1_CAN_CTRL_RSTN_APB_R {
-        RSTN_U1_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_can_ctrl_apb(&self) -> U1_CAN_CTRL_APB_R {
+        U1_CAN_CTRL_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_can(&self) -> RSTN_U1_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_can_ctrl_can(&self) -> U1_CAN_CTRL_CAN_R {
+        U1_CAN_CTRL_CAN_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_timer(&self) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_can_ctrl_timer(&self) -> U1_CAN_CTRL_TIMER_R {
+        U1_CAN_CTRL_TIMER_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_apb(&self) -> RSTN_U0_SI5_TIMER_RSTN_APB_R {
-        RSTN_U0_SI5_TIMER_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_si5_timer_apb(&self) -> U0_SI5_TIMER_APB_R {
+        U0_SI5_TIMER_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer0(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_si5_timer_0(&self) -> U0_SI5_TIMER_0_R {
+        U0_SI5_TIMER_0_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_time10(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_si5_timer_1(&self) -> U0_SI5_TIMER_1_R {
+        U0_SI5_TIMER_1_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer2(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_si5_timer_2(&self) -> U0_SI5_TIMER_2_R {
+        U0_SI5_TIMER_2_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer3(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_si5_timer_3(&self) -> U0_SI5_TIMER_3_R {
+        U0_SI5_TIMER_3_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_int_ctrl_rstn_apb(&self) -> RSTN_U0_INT_CTRL_RSTN_APB_R {
-        RSTN_U0_INT_CTRL_RSTN_APB_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_int_ctrl_apb(&self) -> U0_INT_CTRL_APB_R {
+        U0_INT_CTRL_APB_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_apb(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_temp_sensor_apb(&self) -> U0_TEMP_SENSOR_APB_R {
+        U0_TEMP_SENSOR_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_temp(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_temp_sensor(&self) -> U0_TEMP_SENSOR_R {
+        U0_TEMP_SENSOR_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag_certification_rst_n(&self) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_R {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_jtag_rst(&self) -> U0_JTAG_RST_R {
+        U0_JTAG_RST_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwmdac_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWMDAC_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PWMDAC_RSTN_APB_W::new(self, 0)
+    pub fn u0_pwmdac_apb(&mut self) -> U0_PWMDAC_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PWMDAC_APB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_W::new(self, 1)
+    pub fn u0_pdm_4mic_dmic(&mut self) -> U0_PDM_4MIC_DMIC_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PDM_4MIC_DMIC_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_APB_W::new(self, 2)
+    pub fn u0_pdm_4mic_apb(&mut self) -> U0_PDM_4MIC_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PDM_4MIC_APB_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_W::new(self, 3)
+    pub fn u0_i2srx_apb(&mut self) -> U0_I2SRX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2SRX_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_W::new(self, 4)
+    pub fn u0_i2srx_bclk(&mut self) -> U0_I2SRX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2SRX_BCLK_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_APB_W::new(self, 5)
+    pub fn u0_i2stx_apb(&mut self) -> U0_I2STX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2STX_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_W::new(self, 6)
+    pub fn u0_i2stx_bclk(&mut self) -> U0_I2STX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2STX_BCLK_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_APB_W::new(self, 7)
+    pub fn u1_i2stx_apb(&mut self) -> U1_I2STX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_I2STX_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_W::new(self, 8)
+    pub fn u1_i2stx_bclk(&mut self) -> U1_I2STX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_I2STX_BCLK_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_AHB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_W::new(self, 9)
+    pub fn u0_tdm16slot_ahb(&mut self) -> U0_TDM16SLOT_AHB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_AHB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_TDM_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_W::new(self, 10)
+    pub fn u0_tdm16slot_tdm(&mut self) -> U0_TDM16SLOT_TDM_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_TDM_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_APB_W::new(self, 11)
+    pub fn u0_tdm16slot_apb(&mut self) -> U0_TDM16SLOT_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWM_8CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PWM_8CH_RSTN_APB_W::new(self, 12)
+    pub fn u0_pwm_apb(&mut self) -> U0_PWM_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PWM_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
+    pub fn u0_dskit_wdt_rstn_apb(&mut self) -> U0_DSKIT_WDT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_W::new(self, 14)
+    pub fn u0_dskit_wdt(&mut self) -> U0_DSKIT_WDT_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_DSKIT_WDT_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_APB_W::new(self, 15)
+    pub fn u0_can_ctrl_apb(&mut self) -> U0_CAN_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_W::new(self, 16)
+    pub fn u0_can_ctrl(&mut self) -> U0_CAN_CTRL_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_W::new(self, 17)
+    pub fn u0_can_ctrl_timer(&mut self) -> U0_CAN_CTRL_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_TIMER_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_APB_W::new(self, 18)
+    pub fn u1_can_ctrl_apb(&mut self) -> U1_CAN_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_W::new(self, 19)
+    pub fn u1_can_ctrl_can(&mut self) -> U1_CAN_CTRL_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_CAN_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_W::new(self, 20)
+    pub fn u1_can_ctrl_timer(&mut self) -> U1_CAN_CTRL_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_TIMER_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_APB_W::new(self, 21)
+    pub fn u0_si5_timer_apb(&mut self) -> U0_SI5_TIMER_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer0(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_W::new(self, 22)
+    pub fn u0_si5_timer_0(&mut self) -> U0_SI5_TIMER_0_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_0_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_time10(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_W::new(self, 23)
+    pub fn u0_si5_timer_1(&mut self) -> U0_SI5_TIMER_1_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_1_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer2(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_W::new(self, 24)
+    pub fn u0_si5_timer_2(&mut self) -> U0_SI5_TIMER_2_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_2_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer3(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_W::new(self, 25)
+    pub fn u0_si5_timer_3(&mut self) -> U0_SI5_TIMER_3_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_3_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_int_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_INT_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_INT_CTRL_RSTN_APB_W::new(self, 26)
+    pub fn u0_int_ctrl_apb(&mut self) -> U0_INT_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_INT_CTRL_APB_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_W::new(self, 27)
+    pub fn u0_temp_sensor_apb(&mut self) -> U0_TEMP_SENSOR_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TEMP_SENSOR_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_temp(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W::new(self, 28)
+    pub fn u0_temp_sensor(&mut self) -> U0_TEMP_SENSOR_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TEMP_SENSOR_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag_certification_rst_n(
-        &mut self,
-    ) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_W::new(self, 29)
+    pub fn u0_jtag_rst(&mut self) -> U0_JTAG_RST_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_JTAG_RST_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -11898,139 +11898,139 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_stg_syscon_presetn</name>
+              <name>u0_stg_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_core</name>
+              <name>u0_hifi4_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_axi</name>
+              <name>u0_hifi4_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sec_top_hreesetn</name>
+              <name>u0_sec_top_hreesetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_e2_sft7110_rst_core</name>
+              <name>u0_e2_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_axi</name>
+              <name>u0_dma_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_ahb</name>
+              <name>u0_dma_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_axi</name>
+              <name>u0_usb_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_usb_apb</name>
+              <name>u0_usb_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_utmi_apb</name>
+              <name>u0_usb_utmi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_pwrup</name>
+              <name>u0_usb_pwrup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_mst0</name>
+              <name>u0_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv0</name>
+              <name>u0_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv</name>
+              <name>u0_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pci_rstn_brg</name>
+              <name>u0_pci_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_pcie</name>
+              <name>u0_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_apb</name>
+              <name>u0_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_mst0</name>
+              <name>u1_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv0</name>
+              <name>u1_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv</name>
+              <name>u1_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_brg</name>
+              <name>u1_pcie_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_pcie</name>
+              <name>u1_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_apb</name>
+              <name>u1_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
@@ -12045,139 +12045,139 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_stg_syscon_presetn</name>
+              <name>u0_stg_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_core</name>
+              <name>u0_hifi4_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_hifi4_rst_axi</name>
+              <name>u0_hifi4_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sec_top_hreesetn</name>
+              <name>u0_sec_top_hreesetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_e2_sft7110_rst_core</name>
+              <name>u0_e2_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_axi</name>
+              <name>u0_dma_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dma1p_8ch_56hs_rstn_ahb</name>
+              <name>u0_dma_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_axi</name>
+              <name>u0_usb_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_usb_apb</name>
+              <name>u0_usb_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_utmi_apb</name>
+              <name>u0_usb_utmi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdn_usb_rstn_pwrup</name>
+              <name>u0_usb_pwrup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_mst0</name>
+              <name>u0_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv0</name>
+              <name>u0_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_axi_slv</name>
+              <name>u0_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pci_rstn_brg</name>
+              <name>u0_pci_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_pcie</name>
+              <name>u0_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_plda_pcie_rstn_apb</name>
+              <name>u0_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_mst0</name>
+              <name>u1_pcie_axi_mst0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv0</name>
+              <name>u1_pcie_axi_slv0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_axi_slv</name>
+              <name>u1_pcie_axi_slv</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_brg</name>
+              <name>u1_pcie_brg</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_pcie</name>
+              <name>u1_pcie_pcie</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_plda_pcie_rstn_apb</name>
+              <name>u1_pcie_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
@@ -31023,193 +31023,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_jtag2apb_presetn</name>
+              <name>u0_jtag2apb_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_syscon_presetn</name>
+              <name>u0_sys_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_iomux_presetn</name>
+              <name>u0_sys_iomux_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_bus</name>
+              <name>u0_bus</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_debug_reset</name>
+              <name>u0_debug</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0</name>
+              <name>u0_core_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1</name>
+              <name>u0_core_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2</name>
+              <name>u0_core_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3</name>
+              <name>u0_core3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4</name>
+              <name>u0_core4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0_st</name>
+              <name>u0_core_st_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1_st</name>
+              <name>u0_core_st_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2_st</name>
+              <name>u0_core_st_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3_st</name>
+              <name>u0_core_st_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4_st</name>
+              <name>u0_core_st_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst0</name>
+              <name>u0_trace_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst1</name>
+              <name>u0_trace_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst2</name>
+              <name>u0_trace_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst3</name>
+              <name>u0_trace_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst4</name>
+              <name>u0_trace_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_com_rst</name>
+              <name>u0_trace_com</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_apb</name>
+              <name>u0_img_gpu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_doma</name>
+              <name>u0_img_gpu_doma</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n</name>
+              <name>u0_noc_bus_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n</name>
+              <name>u0_noc_bus_axicfg0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n</name>
+              <name>u0_noc_bus_cpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n</name>
+              <name>u0_noc_bus_disp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n</name>
+              <name>u0_noc_bus_gpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n</name>
+              <name>u0_noc_bus_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n</name>
+              <name>u0_noc_bus_ddrc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n</name>
+              <name>u0_noc_bus_stg_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n</name>
+              <name>u0_noc_bus_vdec_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31224,193 +31224,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
+              <name>u0_noc_bus_venc_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_ahb</name>
+              <name>u0_axi_cfg1_dec_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_main</name>
+              <name>u0_axi_cfg1_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main</name>
+              <name>u0_axi_cfg0_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main_div</name>
+              <name>u0_axi_cfg0_dec_main_div</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_hifi4</name>
+              <name>u0_axi_cfg0_dec_hifi4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_axi</name>
+              <name>u0_ddr_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_osc</name>
+              <name>u0_ddr_osc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_apb</name>
+              <name>u0_ddr_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n</name>
+              <name>u0_isp_top</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi</name>
+              <name>u0_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src</name>
+              <name>u0_vout_src</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_axi</name>
+              <name>u0_codaj12_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_core</name>
+              <name>u0_codaj12_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_apb</name>
+              <name>u0_codaj12_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_axi</name>
+              <name>u0_wave511_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_bpu</name>
+              <name>u0_wave511_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_vce</name>
+              <name>u0_wave511_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_apb</name>
+              <name>u0_wave511_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_jpgresetn</name>
+              <name>u0_vdec_jpg_arb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_mainresetn</name>
+              <name>u0_vdec_jpg_arb_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_aximem_128b_rstn_axi</name>
+              <name>u0_aximem_128b_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_axi</name>
+              <name>u0_wave420l_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_bpu</name>
+              <name>u0_wave420l_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_vce</name>
+              <name>u0_wave420l_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_apb</name>
+              <name>u0_wave420l_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_aximem_128b_rstn_axi</name>
+              <name>u1_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_aximem_128b_rstn_axi</name>
+              <name>u2_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_intmem_rom_sram_rstn_rom</name>
+              <name>u0_intmem_rom_sram</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ahb</name>
+              <name>u0_qspi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_apb</name>
+              <name>u0_qspi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ref</name>
+              <name>u0_qspi_ref</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31425,193 +31425,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sdio_rstn_ahb</name>
+              <name>u0_sdio_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_sdi_rstn_ahb</name>
+              <name>u1_sdi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_aresetn_i</name>
+              <name>u1_gmac5_axi64</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_hresetn_n</name>
+              <name>u1_gmac5_axi64_hresetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_mailbox_presetn</name>
+              <name>u0_mailbox_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ssp_spi_rstn_apb</name>
+              <name>u0_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_ssp_spi_rstn_apb</name>
+              <name>u1_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_ssp_spi_rstn_apb</name>
+              <name>u2_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_ssp_spi_rstn_apb</name>
+              <name>u3_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_ssp_spi_rstn_apb</name>
+              <name>u4_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_ssp_spi_rstn_apb</name>
+              <name>u5_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_ssp_spi_rstn_apb</name>
+              <name>u6_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2c_rstn_apb</name>
+              <name>u0_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2c_rstn_apb</name>
+              <name>u1_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_i2c_rstn_apb</name>
+              <name>u2_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_i2c_rstn_apb</name>
+              <name>u3_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_i2c_rstn_apb</name>
+              <name>u4_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_i2c_rstn_apb</name>
+              <name>u5_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_i2c_rstn_apb</name>
+              <name>u6_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_apb</name>
+              <name>u0_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_core</name>
+              <name>u0_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_apb</name>
+              <name>u1_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_core</name>
+              <name>u1_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_apb</name>
+              <name>u2_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_core</name>
+              <name>u2_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_apb</name>
+              <name>u3_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_core</name>
+              <name>u3_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_apb</name>
+              <name>u4_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_core</name>
+              <name>u4_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_uart_rstn_apb</name>
+              <name>u5_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_uart_rstn_core</name>
+              <name>u6_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_spdif_rstn_apb</name>
+              <name>u0_spdif_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -31626,181 +31626,181 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_pwmdac_rstn_apb</name>
+              <name>u0_pwmdac_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_dmic</name>
+              <name>u0_pdm_4mic_dmic</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_apb</name>
+              <name>u0_pdm_4mic_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_apb</name>
+              <name>u0_i2srx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_bclk</name>
+              <name>u0_i2srx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_apb</name>
+              <name>u0_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_bclk</name>
+              <name>u0_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_apb</name>
+              <name>u1_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_bclk</name>
+              <name>u1_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_ahb</name>
+              <name>u0_tdm16slot_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_tdm</name>
+              <name>u0_tdm16slot_tdm</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_apb</name>
+              <name>u0_tdm16slot_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pwm_8ch_rstn_apb</name>
+              <name>u0_pwm_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_apb</name>
+              <name>u0_dskit_wdt_rstn_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_wdt</name>
+              <name>u0_dskit_wdt</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_apb</name>
+              <name>u0_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_can</name>
+              <name>u0_can_ctrl</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_timer</name>
+              <name>u0_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_apb</name>
+              <name>u1_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_can</name>
+              <name>u1_can_ctrl_can</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_timer</name>
+              <name>u1_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_apb</name>
+              <name>u0_si5_timer_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer0</name>
+              <name>u0_si5_timer_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_time10</name>
+              <name>u0_si5_timer_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer2</name>
+              <name>u0_si5_timer_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer3</name>
+              <name>u0_si5_timer_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_int_ctrl_rstn_apb</name>
+              <name>u0_int_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_apb</name>
+              <name>u0_temp_sensor_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_temp</name>
+              <name>u0_temp_sensor</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_jtag_certification_rst_n</name>
+              <name>u0_jtag_rst</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
@@ -31815,193 +31815,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_jtag2apb_presetn</name>
+              <name>u0_jtag2apb_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_syscon_presetn</name>
+              <name>u0_sys_syscon_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_sys_iomux_presetn</name>
+              <name>u0_sys_iomux_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_bus</name>
+              <name>u0_bus</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_debug_reset</name>
+              <name>u0_debug</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0</name>
+              <name>u0_core_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1</name>
+              <name>u0_core_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2</name>
+              <name>u0_core_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3</name>
+              <name>u0_core3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4</name>
+              <name>u0_core4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core0_st</name>
+              <name>u0_core_st_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core1_st</name>
+              <name>u0_core_st_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core2_st</name>
+              <name>u0_core_st_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core3_st</name>
+              <name>u0_core_st_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_rst_core4_st</name>
+              <name>u0_core_st_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst0</name>
+              <name>u0_trace_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst1</name>
+              <name>u0_trace_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst2</name>
+              <name>u0_trace_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst3</name>
+              <name>u0_trace_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_rst4</name>
+              <name>u0_trace_4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_trace_com_rst</name>
+              <name>u0_trace_com</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_apb</name>
+              <name>u0_img_gpu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_img_gpu_rstn_doma</name>
+              <name>u0_img_gpu_doma</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n</name>
+              <name>u0_noc_bus_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n</name>
+              <name>u0_noc_bus_axicfg0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n</name>
+              <name>u0_noc_bus_cpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n</name>
+              <name>u0_noc_bus_disp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n</name>
+              <name>u0_noc_bus_gpu_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n</name>
+              <name>u0_noc_bus_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n</name>
+              <name>u0_noc_bus_ddrc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n</name>
+              <name>u0_noc_bus_stg_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n</name>
+              <name>u0_noc_bus_vdec_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32016,193 +32016,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sft7100_noc_bus_reset_venc_axi_n</name>
+              <name>u0_noc_bus_venc_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_ahb</name>
+              <name>u0_axi_cfg1_dec_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg1_dec_rstn_main</name>
+              <name>u0_axi_cfg1_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main</name>
+              <name>u0_axi_cfg0_dec_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_main_div</name>
+              <name>u0_axi_cfg0_dec_main_div</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_axi_cfg0_dec_rstn_hifi4</name>
+              <name>u0_axi_cfg0_dec_hifi4</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_axi</name>
+              <name>u0_ddr_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_osc</name>
+              <name>u0_ddr_osc</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ddr_sft7110_rstn_apb</name>
+              <name>u0_ddr_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n</name>
+              <name>u0_isp_top</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi</name>
+              <name>u0_isp_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src</name>
+              <name>u0_vout_src</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_axi</name>
+              <name>u0_codaj12_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_core</name>
+              <name>u0_codaj12_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_codaj12_rstn_apb</name>
+              <name>u0_codaj12_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_axi</name>
+              <name>u0_wave511_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_bpu</name>
+              <name>u0_wave511_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_vce</name>
+              <name>u0_wave511_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave511_rstn_apb</name>
+              <name>u0_wave511_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_jpgresetn</name>
+              <name>u0_vdec_jpg_arb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_vdec_jpg_arb_mainresetn</name>
+              <name>u0_vdec_jpg_arb_main</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_aximem_128b_rstn_axi</name>
+              <name>u0_aximem_128b_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_axi</name>
+              <name>u0_wave420l_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_bpu</name>
+              <name>u0_wave420l_bpu</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_vce</name>
+              <name>u0_wave420l_vce</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_wave420l_rstn_apb</name>
+              <name>u0_wave420l_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_aximem_128b_rstn_axi</name>
+              <name>u1_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_aximem_128b_rstn_axi</name>
+              <name>u2_aximem</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_intmem_rom_sram_rstn_rom</name>
+              <name>u0_intmem_rom_sram</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ahb</name>
+              <name>u0_qspi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_apb</name>
+              <name>u0_qspi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_qspi_rstn_ref</name>
+              <name>u0_qspi_ref</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32217,193 +32217,193 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_sdio_rstn_ahb</name>
+              <name>u0_sdio_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_sdi_rstn_ahb</name>
+              <name>u1_sdi_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_aresetn_i</name>
+              <name>u1_gmac5_axi64</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_gmac5_axi64_hresetn_n</name>
+              <name>u1_gmac5_axi64_hresetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_mailbox_presetn</name>
+              <name>u0_mailbox_presetn</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_ssp_spi_rstn_apb</name>
+              <name>u0_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_ssp_spi_rstn_apb</name>
+              <name>u1_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_ssp_spi_rstn_apb</name>
+              <name>u2_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_ssp_spi_rstn_apb</name>
+              <name>u3_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_ssp_spi_rstn_apb</name>
+              <name>u4_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_ssp_spi_rstn_apb</name>
+              <name>u5_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_ssp_spi_rstn_apb</name>
+              <name>u6_spi_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2c_rstn_apb</name>
+              <name>u0_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2c_rstn_apb</name>
+              <name>u1_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_i2c_rstn_apb</name>
+              <name>u2_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_i2c_rstn_apb</name>
+              <name>u3_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_i2c_rstn_apb</name>
+              <name>u4_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_i2c_rstn_apb</name>
+              <name>u5_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_i2c_rstn_apb</name>
+              <name>u6_i2c_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_apb</name>
+              <name>u0_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_uart_rstn_core</name>
+              <name>u0_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_apb</name>
+              <name>u1_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_uart_rstn_core</name>
+              <name>u1_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_apb</name>
+              <name>u2_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u2_uart_rstn_core</name>
+              <name>u2_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_apb</name>
+              <name>u3_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u3_uart_rstn_core</name>
+              <name>u3_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_apb</name>
+              <name>u4_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u4_uart_rstn_core</name>
+              <name>u4_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u5_uart_rstn_apb</name>
+              <name>u5_uart_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u6_uart_rstn_core</name>
+              <name>u6_uart_core</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[30:30]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_cdns_spdif_rstn_apb</name>
+              <name>u0_spdif_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[31:31]</bitRange>
               <access>read-write</access>
@@ -32418,181 +32418,181 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>rstn_u0_pwmdac_rstn_apb</name>
+              <name>u0_pwmdac_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_dmic</name>
+              <name>u0_pdm_4mic_dmic</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pdm_4mic_rstn_apb</name>
+              <name>u0_pdm_4mic_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[2:2]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_apb</name>
+              <name>u0_i2srx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2srx_3ch_rstn_bclk</name>
+              <name>u0_i2srx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_apb</name>
+              <name>u0_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_i2stx_4ch_rstn_bclk</name>
+              <name>u0_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_apb</name>
+              <name>u1_i2stx_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_i2stx_4ch_rstn_bclk</name>
+              <name>u1_i2stx_bclk</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[8:8]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_ahb</name>
+              <name>u0_tdm16slot_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[9:9]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_tdm</name>
+              <name>u0_tdm16slot_tdm</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[10:10]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_tdm16slot_rstn_apb</name>
+              <name>u0_tdm16slot_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[11:11]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_pwm_8ch_rstn_apb</name>
+              <name>u0_pwm_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[12:12]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_apb</name>
+              <name>u0_dskit_wdt_rstn_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[13:13]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_dskit_wdt_rstn_wdt</name>
+              <name>u0_dskit_wdt</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[14:14]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_apb</name>
+              <name>u0_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[15:15]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_can</name>
+              <name>u0_can_ctrl</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[16:16]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_can_ctrl_rstn_timer</name>
+              <name>u0_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[17:17]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_apb</name>
+              <name>u1_can_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[18:18]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_can</name>
+              <name>u1_can_ctrl_can</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[19:19]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u1_can_ctrl_rstn_timer</name>
+              <name>u1_can_ctrl_timer</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[20:20]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_apb</name>
+              <name>u0_si5_timer_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[21:21]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer0</name>
+              <name>u0_si5_timer_0</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[22:22]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_time10</name>
+              <name>u0_si5_timer_1</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[23:23]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer2</name>
+              <name>u0_si5_timer_2</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[24:24]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_si5_timer_rstn_timer3</name>
+              <name>u0_si5_timer_3</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[25:25]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_int_ctrl_rstn_apb</name>
+              <name>u0_int_ctrl_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[26:26]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_apb</name>
+              <name>u0_temp_sensor_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[27:27]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_temp_sensor_rstn_temp</name>
+              <name>u0_temp_sensor</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[28:28]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rstn_u0_jtag_certification_rst_n</name>
+              <name>u0_jtag_rst</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[29:29]</bitRange>
               <access>read-write</access>
@@ -42817,13 +42817,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>gmac5_axi64_rstn_axi</name>
+              <name>gmac5_axi64_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>gmac5_axi64_rstn_ahb</name>
+              <name>gmac5_axi64_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
@@ -42835,31 +42835,31 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_apb</name>
+              <name>pmu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_wkup</name>
+              <name>pmu_wkup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_apb</name>
+              <name>rtc_hms_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_cal</name>
+              <name>rtc_hms_cal</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_osc32k</name>
+              <name>rtc_hms_osc32k</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>
@@ -42874,13 +42874,13 @@
           <resetValue>0</resetValue>
           <fields>
             <field>
-              <name>gmac5_axi64_rstn_axi</name>
+              <name>gmac5_axi64_axi</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[0:0]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>gmac5_axi64_rstn_ahb</name>
+              <name>gmac5_axi64_ahb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[1:1]</bitRange>
               <access>read-write</access>
@@ -42892,31 +42892,31 @@
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_apb</name>
+              <name>pmu_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[3:3]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>pmu_rstn_wkup</name>
+              <name>pmu_wkup</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[4:4]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_apb</name>
+              <name>rtc_hms_apb</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[5:5]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_cal</name>
+              <name>rtc_hms_cal</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[6:6]</bitRange>
               <access>read-write</access>
             </field>
             <field>
-              <name>rtc_hms_rstn_osc32k</name>
+              <name>rtc_hms_osc32k</name>
               <description>1: Assert reset, 0: De-assert reset</description>
               <bitRange>[7:7]</bitRange>
               <access>read-write</access>

--- a/jh7110-vf2-13b-pac/src/aoncrg/aoncrg_rst_status.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/aoncrg_rst_status.rs
@@ -2,48 +2,48 @@
 pub type R = crate::R<AONCRG_RST_STATUS_SPEC>;
 #[doc = "Register `aoncrg_rst_status` writer"]
 pub type W = crate::W<AONCRG_RST_STATUS_SPEC>;
-#[doc = "Field `gmac5_axi64_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `gmac5_axi64_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `aon_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_R = crate::BitReader;
 #[doc = "Field `aon_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_wkup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_wkup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_cal` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_cal` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_R = crate::BitReader;
+#[doc = "Field `pmu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_wkup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_R = crate::BitReader;
+#[doc = "Field `pmu_wkup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_R = crate::BitReader;
+#[doc = "Field `rtc_hms_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_cal` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_R = crate::BitReader;
+#[doc = "Field `rtc_hms_cal` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_R = crate::BitReader;
+#[doc = "Field `rtc_hms_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_axi(&self) -> GMAC5_AXI64_RSTN_AXI_R {
-        GMAC5_AXI64_RSTN_AXI_R::new((self.bits & 1) != 0)
+    pub fn gmac5_axi64_axi(&self) -> GMAC5_AXI64_AXI_R {
+        GMAC5_AXI64_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_ahb(&self) -> GMAC5_AXI64_RSTN_AHB_R {
-        GMAC5_AXI64_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn gmac5_axi64_ahb(&self) -> GMAC5_AXI64_AHB_R {
+        GMAC5_AXI64_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -52,42 +52,42 @@ impl R {
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_apb(&self) -> PMU_RSTN_APB_R {
-        PMU_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn pmu_apb(&self) -> PMU_APB_R {
+        PMU_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_wkup(&self) -> PMU_RSTN_WKUP_R {
-        PMU_RSTN_WKUP_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn pmu_wkup(&self) -> PMU_WKUP_R {
+        PMU_WKUP_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_apb(&self) -> RTC_HMS_RSTN_APB_R {
-        RTC_HMS_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn rtc_hms_apb(&self) -> RTC_HMS_APB_R {
+        RTC_HMS_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_cal(&self) -> RTC_HMS_RSTN_CAL_R {
-        RTC_HMS_RSTN_CAL_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn rtc_hms_cal(&self) -> RTC_HMS_CAL_R {
+        RTC_HMS_CAL_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_osc32k(&self) -> RTC_HMS_RSTN_OSC32K_R {
-        RTC_HMS_RSTN_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn rtc_hms_osc32k(&self) -> RTC_HMS_OSC32K_R {
+        RTC_HMS_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_axi(&mut self) -> GMAC5_AXI64_RSTN_AXI_W<AONCRG_RST_STATUS_SPEC> {
-        GMAC5_AXI64_RSTN_AXI_W::new(self, 0)
+    pub fn gmac5_axi64_axi(&mut self) -> GMAC5_AXI64_AXI_W<AONCRG_RST_STATUS_SPEC> {
+        GMAC5_AXI64_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_ahb(&mut self) -> GMAC5_AXI64_RSTN_AHB_W<AONCRG_RST_STATUS_SPEC> {
-        GMAC5_AXI64_RSTN_AHB_W::new(self, 1)
+    pub fn gmac5_axi64_ahb(&mut self) -> GMAC5_AXI64_AHB_W<AONCRG_RST_STATUS_SPEC> {
+        GMAC5_AXI64_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -98,32 +98,32 @@ impl W {
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_apb(&mut self) -> PMU_RSTN_APB_W<AONCRG_RST_STATUS_SPEC> {
-        PMU_RSTN_APB_W::new(self, 3)
+    pub fn pmu_apb(&mut self) -> PMU_APB_W<AONCRG_RST_STATUS_SPEC> {
+        PMU_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_wkup(&mut self) -> PMU_RSTN_WKUP_W<AONCRG_RST_STATUS_SPEC> {
-        PMU_RSTN_WKUP_W::new(self, 4)
+    pub fn pmu_wkup(&mut self) -> PMU_WKUP_W<AONCRG_RST_STATUS_SPEC> {
+        PMU_WKUP_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_apb(&mut self) -> RTC_HMS_RSTN_APB_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_APB_W::new(self, 5)
+    pub fn rtc_hms_apb(&mut self) -> RTC_HMS_APB_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_cal(&mut self) -> RTC_HMS_RSTN_CAL_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_CAL_W::new(self, 6)
+    pub fn rtc_hms_cal(&mut self) -> RTC_HMS_CAL_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_CAL_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_osc32k(&mut self) -> RTC_HMS_RSTN_OSC32K_W<AONCRG_RST_STATUS_SPEC> {
-        RTC_HMS_RSTN_OSC32K_W::new(self, 7)
+    pub fn rtc_hms_osc32k(&mut self) -> RTC_HMS_OSC32K_W<AONCRG_RST_STATUS_SPEC> {
+        RTC_HMS_OSC32K_W::new(self, 7)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/aoncrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/aoncrg/soft_rst_addr_sel.rs
@@ -2,48 +2,48 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Register `soft_rst_addr_sel` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_SPEC>;
-#[doc = "Field `gmac5_axi64_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `gmac5_axi64_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `gmac5_axi64_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type GMAC5_AXI64_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `gmac5_axi64_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_R = crate::BitReader;
+#[doc = "Field `gmac5_axi64_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type GMAC5_AXI64_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
 #[doc = "Field `aon_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_R = crate::BitReader;
 #[doc = "Field `aon_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
 pub type AON_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `pmu_rstn_wkup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_R = crate::BitReader;
-#[doc = "Field `pmu_rstn_wkup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type PMU_RSTN_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_cal` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_cal` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rtc_hms_rstn_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_R = crate::BitReader;
-#[doc = "Field `rtc_hms_rstn_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RTC_HMS_RSTN_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_R = crate::BitReader;
+#[doc = "Field `pmu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `pmu_wkup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_R = crate::BitReader;
+#[doc = "Field `pmu_wkup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type PMU_WKUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_R = crate::BitReader;
+#[doc = "Field `rtc_hms_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_cal` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_R = crate::BitReader;
+#[doc = "Field `rtc_hms_cal` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_CAL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `rtc_hms_osc32k` reader - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_R = crate::BitReader;
+#[doc = "Field `rtc_hms_osc32k` writer - 1: Assert reset, 0: De-assert reset"]
+pub type RTC_HMS_OSC32K_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_axi(&self) -> GMAC5_AXI64_RSTN_AXI_R {
-        GMAC5_AXI64_RSTN_AXI_R::new((self.bits & 1) != 0)
+    pub fn gmac5_axi64_axi(&self) -> GMAC5_AXI64_AXI_R {
+        GMAC5_AXI64_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn gmac5_axi64_rstn_ahb(&self) -> GMAC5_AXI64_RSTN_AHB_R {
-        GMAC5_AXI64_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn gmac5_axi64_ahb(&self) -> GMAC5_AXI64_AHB_R {
+        GMAC5_AXI64_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -52,42 +52,42 @@ impl R {
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_apb(&self) -> PMU_RSTN_APB_R {
-        PMU_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn pmu_apb(&self) -> PMU_APB_R {
+        PMU_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn pmu_rstn_wkup(&self) -> PMU_RSTN_WKUP_R {
-        PMU_RSTN_WKUP_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn pmu_wkup(&self) -> PMU_WKUP_R {
+        PMU_WKUP_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_apb(&self) -> RTC_HMS_RSTN_APB_R {
-        RTC_HMS_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn rtc_hms_apb(&self) -> RTC_HMS_APB_R {
+        RTC_HMS_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_cal(&self) -> RTC_HMS_RSTN_CAL_R {
-        RTC_HMS_RSTN_CAL_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn rtc_hms_cal(&self) -> RTC_HMS_CAL_R {
+        RTC_HMS_CAL_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rtc_hms_rstn_osc32k(&self) -> RTC_HMS_RSTN_OSC32K_R {
-        RTC_HMS_RSTN_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn rtc_hms_osc32k(&self) -> RTC_HMS_OSC32K_R {
+        RTC_HMS_OSC32K_R::new(((self.bits >> 7) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_axi(&mut self) -> GMAC5_AXI64_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        GMAC5_AXI64_RSTN_AXI_W::new(self, 0)
+    pub fn gmac5_axi64_axi(&mut self) -> GMAC5_AXI64_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        GMAC5_AXI64_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn gmac5_axi64_rstn_ahb(&mut self) -> GMAC5_AXI64_RSTN_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        GMAC5_AXI64_RSTN_AHB_W::new(self, 1)
+    pub fn gmac5_axi64_ahb(&mut self) -> GMAC5_AXI64_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        GMAC5_AXI64_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
@@ -98,32 +98,32 @@ impl W {
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_apb(&mut self) -> PMU_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        PMU_RSTN_APB_W::new(self, 3)
+    pub fn pmu_apb(&mut self) -> PMU_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        PMU_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn pmu_rstn_wkup(&mut self) -> PMU_RSTN_WKUP_W<SOFT_RST_ADDR_SEL_SPEC> {
-        PMU_RSTN_WKUP_W::new(self, 4)
+    pub fn pmu_wkup(&mut self) -> PMU_WKUP_W<SOFT_RST_ADDR_SEL_SPEC> {
+        PMU_WKUP_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_apb(&mut self) -> RTC_HMS_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_APB_W::new(self, 5)
+    pub fn rtc_hms_apb(&mut self) -> RTC_HMS_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_cal(&mut self) -> RTC_HMS_RSTN_CAL_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_CAL_W::new(self, 6)
+    pub fn rtc_hms_cal(&mut self) -> RTC_HMS_CAL_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_CAL_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rtc_hms_rstn_osc32k(&mut self) -> RTC_HMS_RSTN_OSC32K_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RTC_HMS_RSTN_OSC32K_W::new(self, 7)
+    pub fn rtc_hms_osc32k(&mut self) -> RTC_HMS_OSC32K_W<SOFT_RST_ADDR_SEL_SPEC> {
+        RTC_HMS_OSC32K_W::new(self, 7)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stgcrg/soft_rst_addr_sel.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/soft_rst_addr_sel.rs
@@ -2,395 +2,353 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_SPEC>;
 #[doc = "Register `soft_rst_addr_sel` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_SPEC>;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_R = crate::BitReader;
+#[doc = "Field `u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_R = crate::BitReader;
+#[doc = "Field `u0_e2_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_R = crate::BitReader;
+#[doc = "Field `u0_dma_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_R = crate::BitReader;
+#[doc = "Field `u0_dma_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_R = crate::BitReader;
+#[doc = "Field `u0_usb_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pci_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_R = crate::BitReader;
+#[doc = "Field `u0_pci_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u0_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_R = crate::BitReader;
+#[doc = "Field `u1_pcie_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u1_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_stg_syscon_presetn(&self) -> RSTN_U0_STG_SYSCON_PRESETN_R {
-        RSTN_U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_stg_syscon_presetn(&self) -> U0_STG_SYSCON_PRESETN_R {
+        U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_core(&self) -> RST_U0_HIFI4_RST_CORE_R {
-        RST_U0_HIFI4_RST_CORE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_hifi4_core(&self) -> U0_HIFI4_CORE_R {
+        U0_HIFI4_CORE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_axi(&self) -> RST_U0_HIFI4_RST_AXI_R {
-        RST_U0_HIFI4_RST_AXI_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_hifi4_axi(&self) -> U0_HIFI4_AXI_R {
+        U0_HIFI4_AXI_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sec_top_hreesetn(&self) -> RSTN_U0_SEC_TOP_HREESETN_R {
-        RSTN_U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_sec_top_hreesetn(&self) -> U0_SEC_TOP_HREESETN_R {
+        U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_e2_sft7110_rst_core(&self) -> RST_U0_E2_SFT7110_RST_CORE_R {
-        RST_U0_E2_SFT7110_RST_CORE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_e2_core(&self) -> U0_E2_CORE_R {
+        U0_E2_CORE_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_dma_axi(&self) -> U0_DMA_AXI_R {
+        U0_DMA_AXI_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_dma_ahb(&self) -> U0_DMA_AHB_R {
+        U0_DMA_AHB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&self) -> RSTN_U0_CDN_USB_RSTN_AXI_R {
-        RSTN_U0_CDN_USB_RSTN_AXI_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_axi(&self) -> U0_USB_AXI_R {
+        U0_USB_AXI_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(&self) -> RSTN_U0_CDN_USB_RSTN_USB_APB_R {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_apb(&self) -> U0_USB_APB_R {
+        U0_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(&self) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_R {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_apb(&self) -> U0_USB_UTMI_APB_R {
+        U0_USB_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(&self) -> RSTN_U0_CDN_USB_RSTN_PWRUP_R {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_pwrup(&self) -> U0_USB_PWRUP_R {
+        U0_USB_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_pcie_axi_mst0(&self) -> U0_PCIE_AXI_MST0_R {
+        U0_PCIE_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pcie_axi_slv0(&self) -> U0_PCIE_AXI_SLV0_R {
+        U0_PCIE_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_pcie_axi_slv(&self) -> U0_PCIE_AXI_SLV_R {
+        U0_PCIE_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pci_rstn_brg(&self) -> RSTN_U0_PLDA_PCI_RSTN_BRG_R {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_pci_brg(&self) -> U0_PCI_BRG_R {
+        U0_PCI_BRG_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(&self) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_pcie_pcie(&self) -> U0_PCIE_PCIE_R {
+        U0_PCIE_PCIE_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_apb(&self) -> RSTN_U0_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_apb(&self) -> U0_PCIE_APB_R {
+        U0_PCIE_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_axi_mst0(&self) -> U1_PCIE_AXI_MST0_R {
+        U1_PCIE_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_pcie_axi_slv0(&self) -> U1_PCIE_AXI_SLV0_R {
+        U1_PCIE_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_pcie_axi_slv(&self) -> U1_PCIE_AXI_SLV_R {
+        U1_PCIE_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_brg(&self) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_R {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_pcie_brg(&self) -> U1_PCIE_BRG_R {
+        U1_PCIE_BRG_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(&self) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_pcie_pcie(&self) -> U1_PCIE_PCIE_R {
+        U1_PCIE_PCIE_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_apb(&self) -> RSTN_U1_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_apb(&self) -> U1_PCIE_APB_R {
+        U1_PCIE_APB_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_stg_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_STG_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_STG_SYSCON_PRESETN_W::new(self, 0)
+    pub fn u0_stg_syscon_presetn(&mut self) -> U0_STG_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_STG_SYSCON_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_core(&mut self) -> RST_U0_HIFI4_RST_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_HIFI4_RST_CORE_W::new(self, 1)
+    pub fn u0_hifi4_core(&mut self) -> U0_HIFI4_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_HIFI4_CORE_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_axi(&mut self) -> RST_U0_HIFI4_RST_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_HIFI4_RST_AXI_W::new(self, 2)
+    pub fn u0_hifi4_axi(&mut self) -> U0_HIFI4_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_HIFI4_AXI_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sec_top_hreesetn(
-        &mut self,
-    ) -> RSTN_U0_SEC_TOP_HREESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_SEC_TOP_HREESETN_W::new(self, 3)
+    pub fn u0_sec_top_hreesetn(&mut self) -> U0_SEC_TOP_HREESETN_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_SEC_TOP_HREESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_e2_sft7110_rst_core(
-        &mut self,
-    ) -> RST_U0_E2_SFT7110_RST_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RST_U0_E2_SFT7110_RST_CORE_W::new(self, 4)
+    pub fn u0_e2_core(&mut self) -> U0_E2_CORE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_E2_CORE_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W::new(self, 5)
+    pub fn u0_dma_axi(&mut self) -> U0_DMA_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_DMA_AXI_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W::new(self, 6)
+    pub fn u0_dma_ahb(&mut self) -> U0_DMA_AHB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_DMA_AHB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_AXI_W::new(self, 7)
+    pub fn u0_usb_axi(&mut self) -> U0_USB_AXI_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_AXI_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_USB_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_W::new(self, 8)
+    pub fn u0_usb_apb(&mut self) -> U0_USB_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_W::new(self, 9)
+    pub fn u0_usb_utmi_apb(&mut self) -> U0_USB_UTMI_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_UTMI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_PWRUP_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_W::new(self, 10)
+    pub fn u0_usb_pwrup(&mut self) -> U0_USB_PWRUP_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_USB_PWRUP_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 11)
+    pub fn u0_pcie_axi_mst0(&mut self) -> U0_PCIE_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_MST0_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 12)
+    pub fn u0_pcie_axi_slv0(&mut self) -> U0_PCIE_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_SLV0_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 13)
+    pub fn u0_pcie_axi_slv(&mut self) -> U0_PCIE_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_AXI_SLV_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pci_rstn_brg(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCI_RSTN_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_W::new(self, 14)
+    pub fn u0_pci_brg(&mut self) -> U0_PCI_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCI_BRG_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_W::new(self, 15)
+    pub fn u0_pcie_pcie(&mut self) -> U0_PCIE_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_PCIE_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_W::new(self, 16)
+    pub fn u0_pcie_apb(&mut self) -> U0_PCIE_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U0_PCIE_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 17)
+    pub fn u1_pcie_axi_mst0(&mut self) -> U1_PCIE_AXI_MST0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_MST0_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 18)
+    pub fn u1_pcie_axi_slv0(&mut self) -> U1_PCIE_AXI_SLV0_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_SLV0_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 19)
+    pub fn u1_pcie_axi_slv(&mut self) -> U1_PCIE_AXI_SLV_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_AXI_SLV_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_brg(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_W::new(self, 20)
+    pub fn u1_pcie_brg(&mut self) -> U1_PCIE_BRG_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_BRG_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_W::new(self, 21)
+    pub fn u1_pcie_pcie(&mut self) -> U1_PCIE_PCIE_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_PCIE_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_W::new(self, 22)
+    pub fn u1_pcie_apb(&mut self) -> U1_PCIE_APB_W<SOFT_RST_ADDR_SEL_SPEC> {
+        U1_PCIE_APB_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/stgcrg/stgcrg_rst_stat.rs
+++ b/jh7110-vf2-13b-pac/src/stgcrg/stgcrg_rst_stat.rs
@@ -2,391 +2,353 @@
 pub type R = crate::R<STGCRG_RST_STAT_SPEC>;
 #[doc = "Register `stgcrg_rst_stat` writer"]
 pub type W = crate::W<STGCRG_RST_STAT_SPEC>;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_hifi4_rst_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_R = crate::BitReader;
-#[doc = "Field `rst_u0_hifi4_rst_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_HIFI4_RST_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_R = crate::BitReader;
-#[doc = "Field `rst_u0_e2_sft7110_rst_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_E2_SFT7110_RST_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dma1p_8ch_56hs_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdn_usb_rstn_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDN_USB_RSTN_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pci_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCI_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_brg` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_pcie` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_plda_pcie_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_PLDA_PCIE_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_stg_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_stg_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_STG_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_hifi4_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_R = crate::BitReader;
+#[doc = "Field `u0_hifi4_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_HIFI4_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sec_top_hreesetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_R = crate::BitReader;
+#[doc = "Field `u0_sec_top_hreesetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SEC_TOP_HREESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_e2_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_R = crate::BitReader;
+#[doc = "Field `u0_e2_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_E2_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_R = crate::BitReader;
+#[doc = "Field `u0_dma_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dma_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_R = crate::BitReader;
+#[doc = "Field `u0_dma_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DMA_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_R = crate::BitReader;
+#[doc = "Field `u0_usb_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_utmi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_R = crate::BitReader;
+#[doc = "Field `u0_usb_utmi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_UTMI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_usb_pwrup` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_R = crate::BitReader;
+#[doc = "Field `u0_usb_pwrup` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_USB_PWRUP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u0_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pci_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_R = crate::BitReader;
+#[doc = "Field `u0_pci_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCI_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u0_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u0_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_mst0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_mst0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_MST0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_axi_slv` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_R = crate::BitReader;
+#[doc = "Field `u1_pcie_axi_slv` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_AXI_SLV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_brg` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_R = crate::BitReader;
+#[doc = "Field `u1_pcie_brg` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_BRG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_pcie` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_R = crate::BitReader;
+#[doc = "Field `u1_pcie_pcie` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_PCIE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_pcie_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_R = crate::BitReader;
+#[doc = "Field `u1_pcie_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_PCIE_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_stg_syscon_presetn(&self) -> RSTN_U0_STG_SYSCON_PRESETN_R {
-        RSTN_U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_stg_syscon_presetn(&self) -> U0_STG_SYSCON_PRESETN_R {
+        U0_STG_SYSCON_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_core(&self) -> RST_U0_HIFI4_RST_CORE_R {
-        RST_U0_HIFI4_RST_CORE_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_hifi4_core(&self) -> U0_HIFI4_CORE_R {
+        U0_HIFI4_CORE_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_hifi4_rst_axi(&self) -> RST_U0_HIFI4_RST_AXI_R {
-        RST_U0_HIFI4_RST_AXI_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_hifi4_axi(&self) -> U0_HIFI4_AXI_R {
+        U0_HIFI4_AXI_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sec_top_hreesetn(&self) -> RSTN_U0_SEC_TOP_HREESETN_R {
-        RSTN_U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_sec_top_hreesetn(&self) -> U0_SEC_TOP_HREESETN_R {
+        U0_SEC_TOP_HREESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_e2_sft7110_rst_core(&self) -> RST_U0_E2_SFT7110_RST_CORE_R {
-        RST_U0_E2_SFT7110_RST_CORE_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_e2_core(&self) -> U0_E2_CORE_R {
+        U0_E2_CORE_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_dma_axi(&self) -> U0_DMA_AXI_R {
+        U0_DMA_AXI_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(&self) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_dma_ahb(&self) -> U0_DMA_AHB_R {
+        U0_DMA_AHB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&self) -> RSTN_U0_CDN_USB_RSTN_AXI_R {
-        RSTN_U0_CDN_USB_RSTN_AXI_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_usb_axi(&self) -> U0_USB_AXI_R {
+        U0_USB_AXI_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(&self) -> RSTN_U0_CDN_USB_RSTN_USB_APB_R {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_usb_apb(&self) -> U0_USB_APB_R {
+        U0_USB_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(&self) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_R {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_usb_utmi_apb(&self) -> U0_USB_UTMI_APB_R {
+        U0_USB_UTMI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(&self) -> RSTN_U0_CDN_USB_RSTN_PWRUP_R {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_usb_pwrup(&self) -> U0_USB_PWRUP_R {
+        U0_USB_PWRUP_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_pcie_axi_mst0(&self) -> U0_PCIE_AXI_MST0_R {
+        U0_PCIE_AXI_MST0_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pcie_axi_slv0(&self) -> U0_PCIE_AXI_SLV0_R {
+        U0_PCIE_AXI_SLV0_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(&self) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_pcie_axi_slv(&self) -> U0_PCIE_AXI_SLV_R {
+        U0_PCIE_AXI_SLV_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pci_rstn_brg(&self) -> RSTN_U0_PLDA_PCI_RSTN_BRG_R {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_pci_brg(&self) -> U0_PCI_BRG_R {
+        U0_PCI_BRG_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(&self) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_pcie_pcie(&self) -> U0_PCIE_PCIE_R {
+        U0_PCIE_PCIE_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_plda_pcie_rstn_apb(&self) -> RSTN_U0_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_pcie_apb(&self) -> U0_PCIE_APB_R {
+        U0_PCIE_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u1_pcie_axi_mst0(&self) -> U1_PCIE_AXI_MST0_R {
+        U1_PCIE_AXI_MST0_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_pcie_axi_slv0(&self) -> U1_PCIE_AXI_SLV0_R {
+        U1_PCIE_AXI_SLV0_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(&self) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_pcie_axi_slv(&self) -> U1_PCIE_AXI_SLV_R {
+        U1_PCIE_AXI_SLV_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_brg(&self) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_R {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_pcie_brg(&self) -> U1_PCIE_BRG_R {
+        U1_PCIE_BRG_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(&self) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_R {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_pcie_pcie(&self) -> U1_PCIE_PCIE_R {
+        U1_PCIE_PCIE_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_plda_pcie_rstn_apb(&self) -> RSTN_U1_PLDA_PCIE_RSTN_APB_R {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_pcie_apb(&self) -> U1_PCIE_APB_R {
+        U1_PCIE_APB_R::new(((self.bits >> 22) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_stg_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_STG_SYSCON_PRESETN_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_STG_SYSCON_PRESETN_W::new(self, 0)
+    pub fn u0_stg_syscon_presetn(&mut self) -> U0_STG_SYSCON_PRESETN_W<STGCRG_RST_STAT_SPEC> {
+        U0_STG_SYSCON_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_core(&mut self) -> RST_U0_HIFI4_RST_CORE_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_HIFI4_RST_CORE_W::new(self, 1)
+    pub fn u0_hifi4_core(&mut self) -> U0_HIFI4_CORE_W<STGCRG_RST_STAT_SPEC> {
+        U0_HIFI4_CORE_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_hifi4_rst_axi(&mut self) -> RST_U0_HIFI4_RST_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_HIFI4_RST_AXI_W::new(self, 2)
+    pub fn u0_hifi4_axi(&mut self) -> U0_HIFI4_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_HIFI4_AXI_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sec_top_hreesetn(&mut self) -> RSTN_U0_SEC_TOP_HREESETN_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_SEC_TOP_HREESETN_W::new(self, 3)
+    pub fn u0_sec_top_hreesetn(&mut self) -> U0_SEC_TOP_HREESETN_W<STGCRG_RST_STAT_SPEC> {
+        U0_SEC_TOP_HREESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_e2_sft7110_rst_core(
-        &mut self,
-    ) -> RST_U0_E2_SFT7110_RST_CORE_W<STGCRG_RST_STAT_SPEC> {
-        RST_U0_E2_SFT7110_RST_CORE_W::new(self, 4)
+    pub fn u0_e2_core(&mut self) -> U0_E2_CORE_W<STGCRG_RST_STAT_SPEC> {
+        U0_E2_CORE_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AXI_W::new(self, 5)
+    pub fn u0_dma_axi(&mut self) -> U0_DMA_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_DMA_AXI_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dma1p_8ch_56hs_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_DMA1P_8CH_56HS_RSTN_AHB_W::new(self, 6)
+    pub fn u0_dma_ahb(&mut self) -> U0_DMA_AHB_W<STGCRG_RST_STAT_SPEC> {
+        U0_DMA_AHB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_axi(&mut self) -> RSTN_U0_CDN_USB_RSTN_AXI_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_AXI_W::new(self, 7)
+    pub fn u0_usb_axi(&mut self) -> U0_USB_AXI_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_AXI_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_usb_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_USB_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_USB_APB_W::new(self, 8)
+    pub fn u0_usb_apb(&mut self) -> U0_USB_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_utmi_apb(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_UTMI_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_UTMI_APB_W::new(self, 9)
+    pub fn u0_usb_utmi_apb(&mut self) -> U0_USB_UTMI_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_UTMI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdn_usb_rstn_pwrup(
-        &mut self,
-    ) -> RSTN_U0_CDN_USB_RSTN_PWRUP_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_CDN_USB_RSTN_PWRUP_W::new(self, 10)
+    pub fn u0_usb_pwrup(&mut self) -> U0_USB_PWRUP_W<STGCRG_RST_STAT_SPEC> {
+        U0_USB_PWRUP_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 11)
+    pub fn u0_pcie_axi_mst0(&mut self) -> U0_PCIE_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_MST0_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 12)
+    pub fn u0_pcie_axi_slv0(&mut self) -> U0_PCIE_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_SLV0_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 13)
+    pub fn u0_pcie_axi_slv(&mut self) -> U0_PCIE_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_AXI_SLV_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pci_rstn_brg(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCI_RSTN_BRG_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCI_RSTN_BRG_W::new(self, 14)
+    pub fn u0_pci_brg(&mut self) -> U0_PCI_BRG_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCI_BRG_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_PCIE_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_PCIE_W::new(self, 15)
+    pub fn u0_pcie_pcie(&mut self) -> U0_PCIE_PCIE_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_PCIE_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PLDA_PCIE_RSTN_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U0_PLDA_PCIE_RSTN_APB_W::new(self, 16)
+    pub fn u0_pcie_apb(&mut self) -> U0_PCIE_APB_W<STGCRG_RST_STAT_SPEC> {
+        U0_PCIE_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_mst0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_MST0_W::new(self, 17)
+    pub fn u1_pcie_axi_mst0(&mut self) -> U1_PCIE_AXI_MST0_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_MST0_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv0(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV0_W::new(self, 18)
+    pub fn u1_pcie_axi_slv0(&mut self) -> U1_PCIE_AXI_SLV0_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_SLV0_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_axi_slv(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_AXI_SLV_W::new(self, 19)
+    pub fn u1_pcie_axi_slv(&mut self) -> U1_PCIE_AXI_SLV_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_AXI_SLV_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_brg(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_BRG_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_BRG_W::new(self, 20)
+    pub fn u1_pcie_brg(&mut self) -> U1_PCIE_BRG_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_BRG_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_pcie(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_PCIE_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_PCIE_W::new(self, 21)
+    pub fn u1_pcie_pcie(&mut self) -> U1_PCIE_PCIE_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_PCIE_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_plda_pcie_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_PLDA_PCIE_RSTN_APB_W<STGCRG_RST_STAT_SPEC> {
-        RSTN_U1_PLDA_PCIE_RSTN_APB_W::new(self, 22)
+    pub fn u1_pcie_apb(&mut self) -> U1_PCIE_APB_W<STGCRG_RST_STAT_SPEC> {
+        U1_PCIE_APB_W::new(self, 22)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_0.rs
@@ -2,570 +2,488 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_0_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_0` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_0_SPEC>;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_bus` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_R = crate::BitReader;
+#[doc = "Field `u0_bus` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_debug` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_R = crate::BitReader;
+#[doc = "Field `u0_debug` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_R = crate::BitReader;
+#[doc = "Field `u0_core_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_R = crate::BitReader;
+#[doc = "Field `u0_core_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_R = crate::BitReader;
+#[doc = "Field `u0_core_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_R = crate::BitReader;
+#[doc = "Field `u0_core3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_R = crate::BitReader;
+#[doc = "Field `u0_core4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_R = crate::BitReader;
+#[doc = "Field `u0_core_st_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_R = crate::BitReader;
+#[doc = "Field `u0_core_st_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_R = crate::BitReader;
+#[doc = "Field `u0_core_st_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_R = crate::BitReader;
+#[doc = "Field `u0_core_st_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_R = crate::BitReader;
+#[doc = "Field `u0_core_st_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_R = crate::BitReader;
+#[doc = "Field `u0_trace_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_R = crate::BitReader;
+#[doc = "Field `u0_trace_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_R = crate::BitReader;
+#[doc = "Field `u0_trace_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_R = crate::BitReader;
+#[doc = "Field `u0_trace_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_R = crate::BitReader;
+#[doc = "Field `u0_trace_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_com` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_R = crate::BitReader;
+#[doc = "Field `u0_trace_com` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_doma` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_doma` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_axicfg0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_axicfg0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_cpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_cpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_disp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_disp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_gpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_gpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_ddrc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_ddrc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_stg_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_stg_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_vdec_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_vdec_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag2apb_presetn(&self) -> RSTN_U0_JTAG2APB_PRESETN_R {
-        RSTN_U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_jtag2apb_presetn(&self) -> U0_JTAG2APB_PRESETN_R {
+        U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_syscon_presetn(&self) -> RSTN_U0_SYS_SYSCON_PRESETN_R {
-        RSTN_U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_sys_syscon_presetn(&self) -> U0_SYS_SYSCON_PRESETN_R {
+        U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_iomux_presetn(&self) -> RSTN_U0_SYS_IOMUX_PRESETN_R {
-        RSTN_U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_sys_iomux_presetn(&self) -> U0_SYS_IOMUX_PRESETN_R {
+        U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(&self) -> RST_U0_U7MC_SFT7110_RST_BUS_R {
-        RST_U0_U7MC_SFT7110_RST_BUS_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_bus(&self) -> U0_BUS_R {
+        U0_BUS_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(&self) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_R {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_debug(&self) -> U0_DEBUG_R {
+        U0_DEBUG_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_core_0(&self) -> U0_CORE_0_R {
+        U0_CORE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_core_1(&self) -> U0_CORE_1_R {
+        U0_CORE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_core_2(&self) -> U0_CORE_2_R {
+        U0_CORE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_core3(&self) -> U0_CORE3_R {
+        U0_CORE3_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_core4(&self) -> U0_CORE4_R {
+        U0_CORE4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_core_st_0(&self) -> U0_CORE_ST_0_R {
+        U0_CORE_ST_0_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_core_st_1(&self) -> U0_CORE_ST_1_R {
+        U0_CORE_ST_1_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_core_st_2(&self) -> U0_CORE_ST_2_R {
+        U0_CORE_ST_2_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_core_st_3(&self) -> U0_CORE_ST_3_R {
+        U0_CORE_ST_3_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_core_st_4(&self) -> U0_CORE_ST_4_R {
+        U0_CORE_ST_4_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST0_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_trace_0(&self) -> U0_TRACE_0_R {
+        U0_TRACE_0_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST1_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_trace_1(&self) -> U0_TRACE_1_R {
+        U0_TRACE_1_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST2_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_trace_2(&self) -> U0_TRACE_2_R {
+        U0_TRACE_2_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST3_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_trace_3(&self) -> U0_TRACE_3_R {
+        U0_TRACE_3_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST4_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_trace_4(&self) -> U0_TRACE_4_R {
+        U0_TRACE_4_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(&self) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_R {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_trace_com(&self) -> U0_TRACE_COM_R {
+        U0_TRACE_COM_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_apb(&self) -> RST_U0_IMG_GPU_RSTN_APB_R {
-        RST_U0_IMG_GPU_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_img_gpu_apb(&self) -> U0_IMG_GPU_APB_R {
+        U0_IMG_GPU_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_doma(&self) -> RST_U0_IMG_GPU_RSTN_DOMA_R {
-        RST_U0_IMG_GPU_RSTN_DOMA_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_img_gpu_doma(&self) -> U0_IMG_GPU_DOMA_R {
+        U0_IMG_GPU_DOMA_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_noc_bus_apb(&self) -> U0_NOC_BUS_APB_R {
+        U0_NOC_BUS_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_noc_bus_axicfg0(&self) -> U0_NOC_BUS_AXICFG0_R {
+        U0_NOC_BUS_AXICFG0_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_noc_bus_cpu_axi(&self) -> U0_NOC_BUS_CPU_AXI_R {
+        U0_NOC_BUS_CPU_AXI_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_noc_bus_disp_axi(&self) -> U0_NOC_BUS_DISP_AXI_R {
+        U0_NOC_BUS_DISP_AXI_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_noc_bus_gpu_axi(&self) -> U0_NOC_BUS_GPU_AXI_R {
+        U0_NOC_BUS_GPU_AXI_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_noc_bus_isp_axi(&self) -> U0_NOC_BUS_ISP_AXI_R {
+        U0_NOC_BUS_ISP_AXI_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_noc_bus_ddrc(&self) -> U0_NOC_BUS_DDRC_R {
+        U0_NOC_BUS_DDRC_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_noc_bus_stg_axi(&self) -> U0_NOC_BUS_STG_AXI_R {
+        U0_NOC_BUS_STG_AXI_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_noc_bus_vdec_axi(&self) -> U0_NOC_BUS_VDEC_AXI_R {
+        U0_NOC_BUS_VDEC_AXI_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag2apb_presetn(
-        &mut self,
-    ) -> RSTN_U0_JTAG2APB_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_JTAG2APB_PRESETN_W::new(self, 0)
+    pub fn u0_jtag2apb_presetn(&mut self) -> U0_JTAG2APB_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_JTAG2APB_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_SYS_SYSCON_PRESETN_W::new(self, 1)
+    pub fn u0_sys_syscon_presetn(&mut self) -> U0_SYS_SYSCON_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_SYS_SYSCON_PRESETN_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_iomux_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_IOMUX_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RSTN_U0_SYS_IOMUX_PRESETN_W::new(self, 2)
+    pub fn u0_sys_iomux_presetn(&mut self) -> U0_SYS_IOMUX_PRESETN_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_SYS_IOMUX_PRESETN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_BUS_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_BUS_W::new(self, 3)
+    pub fn u0_bus(&mut self) -> U0_BUS_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_BUS_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_W::new(self, 4)
+    pub fn u0_debug(&mut self) -> U0_DEBUG_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_DEBUG_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_W::new(self, 5)
+    pub fn u0_core_0(&mut self) -> U0_CORE_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_0_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_W::new(self, 6)
+    pub fn u0_core_1(&mut self) -> U0_CORE_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_W::new(self, 7)
+    pub fn u0_core_2(&mut self) -> U0_CORE_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_2_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_W::new(self, 8)
+    pub fn u0_core3(&mut self) -> U0_CORE3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE3_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_W::new(self, 9)
+    pub fn u0_core4(&mut self) -> U0_CORE4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE4_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_W::new(self, 10)
+    pub fn u0_core_st_0(&mut self) -> U0_CORE_ST_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_0_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_W::new(self, 11)
+    pub fn u0_core_st_1(&mut self) -> U0_CORE_ST_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_1_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_W::new(self, 12)
+    pub fn u0_core_st_2(&mut self) -> U0_CORE_ST_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_2_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_W::new(self, 13)
+    pub fn u0_core_st_3(&mut self) -> U0_CORE_ST_3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_3_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_W::new(self, 14)
+    pub fn u0_core_st_4(&mut self) -> U0_CORE_ST_4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_CORE_ST_4_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_W::new(self, 15)
+    pub fn u0_trace_0(&mut self) -> U0_TRACE_0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_0_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_W::new(self, 16)
+    pub fn u0_trace_1(&mut self) -> U0_TRACE_1_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_1_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_W::new(self, 17)
+    pub fn u0_trace_2(&mut self) -> U0_TRACE_2_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_2_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_W::new(self, 18)
+    pub fn u0_trace_3(&mut self) -> U0_TRACE_3_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_3_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_W::new(self, 19)
+    pub fn u0_trace_4(&mut self) -> U0_TRACE_4_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_4_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_W::new(self, 20)
+    pub fn u0_trace_com(&mut self) -> U0_TRACE_COM_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_TRACE_COM_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_apb(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_APB_W::new(self, 21)
+    pub fn u0_img_gpu_apb(&mut self) -> U0_IMG_GPU_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_IMG_GPU_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_doma(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_DOMA_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_DOMA_W::new(self, 22)
+    pub fn u0_img_gpu_doma(&mut self) -> U0_IMG_GPU_DOMA_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_IMG_GPU_DOMA_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W::new(self, 23)
+    pub fn u0_noc_bus_apb(&mut self) -> U0_NOC_BUS_APB_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W::new(self, 24)
+    pub fn u0_noc_bus_axicfg0(&mut self) -> U0_NOC_BUS_AXICFG0_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_AXICFG0_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W::new(self, 25)
+    pub fn u0_noc_bus_cpu_axi(&mut self) -> U0_NOC_BUS_CPU_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_CPU_AXI_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W::new(self, 26)
+    pub fn u0_noc_bus_disp_axi(&mut self) -> U0_NOC_BUS_DISP_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_DISP_AXI_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W::new(self, 27)
+    pub fn u0_noc_bus_gpu_axi(&mut self) -> U0_NOC_BUS_GPU_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_GPU_AXI_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W::new(self, 28)
+    pub fn u0_noc_bus_isp_axi(&mut self) -> U0_NOC_BUS_ISP_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_ISP_AXI_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W::new(self, 29)
+    pub fn u0_noc_bus_ddrc(&mut self) -> U0_NOC_BUS_DDRC_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_DDRC_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W::new(self, 30)
+    pub fn u0_noc_bus_stg_axi(&mut self) -> U0_NOC_BUS_STG_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_STG_AXI_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<SOFT_RST_ADDR_SEL_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W::new(self, 31)
+    pub fn u0_noc_bus_vdec_axi(&mut self) -> U0_NOC_BUS_VDEC_AXI_W<SOFT_RST_ADDR_SEL_0_SPEC> {
+        U0_NOC_BUS_VDEC_AXI_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_1.rs
@@ -2,561 +2,490 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_1_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_1` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_1_SPEC>;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<'a, REG> =
-    crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_venc_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_venc_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_R = crate::BitReader;
+#[doc = "Field `u0_ddr_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_osc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_R = crate::BitReader;
+#[doc = "Field `u0_ddr_osc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_R = crate::BitReader;
+#[doc = "Field `u0_ddr_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_top` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_R = crate::BitReader;
+#[doc = "Field `u0_isp_top` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_R = crate::BitReader;
+#[doc = "Field `u0_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave511_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave511_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave511_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave511_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_aximem_128b_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_R = crate::BitReader;
+#[doc = "Field `u0_aximem_128b_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u1_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u2_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_intmem_rom_sram` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_R = crate::BitReader;
+#[doc = "Field `u0_intmem_rom_sram` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ref` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ref` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R::new((self.bits & 1) != 0)
+    pub fn u0_noc_bus_venc_axi(&self) -> U0_NOC_BUS_VENC_AXI_R {
+        U0_NOC_BUS_VENC_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_ahb(&self) -> U0_AXI_CFG1_DEC_AHB_R {
+        U0_AXI_CFG1_DEC_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_main(&self) -> U0_AXI_CFG1_DEC_MAIN_R {
+        U0_AXI_CFG1_DEC_MAIN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main(&self) -> U0_AXI_CFG0_DEC_MAIN_R {
+        U0_AXI_CFG0_DEC_MAIN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main_div(&self) -> U0_AXI_CFG0_DEC_MAIN_DIV_R {
+        U0_AXI_CFG0_DEC_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_hifi4(&self) -> U0_AXI_CFG0_DEC_HIFI4_R {
+        U0_AXI_CFG0_DEC_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(&self) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_R {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_ddr_axi(&self) -> U0_DDR_AXI_R {
+        U0_DDR_AXI_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(&self) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_R {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_ddr_osc(&self) -> U0_DDR_OSC_R {
+        U0_DDR_OSC_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(&self) -> RSTN_U0_DDR_SFT7110_RSTN_APB_R {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_ddr_apb(&self) -> U0_DDR_APB_R {
+        U0_DDR_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_isp_top(&self) -> U0_ISP_TOP_R {
+        U0_ISP_TOP_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_isp_axi(&self) -> U0_ISP_AXI_R {
+        U0_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_vout_src(&self) -> U0_VOUT_SRC_R {
+        U0_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_axi(&self) -> RSTN_U0_CODAJ12_RSTN_AXI_R {
-        RSTN_U0_CODAJ12_RSTN_AXI_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_codaj12_axi(&self) -> U0_CODAJ12_AXI_R {
+        U0_CODAJ12_AXI_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_core(&self) -> RSTN_U0_CODAJ12_RSTN_CORE_R {
-        RSTN_U0_CODAJ12_RSTN_CORE_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_codaj12_core(&self) -> U0_CODAJ12_CORE_R {
+        U0_CODAJ12_CORE_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_apb(&self) -> RSTN_U0_CODAJ12_RSTN_APB_R {
-        RSTN_U0_CODAJ12_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_codaj12_apb(&self) -> U0_CODAJ12_APB_R {
+        U0_CODAJ12_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_axi(&self) -> RSTN_U0_WAVE511_RSTN_AXI_R {
-        RSTN_U0_WAVE511_RSTN_AXI_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_wave511_axi(&self) -> U0_WAVE511_AXI_R {
+        U0_WAVE511_AXI_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_bpu(&self) -> RSTN_U0_WAVE511_RSTN_BPU_R {
-        RSTN_U0_WAVE511_RSTN_BPU_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_wave511_bpu(&self) -> U0_WAVE511_BPU_R {
+        U0_WAVE511_BPU_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_vce(&self) -> RSTN_U0_WAVE511_RSTN_VCE_R {
-        RSTN_U0_WAVE511_RSTN_VCE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_wave511_vce(&self) -> U0_WAVE511_VCE_R {
+        U0_WAVE511_VCE_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_apb(&self) -> RSTN_U0_WAVE511_RSTN_APB_R {
-        RSTN_U0_WAVE511_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_wave511_apb(&self) -> U0_WAVE511_APB_R {
+        U0_WAVE511_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_vdec_jpg_arb(&self) -> U0_VDEC_JPG_ARB_R {
+        U0_VDEC_JPG_ARB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_vdec_jpg_arb_main(&self) -> U0_VDEC_JPG_ARB_MAIN_R {
+        U0_VDEC_JPG_ARB_MAIN_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_aximem_128b_rstn_axi(&self) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_aximem_128b_axi(&self) -> U0_AXIMEM_128B_AXI_R {
+        U0_AXIMEM_128B_AXI_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_axi(&self) -> RSTN_U0_WAVE420L_RSTN_AXI_R {
-        RSTN_U0_WAVE420L_RSTN_AXI_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_wave420l_axi(&self) -> U0_WAVE420L_AXI_R {
+        U0_WAVE420L_AXI_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_bpu(&self) -> RSTN_U0_WAVE420L_RSTN_BPU_R {
-        RSTN_U0_WAVE420L_RSTN_BPU_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_wave420l_bpu(&self) -> U0_WAVE420L_BPU_R {
+        U0_WAVE420L_BPU_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_vce(&self) -> RSTN_U0_WAVE420L_RSTN_VCE_R {
-        RSTN_U0_WAVE420L_RSTN_VCE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_wave420l_vce(&self) -> U0_WAVE420L_VCE_R {
+        U0_WAVE420L_VCE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_apb(&self) -> RSTN_U0_WAVE420L_RSTN_APB_R {
-        RSTN_U0_WAVE420L_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_wave420l_apb(&self) -> U0_WAVE420L_APB_R {
+        U0_WAVE420L_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_aximem_128b_rstn_axi(&self) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_aximem(&self) -> U1_AXIMEM_R {
+        U1_AXIMEM_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_aximem_128b_rstn_axi(&self) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u2_aximem(&self) -> U2_AXIMEM_R {
+        U2_AXIMEM_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(&self) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_intmem_rom_sram(&self) -> U0_INTMEM_ROM_SRAM_R {
+        U0_INTMEM_ROM_SRAM_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_qspi_ahb(&self) -> U0_QSPI_AHB_R {
+        U0_QSPI_AHB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_APB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_qspi_apb(&self) -> U0_QSPI_APB_R {
+        U0_QSPI_APB_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(&self) -> RSTN_U0_CDNS_QSPI_RSTN_REF_R {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_qspi_ref(&self) -> U0_QSPI_REF_R {
+        U0_QSPI_REF_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &mut self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W::new(self, 0)
+    pub fn u0_noc_bus_venc_axi(&mut self) -> U0_NOC_BUS_VENC_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_NOC_BUS_VENC_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W::new(self, 1)
+    pub fn u0_axi_cfg1_dec_ahb(&mut self) -> U0_AXI_CFG1_DEC_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG1_DEC_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W::new(self, 2)
+    pub fn u0_axi_cfg1_dec_main(&mut self) -> U0_AXI_CFG1_DEC_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG1_DEC_MAIN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W::new(self, 3)
+    pub fn u0_axi_cfg0_dec_main(&mut self) -> U0_AXI_CFG0_DEC_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(
+    pub fn u0_axi_cfg0_dec_main_div(
         &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W::new(self, 4)
+    ) -> U0_AXI_CFG0_DEC_MAIN_DIV_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_DIV_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W::new(self, 5)
+    pub fn u0_axi_cfg0_dec_hifi4(&mut self) -> U0_AXI_CFG0_DEC_HIFI4_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXI_CFG0_DEC_HIFI4_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_W::new(self, 6)
+    pub fn u0_ddr_axi(&mut self) -> U0_DDR_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_AXI_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_W::new(self, 7)
+    pub fn u0_ddr_osc(&mut self) -> U0_DDR_OSC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_OSC_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_W::new(self, 8)
+    pub fn u0_ddr_apb(&mut self) -> U0_DDR_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_DDR_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W::new(self, 9)
+    pub fn u0_isp_top(&mut self) -> U0_ISP_TOP_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_ISP_TOP_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W::new(self, 10)
+    pub fn u0_isp_axi(&mut self) -> U0_ISP_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_ISP_AXI_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &mut self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W::new(self, 11)
+    pub fn u0_vout_src(&mut self) -> U0_VOUT_SRC_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VOUT_SRC_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_AXI_W::new(self, 12)
+    pub fn u0_codaj12_axi(&mut self) -> U0_CODAJ12_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_AXI_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_core(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_CORE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_CORE_W::new(self, 13)
+    pub fn u0_codaj12_core(&mut self) -> U0_CODAJ12_CORE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_CORE_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_APB_W::new(self, 14)
+    pub fn u0_codaj12_apb(&mut self) -> U0_CODAJ12_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_CODAJ12_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_AXI_W::new(self, 15)
+    pub fn u0_wave511_axi(&mut self) -> U0_WAVE511_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_AXI_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_BPU_W::new(self, 16)
+    pub fn u0_wave511_bpu(&mut self) -> U0_WAVE511_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_BPU_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_VCE_W::new(self, 17)
+    pub fn u0_wave511_vce(&mut self) -> U0_WAVE511_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_VCE_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_APB_W::new(self, 18)
+    pub fn u0_wave511_apb(&mut self) -> U0_WAVE511_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE511_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W::new(self, 19)
+    pub fn u0_vdec_jpg_arb(&mut self) -> U0_VDEC_JPG_ARB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VDEC_JPG_ARB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W::new(self, 20)
+    pub fn u0_vdec_jpg_arb_main(&mut self) -> U0_VDEC_JPG_ARB_MAIN_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_VDEC_JPG_ARB_MAIN_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_W::new(self, 21)
+    pub fn u0_aximem_128b_axi(&mut self) -> U0_AXIMEM_128B_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_AXIMEM_128B_AXI_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_AXI_W::new(self, 22)
+    pub fn u0_wave420l_axi(&mut self) -> U0_WAVE420L_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_AXI_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_BPU_W::new(self, 23)
+    pub fn u0_wave420l_bpu(&mut self) -> U0_WAVE420L_BPU_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_BPU_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_VCE_W::new(self, 24)
+    pub fn u0_wave420l_vce(&mut self) -> U0_WAVE420L_VCE_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_VCE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_APB_W::new(self, 25)
+    pub fn u0_wave420l_apb(&mut self) -> U0_WAVE420L_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_WAVE420L_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_W::new(self, 26)
+    pub fn u1_aximem(&mut self) -> U1_AXIMEM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U1_AXIMEM_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_W::new(self, 27)
+    pub fn u2_aximem(&mut self) -> U2_AXIMEM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U2_AXIMEM_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(
-        &mut self,
-    ) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W::new(self, 28)
+    pub fn u0_intmem_rom_sram(&mut self) -> U0_INTMEM_ROM_SRAM_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_INTMEM_ROM_SRAM_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_W::new(self, 29)
+    pub fn u0_qspi_ahb(&mut self) -> U0_QSPI_AHB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_AHB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_W::new(self, 30)
+    pub fn u0_qspi_apb(&mut self) -> U0_QSPI_APB_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_APB_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_REF_W<SOFT_RST_ADDR_SEL_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_W::new(self, 31)
+    pub fn u0_qspi_ref(&mut self) -> U0_QSPI_REF_W<SOFT_RST_ADDR_SEL_1_SPEC> {
+        U0_QSPI_REF_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_2.rs
@@ -2,510 +2,488 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_2_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_2` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_2_SPEC>;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u6_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sdio_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_R = crate::BitReader;
+#[doc = "Field `u0_sdio_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_sdi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_R = crate::BitReader;
+#[doc = "Field `u1_sdi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64_hresetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64_hresetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u1_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u2_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u3_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u4_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u5_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u6_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u2_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u3_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u4_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u5_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u6_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_R = crate::BitReader;
+#[doc = "Field `u0_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u0_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_R = crate::BitReader;
+#[doc = "Field `u1_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u1_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_R = crate::BitReader;
+#[doc = "Field `u2_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u2_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_R = crate::BitReader;
+#[doc = "Field `u3_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u3_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_R = crate::BitReader;
+#[doc = "Field `u4_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u4_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_R = crate::BitReader;
+#[doc = "Field `u5_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u6_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spdif_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_R = crate::BitReader;
+#[doc = "Field `u0_spdif_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sdio_rstn_ahb(&self) -> RSTN_U0_SDIO_RSTN_AHB_R {
-        RSTN_U0_SDIO_RSTN_AHB_R::new((self.bits & 1) != 0)
+    pub fn u0_sdio_ahb(&self) -> U0_SDIO_AHB_R {
+        U0_SDIO_AHB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_sdi_rstn_ahb(&self) -> RSTN_U1_SDI_RSTN_AHB_R {
-        RSTN_U1_SDI_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_sdi_ahb(&self) -> U1_SDI_AHB_R {
+        U1_SDI_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(&self) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_R {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_gmac5_axi64(&self) -> U1_GMAC5_AXI64_R {
+        U1_GMAC5_AXI64_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(&self) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_R {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u1_gmac5_axi64_hresetn(&self) -> U1_GMAC5_AXI64_HRESETN_R {
+        U1_GMAC5_AXI64_HRESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_mailbox_presetn(&self) -> RSTN_U0_MAILBOX_PRESETN_R {
-        RSTN_U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_mailbox_presetn(&self) -> U0_MAILBOX_PRESETN_R {
+        U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ssp_spi_rstn_apb(&self) -> RSTN_U0_SSP_SPI_RSTN_APB_R {
-        RSTN_U0_SSP_SPI_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_spi_apb(&self) -> U0_SPI_APB_R {
+        U0_SPI_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_ssp_spi_rstn_apb(&self) -> RSTN_U1_SSP_SPI_RSTN_APB_R {
-        RSTN_U1_SSP_SPI_RSTN_APB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u1_spi_apb(&self) -> U1_SPI_APB_R {
+        U1_SPI_APB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_ssp_spi_rstn_apb(&self) -> RSTN_U2_SSP_SPI_RSTN_APB_R {
-        RSTN_U2_SSP_SPI_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u2_spi_apb(&self) -> U2_SPI_APB_R {
+        U2_SPI_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_ssp_spi_rstn_apb(&self) -> RSTN_U3_SSP_SPI_RSTN_APB_R {
-        RSTN_U3_SSP_SPI_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u3_spi_apb(&self) -> U3_SPI_APB_R {
+        U3_SPI_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_ssp_spi_rstn_apb(&self) -> RSTN_U4_SSP_SPI_RSTN_APB_R {
-        RSTN_U4_SSP_SPI_RSTN_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u4_spi_apb(&self) -> U4_SPI_APB_R {
+        U4_SPI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_ssp_spi_rstn_apb(&self) -> RSTN_U5_SSP_SPI_RSTN_APB_R {
-        RSTN_U5_SSP_SPI_RSTN_APB_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u5_spi_apb(&self) -> U5_SPI_APB_R {
+        U5_SPI_APB_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_ssp_spi_rstn_apb(&self) -> RSTN_U6_SSP_SPI_RSTN_APB_R {
-        RSTN_U6_SSP_SPI_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u6_spi_apb(&self) -> U6_SPI_APB_R {
+        U6_SPI_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2c_rstn_apb(&self) -> RSTN_U0_I2C_RSTN_APB_R {
-        RSTN_U0_I2C_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_i2c_apb(&self) -> U0_I2C_APB_R {
+        U0_I2C_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2c_rstn_apb(&self) -> RSTN_U1_I2C_RSTN_APB_R {
-        RSTN_U1_I2C_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u1_i2c_apb(&self) -> U1_I2C_APB_R {
+        U1_I2C_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_i2c_rstn_apb(&self) -> RSTN_U2_I2C_RSTN_APB_R {
-        RSTN_U2_I2C_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u2_i2c_apb(&self) -> U2_I2C_APB_R {
+        U2_I2C_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_i2c_rstn_apb(&self) -> RSTN_U3_I2C_RSTN_APB_R {
-        RSTN_U3_I2C_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u3_i2c_apb(&self) -> U3_I2C_APB_R {
+        U3_I2C_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_i2c_rstn_apb(&self) -> RSTN_U4_I2C_RSTN_APB_R {
-        RSTN_U4_I2C_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u4_i2c_apb(&self) -> U4_I2C_APB_R {
+        U4_I2C_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_i2c_rstn_apb(&self) -> RSTN_U5_I2C_RSTN_APB_R {
-        RSTN_U5_I2C_RSTN_APB_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u5_i2c_apb(&self) -> U5_I2C_APB_R {
+        U5_I2C_APB_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_i2c_rstn_apb(&self) -> RSTN_U6_I2C_RSTN_APB_R {
-        RSTN_U6_I2C_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u6_i2c_apb(&self) -> U6_I2C_APB_R {
+        U6_I2C_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_apb(&self) -> RSTN_U0_UART_RSTN_APB_R {
-        RSTN_U0_UART_RSTN_APB_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_uart_apb(&self) -> U0_UART_APB_R {
+        U0_UART_APB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_core(&self) -> RSTN_U0_UART_RSTN_CORE_R {
-        RSTN_U0_UART_RSTN_CORE_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_uart_core(&self) -> U0_UART_CORE_R {
+        U0_UART_CORE_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_apb(&self) -> RSTN_U1_UART_RSTN_APB_R {
-        RSTN_U1_UART_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_uart_apb(&self) -> U1_UART_APB_R {
+        U1_UART_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_core(&self) -> RSTN_U1_UART_RSTN_CORE_R {
-        RSTN_U1_UART_RSTN_CORE_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_uart_core(&self) -> U1_UART_CORE_R {
+        U1_UART_CORE_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_apb(&self) -> RSTN_U2_UART_RSTN_APB_R {
-        RSTN_U2_UART_RSTN_APB_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u2_uart_apb(&self) -> U2_UART_APB_R {
+        U2_UART_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_core(&self) -> RSTN_U2_UART_RSTN_CORE_R {
-        RSTN_U2_UART_RSTN_CORE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u2_uart_core(&self) -> U2_UART_CORE_R {
+        U2_UART_CORE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_apb(&self) -> RSTN_U3_UART_RSTN_APB_R {
-        RSTN_U3_UART_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u3_uart_apb(&self) -> U3_UART_APB_R {
+        U3_UART_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_core(&self) -> RSTN_U3_UART_RSTN_CORE_R {
-        RSTN_U3_UART_RSTN_CORE_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u3_uart_core(&self) -> U3_UART_CORE_R {
+        U3_UART_CORE_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_apb(&self) -> RSTN_U4_UART_RSTN_APB_R {
-        RSTN_U4_UART_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u4_uart_apb(&self) -> U4_UART_APB_R {
+        U4_UART_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_core(&self) -> RSTN_U4_UART_RSTN_CORE_R {
-        RSTN_U4_UART_RSTN_CORE_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u4_uart_core(&self) -> U4_UART_CORE_R {
+        U4_UART_CORE_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_uart_rstn_apb(&self) -> RSTN_U5_UART_RSTN_APB_R {
-        RSTN_U5_UART_RSTN_APB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u5_uart_apb(&self) -> U5_UART_APB_R {
+        U5_UART_APB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_uart_rstn_core(&self) -> RSTN_U6_UART_RSTN_CORE_R {
-        RSTN_U6_UART_RSTN_CORE_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u6_uart_core(&self) -> U6_UART_CORE_R {
+        U6_UART_CORE_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(&self) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_R {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_spdif_apb(&self) -> U0_SPDIF_APB_R {
+        U0_SPDIF_APB_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sdio_rstn_ahb(&mut self) -> RSTN_U0_SDIO_RSTN_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_SDIO_RSTN_AHB_W::new(self, 0)
+    pub fn u0_sdio_ahb(&mut self) -> U0_SDIO_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SDIO_AHB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_sdi_rstn_ahb(&mut self) -> RSTN_U1_SDI_RSTN_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_SDI_RSTN_AHB_W::new(self, 1)
+    pub fn u1_sdi_ahb(&mut self) -> U1_SDI_AHB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_SDI_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_W::new(self, 2)
+    pub fn u1_gmac5_axi64(&mut self) -> U1_GMAC5_AXI64_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_GMAC5_AXI64_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_W::new(self, 3)
+    pub fn u1_gmac5_axi64_hresetn(&mut self) -> U1_GMAC5_AXI64_HRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_GMAC5_AXI64_HRESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_mailbox_presetn(
-        &mut self,
-    ) -> RSTN_U0_MAILBOX_PRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_MAILBOX_PRESETN_W::new(self, 4)
+    pub fn u0_mailbox_presetn(&mut self) -> U0_MAILBOX_PRESETN_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_MAILBOX_PRESETN_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_SSP_SPI_RSTN_APB_W::new(self, 5)
+    pub fn u0_spi_apb(&mut self) -> U0_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SPI_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_SSP_SPI_RSTN_APB_W::new(self, 6)
+    pub fn u1_spi_apb(&mut self) -> U1_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_SPI_APB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U2_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_SSP_SPI_RSTN_APB_W::new(self, 7)
+    pub fn u2_spi_apb(&mut self) -> U2_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_SPI_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U3_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_SSP_SPI_RSTN_APB_W::new(self, 8)
+    pub fn u3_spi_apb(&mut self) -> U3_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_SPI_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U4_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_SSP_SPI_RSTN_APB_W::new(self, 9)
+    pub fn u4_spi_apb(&mut self) -> U4_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_SPI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U5_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_SSP_SPI_RSTN_APB_W::new(self, 10)
+    pub fn u5_spi_apb(&mut self) -> U5_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_SPI_APB_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U6_SSP_SPI_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_SSP_SPI_RSTN_APB_W::new(self, 11)
+    pub fn u6_spi_apb(&mut self) -> U6_SPI_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_SPI_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2c_rstn_apb(&mut self) -> RSTN_U0_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_I2C_RSTN_APB_W::new(self, 12)
+    pub fn u0_i2c_apb(&mut self) -> U0_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_I2C_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2c_rstn_apb(&mut self) -> RSTN_U1_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_I2C_RSTN_APB_W::new(self, 13)
+    pub fn u1_i2c_apb(&mut self) -> U1_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_I2C_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_i2c_rstn_apb(&mut self) -> RSTN_U2_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_I2C_RSTN_APB_W::new(self, 14)
+    pub fn u2_i2c_apb(&mut self) -> U2_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_I2C_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_i2c_rstn_apb(&mut self) -> RSTN_U3_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_I2C_RSTN_APB_W::new(self, 15)
+    pub fn u3_i2c_apb(&mut self) -> U3_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_I2C_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_i2c_rstn_apb(&mut self) -> RSTN_U4_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_I2C_RSTN_APB_W::new(self, 16)
+    pub fn u4_i2c_apb(&mut self) -> U4_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_I2C_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_i2c_rstn_apb(&mut self) -> RSTN_U5_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_I2C_RSTN_APB_W::new(self, 17)
+    pub fn u5_i2c_apb(&mut self) -> U5_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_I2C_APB_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_i2c_rstn_apb(&mut self) -> RSTN_U6_I2C_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_I2C_RSTN_APB_W::new(self, 18)
+    pub fn u6_i2c_apb(&mut self) -> U6_I2C_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_I2C_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_apb(&mut self) -> RSTN_U0_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_UART_RSTN_APB_W::new(self, 19)
+    pub fn u0_uart_apb(&mut self) -> U0_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_UART_APB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_core(&mut self) -> RSTN_U0_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_UART_RSTN_CORE_W::new(self, 20)
+    pub fn u0_uart_core(&mut self) -> U0_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_UART_CORE_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_apb(&mut self) -> RSTN_U1_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_UART_RSTN_APB_W::new(self, 21)
+    pub fn u1_uart_apb(&mut self) -> U1_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_UART_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_core(&mut self) -> RSTN_U1_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U1_UART_RSTN_CORE_W::new(self, 22)
+    pub fn u1_uart_core(&mut self) -> U1_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U1_UART_CORE_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_apb(&mut self) -> RSTN_U2_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_UART_RSTN_APB_W::new(self, 23)
+    pub fn u2_uart_apb(&mut self) -> U2_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_UART_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_core(&mut self) -> RSTN_U2_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U2_UART_RSTN_CORE_W::new(self, 24)
+    pub fn u2_uart_core(&mut self) -> U2_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U2_UART_CORE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_apb(&mut self) -> RSTN_U3_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_UART_RSTN_APB_W::new(self, 25)
+    pub fn u3_uart_apb(&mut self) -> U3_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_UART_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_core(&mut self) -> RSTN_U3_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U3_UART_RSTN_CORE_W::new(self, 26)
+    pub fn u3_uart_core(&mut self) -> U3_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U3_UART_CORE_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_apb(&mut self) -> RSTN_U4_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_UART_RSTN_APB_W::new(self, 27)
+    pub fn u4_uart_apb(&mut self) -> U4_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_UART_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_core(&mut self) -> RSTN_U4_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U4_UART_RSTN_CORE_W::new(self, 28)
+    pub fn u4_uart_core(&mut self) -> U4_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U4_UART_CORE_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_uart_rstn_apb(&mut self) -> RSTN_U5_UART_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U5_UART_RSTN_APB_W::new(self, 29)
+    pub fn u5_uart_apb(&mut self) -> U5_UART_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U5_UART_APB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_uart_rstn_core(&mut self) -> RSTN_U6_UART_RSTN_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U6_UART_RSTN_CORE_W::new(self, 30)
+    pub fn u6_uart_core(&mut self) -> U6_UART_CORE_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U6_UART_CORE_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_W::new(self, 31)
+    pub fn u0_spdif_apb(&mut self) -> U0_SPDIF_APB_W<SOFT_RST_ADDR_SEL_2_SPEC> {
+        U0_SPDIF_APB_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_3.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/soft_rst_addr_sel_3.rs
@@ -2,518 +2,458 @@
 pub type R = crate::R<SOFT_RST_ADDR_SEL_3_SPEC>;
 #[doc = "Register `soft_rst_addr_sel_3` writer"]
 pub type W = crate::W<SOFT_RST_ADDR_SEL_3_SPEC>;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwmdac_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwmdac_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_dmic` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_dmic` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_tdm` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_tdm` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwm_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwm_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_can` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_can` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_int_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_int_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag_rst` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_R = crate::BitReader;
+#[doc = "Field `u0_jtag_rst` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwmdac_rstn_apb(&self) -> RSTN_U0_PWMDAC_RSTN_APB_R {
-        RSTN_U0_PWMDAC_RSTN_APB_R::new((self.bits & 1) != 0)
+    pub fn u0_pwmdac_apb(&self) -> U0_PWMDAC_APB_R {
+        U0_PWMDAC_APB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(&self) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_R {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pdm_4mic_dmic(&self) -> U0_PDM_4MIC_DMIC_R {
+        U0_PDM_4MIC_DMIC_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(&self) -> RSTN_U0_PDM_4MIC_RSTN_APB_R {
-        RSTN_U0_PDM_4MIC_RSTN_APB_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pdm_4mic_apb(&self) -> U0_PDM_4MIC_APB_R {
+        U0_PDM_4MIC_APB_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(&self) -> RSTN_U0_I2SRX_3CH_RSTN_APB_R {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_i2srx_apb(&self) -> U0_I2SRX_APB_R {
+        U0_I2SRX_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(&self) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_R {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_i2srx_bclk(&self) -> U0_I2SRX_BCLK_R {
+        U0_I2SRX_BCLK_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(&self) -> RSTN_U0_I2STX_4CH_RSTN_APB_R {
-        RSTN_U0_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_i2stx_apb(&self) -> U0_I2STX_APB_R {
+        U0_I2STX_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(&self) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_i2stx_bclk(&self) -> U0_I2STX_BCLK_R {
+        U0_I2STX_BCLK_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(&self) -> RSTN_U1_I2STX_4CH_RSTN_APB_R {
-        RSTN_U1_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_i2stx_apb(&self) -> U1_I2STX_APB_R {
+        U1_I2STX_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(&self) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_i2stx_bclk(&self) -> U1_I2STX_BCLK_R {
+        U1_I2STX_BCLK_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(&self) -> RSTN_U0_TDM16SLOT_RSTN_AHB_R {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_tdm16slot_ahb(&self) -> U0_TDM16SLOT_AHB_R {
+        U0_TDM16SLOT_AHB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(&self) -> RSTN_U0_TDM16SLOT_RSTN_TDM_R {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_tdm16slot_tdm(&self) -> U0_TDM16SLOT_TDM_R {
+        U0_TDM16SLOT_TDM_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_apb(&self) -> RSTN_U0_TDM16SLOT_RSTN_APB_R {
-        RSTN_U0_TDM16SLOT_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_tdm16slot_apb(&self) -> U0_TDM16SLOT_APB_R {
+        U0_TDM16SLOT_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(&self) -> RSTN_U0_PWM_8CH_RSTN_APB_R {
-        RSTN_U0_PWM_8CH_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pwm_apb(&self) -> U0_PWM_APB_R {
+        U0_PWM_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(&self) -> RSTN_U0_DSKIT_WDT_RSTN_APB_R {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_dskit_wdt_rstn_apb(&self) -> U0_DSKIT_WDT_RSTN_APB_R {
+        U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(&self) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_R {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_dskit_wdt(&self) -> U0_DSKIT_WDT_R {
+        U0_DSKIT_WDT_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_apb(&self) -> RSTN_U0_CAN_CTRL_RSTN_APB_R {
-        RSTN_U0_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_can_ctrl_apb(&self) -> U0_CAN_CTRL_APB_R {
+        U0_CAN_CTRL_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_can(&self) -> RSTN_U0_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_can_ctrl(&self) -> U0_CAN_CTRL_R {
+        U0_CAN_CTRL_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_timer(&self) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_can_ctrl_timer(&self) -> U0_CAN_CTRL_TIMER_R {
+        U0_CAN_CTRL_TIMER_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_apb(&self) -> RSTN_U1_CAN_CTRL_RSTN_APB_R {
-        RSTN_U1_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_can_ctrl_apb(&self) -> U1_CAN_CTRL_APB_R {
+        U1_CAN_CTRL_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_can(&self) -> RSTN_U1_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_can_ctrl_can(&self) -> U1_CAN_CTRL_CAN_R {
+        U1_CAN_CTRL_CAN_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_timer(&self) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_can_ctrl_timer(&self) -> U1_CAN_CTRL_TIMER_R {
+        U1_CAN_CTRL_TIMER_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_apb(&self) -> RSTN_U0_SI5_TIMER_RSTN_APB_R {
-        RSTN_U0_SI5_TIMER_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_si5_timer_apb(&self) -> U0_SI5_TIMER_APB_R {
+        U0_SI5_TIMER_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer0(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_si5_timer_0(&self) -> U0_SI5_TIMER_0_R {
+        U0_SI5_TIMER_0_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_time10(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_si5_timer_1(&self) -> U0_SI5_TIMER_1_R {
+        U0_SI5_TIMER_1_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer2(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_si5_timer_2(&self) -> U0_SI5_TIMER_2_R {
+        U0_SI5_TIMER_2_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer3(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_si5_timer_3(&self) -> U0_SI5_TIMER_3_R {
+        U0_SI5_TIMER_3_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_int_ctrl_rstn_apb(&self) -> RSTN_U0_INT_CTRL_RSTN_APB_R {
-        RSTN_U0_INT_CTRL_RSTN_APB_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_int_ctrl_apb(&self) -> U0_INT_CTRL_APB_R {
+        U0_INT_CTRL_APB_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_apb(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_temp_sensor_apb(&self) -> U0_TEMP_SENSOR_APB_R {
+        U0_TEMP_SENSOR_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_temp(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_temp_sensor(&self) -> U0_TEMP_SENSOR_R {
+        U0_TEMP_SENSOR_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag_certification_rst_n(&self) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_R {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_jtag_rst(&self) -> U0_JTAG_RST_R {
+        U0_JTAG_RST_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwmdac_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWMDAC_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PWMDAC_RSTN_APB_W::new(self, 0)
+    pub fn u0_pwmdac_apb(&mut self) -> U0_PWMDAC_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PWMDAC_APB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_W::new(self, 1)
+    pub fn u0_pdm_4mic_dmic(&mut self) -> U0_PDM_4MIC_DMIC_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PDM_4MIC_DMIC_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_APB_W::new(self, 2)
+    pub fn u0_pdm_4mic_apb(&mut self) -> U0_PDM_4MIC_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PDM_4MIC_APB_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_W::new(self, 3)
+    pub fn u0_i2srx_apb(&mut self) -> U0_I2SRX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2SRX_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_W::new(self, 4)
+    pub fn u0_i2srx_bclk(&mut self) -> U0_I2SRX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2SRX_BCLK_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_APB_W::new(self, 5)
+    pub fn u0_i2stx_apb(&mut self) -> U0_I2STX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2STX_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_W::new(self, 6)
+    pub fn u0_i2stx_bclk(&mut self) -> U0_I2STX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_I2STX_BCLK_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_APB_W::new(self, 7)
+    pub fn u1_i2stx_apb(&mut self) -> U1_I2STX_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_I2STX_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_W::new(self, 8)
+    pub fn u1_i2stx_bclk(&mut self) -> U1_I2STX_BCLK_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_I2STX_BCLK_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_AHB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_W::new(self, 9)
+    pub fn u0_tdm16slot_ahb(&mut self) -> U0_TDM16SLOT_AHB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_AHB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_TDM_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_W::new(self, 10)
+    pub fn u0_tdm16slot_tdm(&mut self) -> U0_TDM16SLOT_TDM_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_TDM_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_APB_W::new(self, 11)
+    pub fn u0_tdm16slot_apb(&mut self) -> U0_TDM16SLOT_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TDM16SLOT_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWM_8CH_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_PWM_8CH_RSTN_APB_W::new(self, 12)
+    pub fn u0_pwm_apb(&mut self) -> U0_PWM_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_PWM_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
+    pub fn u0_dskit_wdt_rstn_apb(&mut self) -> U0_DSKIT_WDT_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_W::new(self, 14)
+    pub fn u0_dskit_wdt(&mut self) -> U0_DSKIT_WDT_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_DSKIT_WDT_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_APB_W::new(self, 15)
+    pub fn u0_can_ctrl_apb(&mut self) -> U0_CAN_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_W::new(self, 16)
+    pub fn u0_can_ctrl(&mut self) -> U0_CAN_CTRL_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_W::new(self, 17)
+    pub fn u0_can_ctrl_timer(&mut self) -> U0_CAN_CTRL_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_CAN_CTRL_TIMER_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_APB_W::new(self, 18)
+    pub fn u1_can_ctrl_apb(&mut self) -> U1_CAN_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_W::new(self, 19)
+    pub fn u1_can_ctrl_can(&mut self) -> U1_CAN_CTRL_CAN_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_CAN_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_W::new(self, 20)
+    pub fn u1_can_ctrl_timer(&mut self) -> U1_CAN_CTRL_TIMER_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U1_CAN_CTRL_TIMER_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_APB_W::new(self, 21)
+    pub fn u0_si5_timer_apb(&mut self) -> U0_SI5_TIMER_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer0(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_W::new(self, 22)
+    pub fn u0_si5_timer_0(&mut self) -> U0_SI5_TIMER_0_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_0_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_time10(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_W::new(self, 23)
+    pub fn u0_si5_timer_1(&mut self) -> U0_SI5_TIMER_1_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_1_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer2(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_W::new(self, 24)
+    pub fn u0_si5_timer_2(&mut self) -> U0_SI5_TIMER_2_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_2_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer3(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_W::new(self, 25)
+    pub fn u0_si5_timer_3(&mut self) -> U0_SI5_TIMER_3_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_SI5_TIMER_3_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_int_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_INT_CTRL_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_INT_CTRL_RSTN_APB_W::new(self, 26)
+    pub fn u0_int_ctrl_apb(&mut self) -> U0_INT_CTRL_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_INT_CTRL_APB_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_W::new(self, 27)
+    pub fn u0_temp_sensor_apb(&mut self) -> U0_TEMP_SENSOR_APB_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TEMP_SENSOR_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_temp(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W::new(self, 28)
+    pub fn u0_temp_sensor(&mut self) -> U0_TEMP_SENSOR_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_TEMP_SENSOR_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag_certification_rst_n(
-        &mut self,
-    ) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_W<SOFT_RST_ADDR_SEL_3_SPEC> {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_W::new(self, 29)
+    pub fn u0_jtag_rst(&mut self) -> U0_JTAG_RST_W<SOFT_RST_ADDR_SEL_3_SPEC> {
+        U0_JTAG_RST_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_0.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_0.rs
@@ -2,570 +2,488 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_0_SPEC>;
 #[doc = "Register `syscrg_rst_status_0` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_0_SPEC>;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_bus` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_debug_reset` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_DEBUG_RESET_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core0_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core1_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core2_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core3_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_rst_core4_st` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst1` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST1_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_rst4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_RST4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_trace_com_rst` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_R = crate::BitReader;
-#[doc = "Field `rst_u0_img_gpu_rstn_doma` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_IMG_GPU_RSTN_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag2apb_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_jtag2apb_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG2APB_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_syscon_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_syscon_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_SYSCON_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sys_iomux_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_sys_iomux_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SYS_IOMUX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_bus` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_R = crate::BitReader;
+#[doc = "Field `u0_bus` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_BUS_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_debug` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_R = crate::BitReader;
+#[doc = "Field `u0_debug` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DEBUG_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_R = crate::BitReader;
+#[doc = "Field `u0_core_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_R = crate::BitReader;
+#[doc = "Field `u0_core_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_R = crate::BitReader;
+#[doc = "Field `u0_core_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_R = crate::BitReader;
+#[doc = "Field `u0_core3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_R = crate::BitReader;
+#[doc = "Field `u0_core4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_R = crate::BitReader;
+#[doc = "Field `u0_core_st_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_R = crate::BitReader;
+#[doc = "Field `u0_core_st_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_R = crate::BitReader;
+#[doc = "Field `u0_core_st_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_R = crate::BitReader;
+#[doc = "Field `u0_core_st_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_core_st_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_R = crate::BitReader;
+#[doc = "Field `u0_core_st_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CORE_ST_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_R = crate::BitReader;
+#[doc = "Field `u0_trace_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_R = crate::BitReader;
+#[doc = "Field `u0_trace_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_R = crate::BitReader;
+#[doc = "Field `u0_trace_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_R = crate::BitReader;
+#[doc = "Field `u0_trace_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_R = crate::BitReader;
+#[doc = "Field `u0_trace_4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_trace_com` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_R = crate::BitReader;
+#[doc = "Field `u0_trace_com` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TRACE_COM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_img_gpu_doma` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_R = crate::BitReader;
+#[doc = "Field `u0_img_gpu_doma` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_IMG_GPU_DOMA_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_axicfg0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_axicfg0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_AXICFG0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_cpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_cpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_CPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_disp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_disp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_gpu_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_gpu_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_GPU_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_ddrc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_ddrc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_DDRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_stg_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_stg_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_STG_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_vdec_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_vdec_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VDEC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag2apb_presetn(&self) -> RSTN_U0_JTAG2APB_PRESETN_R {
-        RSTN_U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
+    pub fn u0_jtag2apb_presetn(&self) -> U0_JTAG2APB_PRESETN_R {
+        U0_JTAG2APB_PRESETN_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_syscon_presetn(&self) -> RSTN_U0_SYS_SYSCON_PRESETN_R {
-        RSTN_U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_sys_syscon_presetn(&self) -> U0_SYS_SYSCON_PRESETN_R {
+        U0_SYS_SYSCON_PRESETN_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sys_iomux_presetn(&self) -> RSTN_U0_SYS_IOMUX_PRESETN_R {
-        RSTN_U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_sys_iomux_presetn(&self) -> U0_SYS_IOMUX_PRESETN_R {
+        U0_SYS_IOMUX_PRESETN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(&self) -> RST_U0_U7MC_SFT7110_RST_BUS_R {
-        RST_U0_U7MC_SFT7110_RST_BUS_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_bus(&self) -> U0_BUS_R {
+        U0_BUS_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(&self) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_R {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_debug(&self) -> U0_DEBUG_R {
+        U0_DEBUG_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_core_0(&self) -> U0_CORE_0_R {
+        U0_CORE_0_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_core_1(&self) -> U0_CORE_1_R {
+        U0_CORE_1_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_core_2(&self) -> U0_CORE_2_R {
+        U0_CORE_2_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_core3(&self) -> U0_CORE3_R {
+        U0_CORE3_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_core4(&self) -> U0_CORE4_R {
+        U0_CORE4_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_core_st_0(&self) -> U0_CORE_ST_0_R {
+        U0_CORE_ST_0_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_core_st_1(&self) -> U0_CORE_ST_1_R {
+        U0_CORE_ST_1_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_core_st_2(&self) -> U0_CORE_ST_2_R {
+        U0_CORE_ST_2_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_core_st_3(&self) -> U0_CORE_ST_3_R {
+        U0_CORE_ST_3_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(&self) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_R {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_core_st_4(&self) -> U0_CORE_ST_4_R {
+        U0_CORE_ST_4_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST0_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_trace_0(&self) -> U0_TRACE_0_R {
+        U0_TRACE_0_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST1_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_trace_1(&self) -> U0_TRACE_1_R {
+        U0_TRACE_1_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST2_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_trace_2(&self) -> U0_TRACE_2_R {
+        U0_TRACE_2_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST3_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_trace_3(&self) -> U0_TRACE_3_R {
+        U0_TRACE_3_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(&self) -> RST_U0_U7MC_SFT7110_TRACE_RST4_R {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_trace_4(&self) -> U0_TRACE_4_R {
+        U0_TRACE_4_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(&self) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_R {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_trace_com(&self) -> U0_TRACE_COM_R {
+        U0_TRACE_COM_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_apb(&self) -> RST_U0_IMG_GPU_RSTN_APB_R {
-        RST_U0_IMG_GPU_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_img_gpu_apb(&self) -> U0_IMG_GPU_APB_R {
+        U0_IMG_GPU_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_img_gpu_rstn_doma(&self) -> RST_U0_IMG_GPU_RSTN_DOMA_R {
-        RST_U0_IMG_GPU_RSTN_DOMA_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_img_gpu_doma(&self) -> U0_IMG_GPU_DOMA_R {
+        U0_IMG_GPU_DOMA_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_noc_bus_apb(&self) -> U0_NOC_BUS_APB_R {
+        U0_NOC_BUS_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_noc_bus_axicfg0(&self) -> U0_NOC_BUS_AXICFG0_R {
+        U0_NOC_BUS_AXICFG0_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_noc_bus_cpu_axi(&self) -> U0_NOC_BUS_CPU_AXI_R {
+        U0_NOC_BUS_CPU_AXI_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_noc_bus_disp_axi(&self) -> U0_NOC_BUS_DISP_AXI_R {
+        U0_NOC_BUS_DISP_AXI_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_noc_bus_gpu_axi(&self) -> U0_NOC_BUS_GPU_AXI_R {
+        U0_NOC_BUS_GPU_AXI_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_noc_bus_isp_axi(&self) -> U0_NOC_BUS_ISP_AXI_R {
+        U0_NOC_BUS_ISP_AXI_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_noc_bus_ddrc(&self) -> U0_NOC_BUS_DDRC_R {
+        U0_NOC_BUS_DDRC_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_noc_bus_stg_axi(&self) -> U0_NOC_BUS_STG_AXI_R {
+        U0_NOC_BUS_STG_AXI_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_noc_bus_vdec_axi(&self) -> U0_NOC_BUS_VDEC_AXI_R {
+        U0_NOC_BUS_VDEC_AXI_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag2apb_presetn(
-        &mut self,
-    ) -> RSTN_U0_JTAG2APB_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_JTAG2APB_PRESETN_W::new(self, 0)
+    pub fn u0_jtag2apb_presetn(&mut self) -> U0_JTAG2APB_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_JTAG2APB_PRESETN_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_syscon_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_SYSCON_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_SYS_SYSCON_PRESETN_W::new(self, 1)
+    pub fn u0_sys_syscon_presetn(&mut self) -> U0_SYS_SYSCON_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_SYS_SYSCON_PRESETN_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sys_iomux_presetn(
-        &mut self,
-    ) -> RSTN_U0_SYS_IOMUX_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RSTN_U0_SYS_IOMUX_PRESETN_W::new(self, 2)
+    pub fn u0_sys_iomux_presetn(&mut self) -> U0_SYS_IOMUX_PRESETN_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_SYS_IOMUX_PRESETN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_bus(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_BUS_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_BUS_W::new(self, 3)
+    pub fn u0_bus(&mut self) -> U0_BUS_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_BUS_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_debug_reset(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_DEBUG_RESET_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_DEBUG_RESET_W::new(self, 4)
+    pub fn u0_debug(&mut self) -> U0_DEBUG_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_DEBUG_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_W::new(self, 5)
+    pub fn u0_core_0(&mut self) -> U0_CORE_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_0_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_W::new(self, 6)
+    pub fn u0_core_1(&mut self) -> U0_CORE_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_1_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_W::new(self, 7)
+    pub fn u0_core_2(&mut self) -> U0_CORE_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_2_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_W::new(self, 8)
+    pub fn u0_core3(&mut self) -> U0_CORE3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE3_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_W::new(self, 9)
+    pub fn u0_core4(&mut self) -> U0_CORE4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE4_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core0_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE0_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE0_ST_W::new(self, 10)
+    pub fn u0_core_st_0(&mut self) -> U0_CORE_ST_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_0_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core1_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE1_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE1_ST_W::new(self, 11)
+    pub fn u0_core_st_1(&mut self) -> U0_CORE_ST_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_1_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core2_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE2_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE2_ST_W::new(self, 12)
+    pub fn u0_core_st_2(&mut self) -> U0_CORE_ST_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_2_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core3_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE3_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE3_ST_W::new(self, 13)
+    pub fn u0_core_st_3(&mut self) -> U0_CORE_ST_3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_3_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_rst_core4_st(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_RST_CORE4_ST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_RST_CORE4_ST_W::new(self, 14)
+    pub fn u0_core_st_4(&mut self) -> U0_CORE_ST_4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_CORE_ST_4_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst0(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST0_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST0_W::new(self, 15)
+    pub fn u0_trace_0(&mut self) -> U0_TRACE_0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_0_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst1(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST1_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST1_W::new(self, 16)
+    pub fn u0_trace_1(&mut self) -> U0_TRACE_1_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_1_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst2(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST2_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST2_W::new(self, 17)
+    pub fn u0_trace_2(&mut self) -> U0_TRACE_2_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_2_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst3(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST3_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST3_W::new(self, 18)
+    pub fn u0_trace_3(&mut self) -> U0_TRACE_3_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_3_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_rst4(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_RST4_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_RST4_W::new(self, 19)
+    pub fn u0_trace_4(&mut self) -> U0_TRACE_4_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_4_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_trace_com_rst(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_TRACE_COM_RST_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_TRACE_COM_RST_W::new(self, 20)
+    pub fn u0_trace_com(&mut self) -> U0_TRACE_COM_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_TRACE_COM_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_apb(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_APB_W::new(self, 21)
+    pub fn u0_img_gpu_apb(&mut self) -> U0_IMG_GPU_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_IMG_GPU_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_img_gpu_rstn_doma(
-        &mut self,
-    ) -> RST_U0_IMG_GPU_RSTN_DOMA_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_IMG_GPU_RSTN_DOMA_W::new(self, 22)
+    pub fn u0_img_gpu_doma(&mut self) -> U0_IMG_GPU_DOMA_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_IMG_GPU_DOMA_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_apb_bus_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_APB_BUS_N_W::new(self, 23)
+    pub fn u0_noc_bus_apb(&mut self) -> U0_NOC_BUS_APB_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_axicfg0_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_AXICFG0_AXI_N_W::new(self, 24)
+    pub fn u0_noc_bus_axicfg0(&mut self) -> U0_NOC_BUS_AXICFG0_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_AXICFG0_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_cpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_CPU_AXI_N_W::new(self, 25)
+    pub fn u0_noc_bus_cpu_axi(&mut self) -> U0_NOC_BUS_CPU_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_CPU_AXI_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_disp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DISP_AXI_N_W::new(self, 26)
+    pub fn u0_noc_bus_disp_axi(&mut self) -> U0_NOC_BUS_DISP_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_DISP_AXI_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_gpu_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_GPU_AXI_N_W::new(self, 27)
+    pub fn u0_noc_bus_gpu_axi(&mut self) -> U0_NOC_BUS_GPU_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_GPU_AXI_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_isp_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_ISP_AXI_N_W::new(self, 28)
+    pub fn u0_noc_bus_isp_axi(&mut self) -> U0_NOC_BUS_ISP_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_ISP_AXI_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_ddrc_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_DDRC_N_W::new(self, 29)
+    pub fn u0_noc_bus_ddrc(&mut self) -> U0_NOC_BUS_DDRC_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_DDRC_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_stg_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_STG_AXI_N_W::new(self, 30)
+    pub fn u0_noc_bus_stg_axi(&mut self) -> U0_NOC_BUS_STG_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_STG_AXI_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rst_u0_u7mc_sft7110_noc_bus_reset_vdec_axi_n(
-        &mut self,
-    ) -> RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W<SYSCRG_RST_STATUS_0_SPEC> {
-        RST_U0_U7MC_SFT7110_NOC_BUS_RESET_VDEC_AXI_N_W::new(self, 31)
+    pub fn u0_noc_bus_vdec_axi(&mut self) -> U0_NOC_BUS_VDEC_AXI_W<SYSCRG_RST_STATUS_0_SPEC> {
+        U0_NOC_BUS_VDEC_AXI_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_1.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_1.rs
@@ -2,561 +2,490 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_1_SPEC>;
 #[doc = "Register `syscrg_rst_status_1` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_1_SPEC>;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sft7100_noc_bus_reset_venc_axi_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg1_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_main_div` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R = crate::BitReader;
-#[doc = "Field `rstn_u0_axi_cfg0_dec_rstn_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_osc` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ddr_sft7110_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DDR_SFT7110_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<'a, REG> =
-    crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_codaj12_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CODAJ12_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave511_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE511_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_jpgresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_vdec_jpg_arb_mainresetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_bpu` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_vce` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_wave420l_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_WAVE420L_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u1_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_R = crate::BitReader;
-#[doc = "Field `rstn_u2_aximem_128b_rstn_axi` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_AXIMEM_128B_RSTN_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_intmem_rom_sram_rstn_rom` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_qspi_rstn_ref` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_QSPI_RSTN_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_noc_bus_venc_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_R = crate::BitReader;
+#[doc = "Field `u0_noc_bus_venc_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_NOC_BUS_VENC_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg1_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg1_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG1_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_main_div` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_MAIN_DIV_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_R = crate::BitReader;
+#[doc = "Field `u0_axi_cfg0_dec_hifi4` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXI_CFG0_DEC_HIFI4_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_R = crate::BitReader;
+#[doc = "Field `u0_ddr_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_osc` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_R = crate::BitReader;
+#[doc = "Field `u0_ddr_osc` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_OSC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_ddr_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_R = crate::BitReader;
+#[doc = "Field `u0_ddr_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DDR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_top` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_R = crate::BitReader;
+#[doc = "Field `u0_isp_top` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_TOP_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_isp_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_R = crate::BitReader;
+#[doc = "Field `u0_isp_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_ISP_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vout_src` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_R = crate::BitReader;
+#[doc = "Field `u0_vout_src` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VOUT_SRC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_codaj12_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_R = crate::BitReader;
+#[doc = "Field `u0_codaj12_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CODAJ12_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave511_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave511_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave511_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave511_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave511_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE511_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_vdec_jpg_arb_main` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_R = crate::BitReader;
+#[doc = "Field `u0_vdec_jpg_arb_main` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_VDEC_JPG_ARB_MAIN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_aximem_128b_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_R = crate::BitReader;
+#[doc = "Field `u0_aximem_128b_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_AXIMEM_128B_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_axi` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_axi` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_AXI_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_bpu` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_bpu` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_BPU_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_vce` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_vce` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_VCE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_wave420l_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_R = crate::BitReader;
+#[doc = "Field `u0_wave420l_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_WAVE420L_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u1_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_aximem` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_R = crate::BitReader;
+#[doc = "Field `u2_aximem` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_AXIMEM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_intmem_rom_sram` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_R = crate::BitReader;
+#[doc = "Field `u0_intmem_rom_sram` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INTMEM_ROM_SRAM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_qspi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_qspi_ref` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_R = crate::BitReader;
+#[doc = "Field `u0_qspi_ref` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_QSPI_REF_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_R::new((self.bits & 1) != 0)
+    pub fn u0_noc_bus_venc_axi(&self) -> U0_NOC_BUS_VENC_AXI_R {
+        U0_NOC_BUS_VENC_AXI_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_ahb(&self) -> U0_AXI_CFG1_DEC_AHB_R {
+        U0_AXI_CFG1_DEC_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_axi_cfg1_dec_main(&self) -> U0_AXI_CFG1_DEC_MAIN_R {
+        U0_AXI_CFG1_DEC_MAIN_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main(&self) -> U0_AXI_CFG0_DEC_MAIN_R {
+        U0_AXI_CFG0_DEC_MAIN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_main_div(&self) -> U0_AXI_CFG0_DEC_MAIN_DIV_R {
+        U0_AXI_CFG0_DEC_MAIN_DIV_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(&self) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_axi_cfg0_dec_hifi4(&self) -> U0_AXI_CFG0_DEC_HIFI4_R {
+        U0_AXI_CFG0_DEC_HIFI4_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(&self) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_R {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_ddr_axi(&self) -> U0_DDR_AXI_R {
+        U0_DDR_AXI_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(&self) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_R {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u0_ddr_osc(&self) -> U0_DDR_OSC_R {
+        U0_DDR_OSC_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(&self) -> RSTN_U0_DDR_SFT7110_RSTN_APB_R {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u0_ddr_apb(&self) -> U0_DDR_APB_R {
+        U0_DDR_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_isp_top(&self) -> U0_ISP_TOP_R {
+        U0_ISP_TOP_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_isp_axi(&self) -> U0_ISP_AXI_R {
+        U0_ISP_AXI_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_vout_src(&self) -> U0_VOUT_SRC_R {
+        U0_VOUT_SRC_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_axi(&self) -> RSTN_U0_CODAJ12_RSTN_AXI_R {
-        RSTN_U0_CODAJ12_RSTN_AXI_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_codaj12_axi(&self) -> U0_CODAJ12_AXI_R {
+        U0_CODAJ12_AXI_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_core(&self) -> RSTN_U0_CODAJ12_RSTN_CORE_R {
-        RSTN_U0_CODAJ12_RSTN_CORE_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_codaj12_core(&self) -> U0_CODAJ12_CORE_R {
+        U0_CODAJ12_CORE_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_codaj12_rstn_apb(&self) -> RSTN_U0_CODAJ12_RSTN_APB_R {
-        RSTN_U0_CODAJ12_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_codaj12_apb(&self) -> U0_CODAJ12_APB_R {
+        U0_CODAJ12_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_axi(&self) -> RSTN_U0_WAVE511_RSTN_AXI_R {
-        RSTN_U0_WAVE511_RSTN_AXI_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_wave511_axi(&self) -> U0_WAVE511_AXI_R {
+        U0_WAVE511_AXI_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_bpu(&self) -> RSTN_U0_WAVE511_RSTN_BPU_R {
-        RSTN_U0_WAVE511_RSTN_BPU_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_wave511_bpu(&self) -> U0_WAVE511_BPU_R {
+        U0_WAVE511_BPU_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_vce(&self) -> RSTN_U0_WAVE511_RSTN_VCE_R {
-        RSTN_U0_WAVE511_RSTN_VCE_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_wave511_vce(&self) -> U0_WAVE511_VCE_R {
+        U0_WAVE511_VCE_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave511_rstn_apb(&self) -> RSTN_U0_WAVE511_RSTN_APB_R {
-        RSTN_U0_WAVE511_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u0_wave511_apb(&self) -> U0_WAVE511_APB_R {
+        U0_WAVE511_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_vdec_jpg_arb(&self) -> U0_VDEC_JPG_ARB_R {
+        U0_VDEC_JPG_ARB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(&self) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_vdec_jpg_arb_main(&self) -> U0_VDEC_JPG_ARB_MAIN_R {
+        U0_VDEC_JPG_ARB_MAIN_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_aximem_128b_rstn_axi(&self) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_aximem_128b_axi(&self) -> U0_AXIMEM_128B_AXI_R {
+        U0_AXIMEM_128B_AXI_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_axi(&self) -> RSTN_U0_WAVE420L_RSTN_AXI_R {
-        RSTN_U0_WAVE420L_RSTN_AXI_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_wave420l_axi(&self) -> U0_WAVE420L_AXI_R {
+        U0_WAVE420L_AXI_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_bpu(&self) -> RSTN_U0_WAVE420L_RSTN_BPU_R {
-        RSTN_U0_WAVE420L_RSTN_BPU_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_wave420l_bpu(&self) -> U0_WAVE420L_BPU_R {
+        U0_WAVE420L_BPU_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_vce(&self) -> RSTN_U0_WAVE420L_RSTN_VCE_R {
-        RSTN_U0_WAVE420L_RSTN_VCE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_wave420l_vce(&self) -> U0_WAVE420L_VCE_R {
+        U0_WAVE420L_VCE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_wave420l_rstn_apb(&self) -> RSTN_U0_WAVE420L_RSTN_APB_R {
-        RSTN_U0_WAVE420L_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_wave420l_apb(&self) -> U0_WAVE420L_APB_R {
+        U0_WAVE420L_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_aximem_128b_rstn_axi(&self) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u1_aximem(&self) -> U1_AXIMEM_R {
+        U1_AXIMEM_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_aximem_128b_rstn_axi(&self) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_R {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u2_aximem(&self) -> U2_AXIMEM_R {
+        U2_AXIMEM_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(&self) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_intmem_rom_sram(&self) -> U0_INTMEM_ROM_SRAM_R {
+        U0_INTMEM_ROM_SRAM_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_qspi_ahb(&self) -> U0_QSPI_AHB_R {
+        U0_QSPI_AHB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(&self) -> RSTN_U0_CDNS_QSPI_RSTN_APB_R {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u0_qspi_apb(&self) -> U0_QSPI_APB_R {
+        U0_QSPI_APB_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(&self) -> RSTN_U0_CDNS_QSPI_RSTN_REF_R {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_qspi_ref(&self) -> U0_QSPI_REF_R {
+        U0_QSPI_REF_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sft7100_noc_bus_reset_venc_axi_n(
-        &mut self,
-    ) -> RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_SFT7100_NOC_BUS_RESET_VENC_AXI_N_W::new(self, 0)
+    pub fn u0_noc_bus_venc_axi(&mut self) -> U0_NOC_BUS_VENC_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_NOC_BUS_VENC_AXI_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_AHB_W::new(self, 1)
+    pub fn u0_axi_cfg1_dec_ahb(&mut self) -> U0_AXI_CFG1_DEC_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG1_DEC_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg1_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG1_DEC_RSTN_MAIN_W::new(self, 2)
+    pub fn u0_axi_cfg1_dec_main(&mut self) -> U0_AXI_CFG1_DEC_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG1_DEC_MAIN_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_W::new(self, 3)
+    pub fn u0_axi_cfg0_dec_main(&mut self) -> U0_AXI_CFG0_DEC_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_main_div(
+    pub fn u0_axi_cfg0_dec_main_div(
         &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_MAIN_DIV_W::new(self, 4)
+    ) -> U0_AXI_CFG0_DEC_MAIN_DIV_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_MAIN_DIV_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_axi_cfg0_dec_rstn_hifi4(
-        &mut self,
-    ) -> RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXI_CFG0_DEC_RSTN_HIFI4_W::new(self, 5)
+    pub fn u0_axi_cfg0_dec_hifi4(&mut self) -> U0_AXI_CFG0_DEC_HIFI4_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXI_CFG0_DEC_HIFI4_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_AXI_W::new(self, 6)
+    pub fn u0_ddr_axi(&mut self) -> U0_DDR_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_AXI_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_osc(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_OSC_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_OSC_W::new(self, 7)
+    pub fn u0_ddr_osc(&mut self) -> U0_DDR_OSC_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_OSC_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ddr_sft7110_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DDR_SFT7110_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DDR_SFT7110_RSTN_APB_W::new(self, 8)
+    pub fn u0_ddr_apb(&mut self) -> U0_DDR_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_DDR_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_ip_top_reset_n(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_IP_TOP_RESET_N_W::new(self, 9)
+    pub fn u0_isp_top(&mut self) -> U0_ISP_TOP_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_ISP_TOP_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_isp_top_rstn_dom_isp_top_rstn_isp_axi(
-        &mut self,
-    ) -> RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_ISP_TOP_RSTN_DOM_ISP_TOP_RSTN_ISP_AXI_W::new(self, 10)
+    pub fn u0_isp_axi(&mut self) -> U0_ISP_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_ISP_AXI_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dom_vout_top_rstn_dom_vout_top_rstn_vout_src(
-        &mut self,
-    ) -> RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_DOM_VOUT_TOP_RSTN_DOM_VOUT_TOP_RSTN_VOUT_SRC_W::new(self, 11)
+    pub fn u0_vout_src(&mut self) -> U0_VOUT_SRC_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VOUT_SRC_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_AXI_W::new(self, 12)
+    pub fn u0_codaj12_axi(&mut self) -> U0_CODAJ12_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_AXI_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_core(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_CORE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_CORE_W::new(self, 13)
+    pub fn u0_codaj12_core(&mut self) -> U0_CODAJ12_CORE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_CORE_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_codaj12_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CODAJ12_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CODAJ12_RSTN_APB_W::new(self, 14)
+    pub fn u0_codaj12_apb(&mut self) -> U0_CODAJ12_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_CODAJ12_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_AXI_W::new(self, 15)
+    pub fn u0_wave511_axi(&mut self) -> U0_WAVE511_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_AXI_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_BPU_W::new(self, 16)
+    pub fn u0_wave511_bpu(&mut self) -> U0_WAVE511_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_BPU_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_VCE_W::new(self, 17)
+    pub fn u0_wave511_vce(&mut self) -> U0_WAVE511_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_VCE_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave511_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE511_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE511_RSTN_APB_W::new(self, 18)
+    pub fn u0_wave511_apb(&mut self) -> U0_WAVE511_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE511_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_jpgresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_JPGRESETN_W::new(self, 19)
+    pub fn u0_vdec_jpg_arb(&mut self) -> U0_VDEC_JPG_ARB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VDEC_JPG_ARB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_vdec_jpg_arb_mainresetn(
-        &mut self,
-    ) -> RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_VDEC_JPG_ARB_MAINRESETN_W::new(self, 20)
+    pub fn u0_vdec_jpg_arb_main(&mut self) -> U0_VDEC_JPG_ARB_MAIN_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_VDEC_JPG_ARB_MAIN_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_AXIMEM_128B_RSTN_AXI_W::new(self, 21)
+    pub fn u0_aximem_128b_axi(&mut self) -> U0_AXIMEM_128B_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_AXIMEM_128B_AXI_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_axi(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_AXI_W::new(self, 22)
+    pub fn u0_wave420l_axi(&mut self) -> U0_WAVE420L_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_AXI_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_bpu(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_BPU_W::new(self, 23)
+    pub fn u0_wave420l_bpu(&mut self) -> U0_WAVE420L_BPU_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_BPU_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_vce(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_VCE_W::new(self, 24)
+    pub fn u0_wave420l_vce(&mut self) -> U0_WAVE420L_VCE_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_VCE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_wave420l_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_WAVE420L_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_WAVE420L_RSTN_APB_W::new(self, 25)
+    pub fn u0_wave420l_apb(&mut self) -> U0_WAVE420L_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_WAVE420L_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U1_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U1_AXIMEM_128B_RSTN_AXI_W::new(self, 26)
+    pub fn u1_aximem(&mut self) -> U1_AXIMEM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U1_AXIMEM_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_aximem_128b_rstn_axi(
-        &mut self,
-    ) -> RSTN_U2_AXIMEM_128B_RSTN_AXI_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U2_AXIMEM_128B_RSTN_AXI_W::new(self, 27)
+    pub fn u2_aximem(&mut self) -> U2_AXIMEM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U2_AXIMEM_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_intmem_rom_sram_rstn_rom(
-        &mut self,
-    ) -> RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_INTMEM_ROM_SRAM_RSTN_ROM_W::new(self, 28)
+    pub fn u0_intmem_rom_sram(&mut self) -> U0_INTMEM_ROM_SRAM_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_INTMEM_ROM_SRAM_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_AHB_W::new(self, 29)
+    pub fn u0_qspi_ahb(&mut self) -> U0_QSPI_AHB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_AHB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_APB_W::new(self, 30)
+    pub fn u0_qspi_apb(&mut self) -> U0_QSPI_APB_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_APB_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_qspi_rstn_ref(
-        &mut self,
-    ) -> RSTN_U0_CDNS_QSPI_RSTN_REF_W<SYSCRG_RST_STATUS_1_SPEC> {
-        RSTN_U0_CDNS_QSPI_RSTN_REF_W::new(self, 31)
+    pub fn u0_qspi_ref(&mut self) -> U0_QSPI_REF_W<SYSCRG_RST_STATUS_1_SPEC> {
+        U0_QSPI_REF_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_2.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_2.rs
@@ -2,510 +2,488 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_2_SPEC>;
 #[doc = "Register `syscrg_rst_status_2` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_2_SPEC>;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_sdio_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SDIO_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_sdi_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SDI_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_aresetn_i` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_ARESETN_I_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_R = crate::BitReader;
-#[doc = "Field `rstn_u1_gmac5_axi64_hresetn_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_GMAC5_AXI64_HRESETN_N_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_ssp_spi_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_SSP_SPI_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u6_i2c_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_I2C_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u0_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u1_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u2_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u2_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U2_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u3_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u3_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U3_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u4_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u4_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U4_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u5_uart_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u5_uart_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U5_UART_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u6_uart_rstn_core` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_R = crate::BitReader;
-#[doc = "Field `rstn_u6_uart_rstn_core` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U6_UART_RSTN_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_cdns_spdif_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CDNS_SPDIF_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_sdio_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_R = crate::BitReader;
+#[doc = "Field `u0_sdio_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SDIO_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_sdi_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_R = crate::BitReader;
+#[doc = "Field `u1_sdi_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SDI_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_gmac5_axi64_hresetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_R = crate::BitReader;
+#[doc = "Field `u1_gmac5_axi64_hresetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_GMAC5_AXI64_HRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_mailbox_presetn` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_R = crate::BitReader;
+#[doc = "Field `u0_mailbox_presetn` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_MAILBOX_PRESETN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u0_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u1_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u2_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u3_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u4_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u5_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_spi_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_R = crate::BitReader;
+#[doc = "Field `u6_spi_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_SPI_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u2_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u3_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u4_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u5_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_i2c_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_R = crate::BitReader;
+#[doc = "Field `u6_i2c_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_I2C_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_R = crate::BitReader;
+#[doc = "Field `u0_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u0_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_R = crate::BitReader;
+#[doc = "Field `u1_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u1_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_R = crate::BitReader;
+#[doc = "Field `u2_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u2_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u2_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U2_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_R = crate::BitReader;
+#[doc = "Field `u3_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u3_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u3_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U3_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_R = crate::BitReader;
+#[doc = "Field `u4_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u4_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u4_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U4_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u5_uart_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_R = crate::BitReader;
+#[doc = "Field `u5_uart_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U5_UART_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u6_uart_core` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_R = crate::BitReader;
+#[doc = "Field `u6_uart_core` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U6_UART_CORE_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_spdif_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_R = crate::BitReader;
+#[doc = "Field `u0_spdif_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SPDIF_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_sdio_rstn_ahb(&self) -> RSTN_U0_SDIO_RSTN_AHB_R {
-        RSTN_U0_SDIO_RSTN_AHB_R::new((self.bits & 1) != 0)
+    pub fn u0_sdio_ahb(&self) -> U0_SDIO_AHB_R {
+        U0_SDIO_AHB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_sdi_rstn_ahb(&self) -> RSTN_U1_SDI_RSTN_AHB_R {
-        RSTN_U1_SDI_RSTN_AHB_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u1_sdi_ahb(&self) -> U1_SDI_AHB_R {
+        U1_SDI_AHB_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(&self) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_R {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u1_gmac5_axi64(&self) -> U1_GMAC5_AXI64_R {
+        U1_GMAC5_AXI64_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(&self) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_R {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u1_gmac5_axi64_hresetn(&self) -> U1_GMAC5_AXI64_HRESETN_R {
+        U1_GMAC5_AXI64_HRESETN_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_mailbox_presetn(&self) -> RSTN_U0_MAILBOX_PRESETN_R {
-        RSTN_U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_mailbox_presetn(&self) -> U0_MAILBOX_PRESETN_R {
+        U0_MAILBOX_PRESETN_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_ssp_spi_rstn_apb(&self) -> RSTN_U0_SSP_SPI_RSTN_APB_R {
-        RSTN_U0_SSP_SPI_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_spi_apb(&self) -> U0_SPI_APB_R {
+        U0_SPI_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_ssp_spi_rstn_apb(&self) -> RSTN_U1_SSP_SPI_RSTN_APB_R {
-        RSTN_U1_SSP_SPI_RSTN_APB_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u1_spi_apb(&self) -> U1_SPI_APB_R {
+        U1_SPI_APB_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_ssp_spi_rstn_apb(&self) -> RSTN_U2_SSP_SPI_RSTN_APB_R {
-        RSTN_U2_SSP_SPI_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u2_spi_apb(&self) -> U2_SPI_APB_R {
+        U2_SPI_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_ssp_spi_rstn_apb(&self) -> RSTN_U3_SSP_SPI_RSTN_APB_R {
-        RSTN_U3_SSP_SPI_RSTN_APB_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u3_spi_apb(&self) -> U3_SPI_APB_R {
+        U3_SPI_APB_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_ssp_spi_rstn_apb(&self) -> RSTN_U4_SSP_SPI_RSTN_APB_R {
-        RSTN_U4_SSP_SPI_RSTN_APB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u4_spi_apb(&self) -> U4_SPI_APB_R {
+        U4_SPI_APB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_ssp_spi_rstn_apb(&self) -> RSTN_U5_SSP_SPI_RSTN_APB_R {
-        RSTN_U5_SSP_SPI_RSTN_APB_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u5_spi_apb(&self) -> U5_SPI_APB_R {
+        U5_SPI_APB_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_ssp_spi_rstn_apb(&self) -> RSTN_U6_SSP_SPI_RSTN_APB_R {
-        RSTN_U6_SSP_SPI_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u6_spi_apb(&self) -> U6_SPI_APB_R {
+        U6_SPI_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2c_rstn_apb(&self) -> RSTN_U0_I2C_RSTN_APB_R {
-        RSTN_U0_I2C_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_i2c_apb(&self) -> U0_I2C_APB_R {
+        U0_I2C_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2c_rstn_apb(&self) -> RSTN_U1_I2C_RSTN_APB_R {
-        RSTN_U1_I2C_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u1_i2c_apb(&self) -> U1_I2C_APB_R {
+        U1_I2C_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_i2c_rstn_apb(&self) -> RSTN_U2_I2C_RSTN_APB_R {
-        RSTN_U2_I2C_RSTN_APB_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u2_i2c_apb(&self) -> U2_I2C_APB_R {
+        U2_I2C_APB_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_i2c_rstn_apb(&self) -> RSTN_U3_I2C_RSTN_APB_R {
-        RSTN_U3_I2C_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u3_i2c_apb(&self) -> U3_I2C_APB_R {
+        U3_I2C_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_i2c_rstn_apb(&self) -> RSTN_U4_I2C_RSTN_APB_R {
-        RSTN_U4_I2C_RSTN_APB_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u4_i2c_apb(&self) -> U4_I2C_APB_R {
+        U4_I2C_APB_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_i2c_rstn_apb(&self) -> RSTN_U5_I2C_RSTN_APB_R {
-        RSTN_U5_I2C_RSTN_APB_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u5_i2c_apb(&self) -> U5_I2C_APB_R {
+        U5_I2C_APB_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_i2c_rstn_apb(&self) -> RSTN_U6_I2C_RSTN_APB_R {
-        RSTN_U6_I2C_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u6_i2c_apb(&self) -> U6_I2C_APB_R {
+        U6_I2C_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_apb(&self) -> RSTN_U0_UART_RSTN_APB_R {
-        RSTN_U0_UART_RSTN_APB_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u0_uart_apb(&self) -> U0_UART_APB_R {
+        U0_UART_APB_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_uart_rstn_core(&self) -> RSTN_U0_UART_RSTN_CORE_R {
-        RSTN_U0_UART_RSTN_CORE_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u0_uart_core(&self) -> U0_UART_CORE_R {
+        U0_UART_CORE_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_apb(&self) -> RSTN_U1_UART_RSTN_APB_R {
-        RSTN_U1_UART_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u1_uart_apb(&self) -> U1_UART_APB_R {
+        U1_UART_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_uart_rstn_core(&self) -> RSTN_U1_UART_RSTN_CORE_R {
-        RSTN_U1_UART_RSTN_CORE_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u1_uart_core(&self) -> U1_UART_CORE_R {
+        U1_UART_CORE_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_apb(&self) -> RSTN_U2_UART_RSTN_APB_R {
-        RSTN_U2_UART_RSTN_APB_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u2_uart_apb(&self) -> U2_UART_APB_R {
+        U2_UART_APB_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u2_uart_rstn_core(&self) -> RSTN_U2_UART_RSTN_CORE_R {
-        RSTN_U2_UART_RSTN_CORE_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u2_uart_core(&self) -> U2_UART_CORE_R {
+        U2_UART_CORE_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_apb(&self) -> RSTN_U3_UART_RSTN_APB_R {
-        RSTN_U3_UART_RSTN_APB_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u3_uart_apb(&self) -> U3_UART_APB_R {
+        U3_UART_APB_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u3_uart_rstn_core(&self) -> RSTN_U3_UART_RSTN_CORE_R {
-        RSTN_U3_UART_RSTN_CORE_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u3_uart_core(&self) -> U3_UART_CORE_R {
+        U3_UART_CORE_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_apb(&self) -> RSTN_U4_UART_RSTN_APB_R {
-        RSTN_U4_UART_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u4_uart_apb(&self) -> U4_UART_APB_R {
+        U4_UART_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u4_uart_rstn_core(&self) -> RSTN_U4_UART_RSTN_CORE_R {
-        RSTN_U4_UART_RSTN_CORE_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u4_uart_core(&self) -> U4_UART_CORE_R {
+        U4_UART_CORE_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u5_uart_rstn_apb(&self) -> RSTN_U5_UART_RSTN_APB_R {
-        RSTN_U5_UART_RSTN_APB_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u5_uart_apb(&self) -> U5_UART_APB_R {
+        U5_UART_APB_R::new(((self.bits >> 29) & 1) != 0)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u6_uart_rstn_core(&self) -> RSTN_U6_UART_RSTN_CORE_R {
-        RSTN_U6_UART_RSTN_CORE_R::new(((self.bits >> 30) & 1) != 0)
+    pub fn u6_uart_core(&self) -> U6_UART_CORE_R {
+        U6_UART_CORE_R::new(((self.bits >> 30) & 1) != 0)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(&self) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_R {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_R::new(((self.bits >> 31) & 1) != 0)
+    pub fn u0_spdif_apb(&self) -> U0_SPDIF_APB_R {
+        U0_SPDIF_APB_R::new(((self.bits >> 31) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_sdio_rstn_ahb(&mut self) -> RSTN_U0_SDIO_RSTN_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_SDIO_RSTN_AHB_W::new(self, 0)
+    pub fn u0_sdio_ahb(&mut self) -> U0_SDIO_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SDIO_AHB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_sdi_rstn_ahb(&mut self) -> RSTN_U1_SDI_RSTN_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_SDI_RSTN_AHB_W::new(self, 1)
+    pub fn u1_sdi_ahb(&mut self) -> U1_SDI_AHB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_SDI_AHB_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_aresetn_i(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_ARESETN_I_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_ARESETN_I_W::new(self, 2)
+    pub fn u1_gmac5_axi64(&mut self) -> U1_GMAC5_AXI64_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_GMAC5_AXI64_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_gmac5_axi64_hresetn_n(
-        &mut self,
-    ) -> RSTN_U1_GMAC5_AXI64_HRESETN_N_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_GMAC5_AXI64_HRESETN_N_W::new(self, 3)
+    pub fn u1_gmac5_axi64_hresetn(&mut self) -> U1_GMAC5_AXI64_HRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_GMAC5_AXI64_HRESETN_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_mailbox_presetn(
-        &mut self,
-    ) -> RSTN_U0_MAILBOX_PRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_MAILBOX_PRESETN_W::new(self, 4)
+    pub fn u0_mailbox_presetn(&mut self) -> U0_MAILBOX_PRESETN_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_MAILBOX_PRESETN_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_SSP_SPI_RSTN_APB_W::new(self, 5)
+    pub fn u0_spi_apb(&mut self) -> U0_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SPI_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_SSP_SPI_RSTN_APB_W::new(self, 6)
+    pub fn u1_spi_apb(&mut self) -> U1_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_SPI_APB_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U2_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_SSP_SPI_RSTN_APB_W::new(self, 7)
+    pub fn u2_spi_apb(&mut self) -> U2_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_SPI_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U3_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_SSP_SPI_RSTN_APB_W::new(self, 8)
+    pub fn u3_spi_apb(&mut self) -> U3_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_SPI_APB_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U4_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_SSP_SPI_RSTN_APB_W::new(self, 9)
+    pub fn u4_spi_apb(&mut self) -> U4_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_SPI_APB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U5_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_SSP_SPI_RSTN_APB_W::new(self, 10)
+    pub fn u5_spi_apb(&mut self) -> U5_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_SPI_APB_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_ssp_spi_rstn_apb(
-        &mut self,
-    ) -> RSTN_U6_SSP_SPI_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_SSP_SPI_RSTN_APB_W::new(self, 11)
+    pub fn u6_spi_apb(&mut self) -> U6_SPI_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_SPI_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2c_rstn_apb(&mut self) -> RSTN_U0_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_I2C_RSTN_APB_W::new(self, 12)
+    pub fn u0_i2c_apb(&mut self) -> U0_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_I2C_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2c_rstn_apb(&mut self) -> RSTN_U1_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_I2C_RSTN_APB_W::new(self, 13)
+    pub fn u1_i2c_apb(&mut self) -> U1_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_I2C_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_i2c_rstn_apb(&mut self) -> RSTN_U2_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_I2C_RSTN_APB_W::new(self, 14)
+    pub fn u2_i2c_apb(&mut self) -> U2_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_I2C_APB_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_i2c_rstn_apb(&mut self) -> RSTN_U3_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_I2C_RSTN_APB_W::new(self, 15)
+    pub fn u3_i2c_apb(&mut self) -> U3_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_I2C_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_i2c_rstn_apb(&mut self) -> RSTN_U4_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_I2C_RSTN_APB_W::new(self, 16)
+    pub fn u4_i2c_apb(&mut self) -> U4_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_I2C_APB_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_i2c_rstn_apb(&mut self) -> RSTN_U5_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_I2C_RSTN_APB_W::new(self, 17)
+    pub fn u5_i2c_apb(&mut self) -> U5_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_I2C_APB_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_i2c_rstn_apb(&mut self) -> RSTN_U6_I2C_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_I2C_RSTN_APB_W::new(self, 18)
+    pub fn u6_i2c_apb(&mut self) -> U6_I2C_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_I2C_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_apb(&mut self) -> RSTN_U0_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_UART_RSTN_APB_W::new(self, 19)
+    pub fn u0_uart_apb(&mut self) -> U0_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_UART_APB_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_uart_rstn_core(&mut self) -> RSTN_U0_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_UART_RSTN_CORE_W::new(self, 20)
+    pub fn u0_uart_core(&mut self) -> U0_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_UART_CORE_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_apb(&mut self) -> RSTN_U1_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_UART_RSTN_APB_W::new(self, 21)
+    pub fn u1_uart_apb(&mut self) -> U1_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_UART_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_uart_rstn_core(&mut self) -> RSTN_U1_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U1_UART_RSTN_CORE_W::new(self, 22)
+    pub fn u1_uart_core(&mut self) -> U1_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U1_UART_CORE_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_apb(&mut self) -> RSTN_U2_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_UART_RSTN_APB_W::new(self, 23)
+    pub fn u2_uart_apb(&mut self) -> U2_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_UART_APB_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u2_uart_rstn_core(&mut self) -> RSTN_U2_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U2_UART_RSTN_CORE_W::new(self, 24)
+    pub fn u2_uart_core(&mut self) -> U2_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U2_UART_CORE_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_apb(&mut self) -> RSTN_U3_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_UART_RSTN_APB_W::new(self, 25)
+    pub fn u3_uart_apb(&mut self) -> U3_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_UART_APB_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u3_uart_rstn_core(&mut self) -> RSTN_U3_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U3_UART_RSTN_CORE_W::new(self, 26)
+    pub fn u3_uart_core(&mut self) -> U3_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U3_UART_CORE_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_apb(&mut self) -> RSTN_U4_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_UART_RSTN_APB_W::new(self, 27)
+    pub fn u4_uart_apb(&mut self) -> U4_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_UART_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u4_uart_rstn_core(&mut self) -> RSTN_U4_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U4_UART_RSTN_CORE_W::new(self, 28)
+    pub fn u4_uart_core(&mut self) -> U4_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U4_UART_CORE_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u5_uart_rstn_apb(&mut self) -> RSTN_U5_UART_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U5_UART_RSTN_APB_W::new(self, 29)
+    pub fn u5_uart_apb(&mut self) -> U5_UART_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U5_UART_APB_W::new(self, 29)
     }
     #[doc = "Bit 30 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u6_uart_rstn_core(&mut self) -> RSTN_U6_UART_RSTN_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U6_UART_RSTN_CORE_W::new(self, 30)
+    pub fn u6_uart_core(&mut self) -> U6_UART_CORE_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U6_UART_CORE_W::new(self, 30)
     }
     #[doc = "Bit 31 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_cdns_spdif_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CDNS_SPDIF_RSTN_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
-        RSTN_U0_CDNS_SPDIF_RSTN_APB_W::new(self, 31)
+    pub fn u0_spdif_apb(&mut self) -> U0_SPDIF_APB_W<SYSCRG_RST_STATUS_2_SPEC> {
+        U0_SPDIF_APB_W::new(self, 31)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_3.rs
+++ b/jh7110-vf2-13b-pac/src/syscrg/syscrg_rst_status_3.rs
@@ -2,518 +2,458 @@
 pub type R = crate::R<SYSCRG_RST_STATUS_3_SPEC>;
 #[doc = "Register `syscrg_rst_status_3` writer"]
 pub type W = crate::W<SYSCRG_RST_STATUS_3_SPEC>;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwmdac_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWMDAC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_dmic` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pdm_4mic_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PDM_4MIC_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2srx_3ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u0_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_R = crate::BitReader;
-#[doc = "Field `rstn_u1_i2stx_4ch_rstn_bclk` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_I2STX_4CH_RSTN_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_ahb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_tdm` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_tdm16slot_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TDM16SLOT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_pwm_8ch_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_PWM_8CH_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_R = crate::BitReader;
-#[doc = "Field `rstn_u0_dskit_wdt_rstn_wdt` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_DSKIT_WDT_RSTN_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u0_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_can` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_R = crate::BitReader;
-#[doc = "Field `rstn_u1_can_ctrl_rstn_timer` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U1_CAN_CTRL_RSTN_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer0` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_time10` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIME10_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer2` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_R = crate::BitReader;
-#[doc = "Field `rstn_u0_si5_timer_rstn_timer3` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_int_ctrl_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_INT_CTRL_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R = crate::BitReader;
-#[doc = "Field `rstn_u0_temp_sensor_rstn_temp` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<'a, REG> = crate::BitWriter<'a, REG>;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` reader - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_R = crate::BitReader;
-#[doc = "Field `rstn_u0_jtag_certification_rst_n` writer - 1: Assert reset, 0: De-assert reset"]
-pub type RSTN_U0_JTAG_CERTIFICATION_RST_N_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwmdac_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwmdac_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWMDAC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_dmic` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_dmic` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_DMIC_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pdm_4mic_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_R = crate::BitReader;
+#[doc = "Field `u0_pdm_4mic_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PDM_4MIC_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2srx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2srx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2SRX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u0_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_i2stx_bclk` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_R = crate::BitReader;
+#[doc = "Field `u1_i2stx_bclk` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_I2STX_BCLK_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_ahb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_ahb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_AHB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_tdm` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_tdm` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_TDM_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_tdm16slot_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_R = crate::BitReader;
+#[doc = "Field `u0_tdm16slot_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TDM16SLOT_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_pwm_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_R = crate::BitReader;
+#[doc = "Field `u0_pwm_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_PWM_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt_rstn_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_RSTN_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_dskit_wdt` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_R = crate::BitReader;
+#[doc = "Field `u0_dskit_wdt` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_DSKIT_WDT_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u0_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_can` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_can` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_CAN_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u1_can_ctrl_timer` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_R = crate::BitReader;
+#[doc = "Field `u1_can_ctrl_timer` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U1_CAN_CTRL_TIMER_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_0` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_0` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_0_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_1` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_1` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_1_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_2` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_2` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_2_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_si5_timer_3` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_R = crate::BitReader;
+#[doc = "Field `u0_si5_timer_3` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_SI5_TIMER_3_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_int_ctrl_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_R = crate::BitReader;
+#[doc = "Field `u0_int_ctrl_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_INT_CTRL_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor_apb` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor_apb` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_APB_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_temp_sensor` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_R = crate::BitReader;
+#[doc = "Field `u0_temp_sensor` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_TEMP_SENSOR_W<'a, REG> = crate::BitWriter<'a, REG>;
+#[doc = "Field `u0_jtag_rst` reader - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_R = crate::BitReader;
+#[doc = "Field `u0_jtag_rst` writer - 1: Assert reset, 0: De-assert reset"]
+pub type U0_JTAG_RST_W<'a, REG> = crate::BitWriter<'a, REG>;
 impl R {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwmdac_rstn_apb(&self) -> RSTN_U0_PWMDAC_RSTN_APB_R {
-        RSTN_U0_PWMDAC_RSTN_APB_R::new((self.bits & 1) != 0)
+    pub fn u0_pwmdac_apb(&self) -> U0_PWMDAC_APB_R {
+        U0_PWMDAC_APB_R::new((self.bits & 1) != 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(&self) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_R {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_R::new(((self.bits >> 1) & 1) != 0)
+    pub fn u0_pdm_4mic_dmic(&self) -> U0_PDM_4MIC_DMIC_R {
+        U0_PDM_4MIC_DMIC_R::new(((self.bits >> 1) & 1) != 0)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(&self) -> RSTN_U0_PDM_4MIC_RSTN_APB_R {
-        RSTN_U0_PDM_4MIC_RSTN_APB_R::new(((self.bits >> 2) & 1) != 0)
+    pub fn u0_pdm_4mic_apb(&self) -> U0_PDM_4MIC_APB_R {
+        U0_PDM_4MIC_APB_R::new(((self.bits >> 2) & 1) != 0)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(&self) -> RSTN_U0_I2SRX_3CH_RSTN_APB_R {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_R::new(((self.bits >> 3) & 1) != 0)
+    pub fn u0_i2srx_apb(&self) -> U0_I2SRX_APB_R {
+        U0_I2SRX_APB_R::new(((self.bits >> 3) & 1) != 0)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(&self) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_R {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_R::new(((self.bits >> 4) & 1) != 0)
+    pub fn u0_i2srx_bclk(&self) -> U0_I2SRX_BCLK_R {
+        U0_I2SRX_BCLK_R::new(((self.bits >> 4) & 1) != 0)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(&self) -> RSTN_U0_I2STX_4CH_RSTN_APB_R {
-        RSTN_U0_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 5) & 1) != 0)
+    pub fn u0_i2stx_apb(&self) -> U0_I2STX_APB_R {
+        U0_I2STX_APB_R::new(((self.bits >> 5) & 1) != 0)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(&self) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 6) & 1) != 0)
+    pub fn u0_i2stx_bclk(&self) -> U0_I2STX_BCLK_R {
+        U0_I2STX_BCLK_R::new(((self.bits >> 6) & 1) != 0)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(&self) -> RSTN_U1_I2STX_4CH_RSTN_APB_R {
-        RSTN_U1_I2STX_4CH_RSTN_APB_R::new(((self.bits >> 7) & 1) != 0)
+    pub fn u1_i2stx_apb(&self) -> U1_I2STX_APB_R {
+        U1_I2STX_APB_R::new(((self.bits >> 7) & 1) != 0)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(&self) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_R {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_R::new(((self.bits >> 8) & 1) != 0)
+    pub fn u1_i2stx_bclk(&self) -> U1_I2STX_BCLK_R {
+        U1_I2STX_BCLK_R::new(((self.bits >> 8) & 1) != 0)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(&self) -> RSTN_U0_TDM16SLOT_RSTN_AHB_R {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_R::new(((self.bits >> 9) & 1) != 0)
+    pub fn u0_tdm16slot_ahb(&self) -> U0_TDM16SLOT_AHB_R {
+        U0_TDM16SLOT_AHB_R::new(((self.bits >> 9) & 1) != 0)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(&self) -> RSTN_U0_TDM16SLOT_RSTN_TDM_R {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_R::new(((self.bits >> 10) & 1) != 0)
+    pub fn u0_tdm16slot_tdm(&self) -> U0_TDM16SLOT_TDM_R {
+        U0_TDM16SLOT_TDM_R::new(((self.bits >> 10) & 1) != 0)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_tdm16slot_rstn_apb(&self) -> RSTN_U0_TDM16SLOT_RSTN_APB_R {
-        RSTN_U0_TDM16SLOT_RSTN_APB_R::new(((self.bits >> 11) & 1) != 0)
+    pub fn u0_tdm16slot_apb(&self) -> U0_TDM16SLOT_APB_R {
+        U0_TDM16SLOT_APB_R::new(((self.bits >> 11) & 1) != 0)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(&self) -> RSTN_U0_PWM_8CH_RSTN_APB_R {
-        RSTN_U0_PWM_8CH_RSTN_APB_R::new(((self.bits >> 12) & 1) != 0)
+    pub fn u0_pwm_apb(&self) -> U0_PWM_APB_R {
+        U0_PWM_APB_R::new(((self.bits >> 12) & 1) != 0)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(&self) -> RSTN_U0_DSKIT_WDT_RSTN_APB_R {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
+    pub fn u0_dskit_wdt_rstn_apb(&self) -> U0_DSKIT_WDT_RSTN_APB_R {
+        U0_DSKIT_WDT_RSTN_APB_R::new(((self.bits >> 13) & 1) != 0)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(&self) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_R {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_R::new(((self.bits >> 14) & 1) != 0)
+    pub fn u0_dskit_wdt(&self) -> U0_DSKIT_WDT_R {
+        U0_DSKIT_WDT_R::new(((self.bits >> 14) & 1) != 0)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_apb(&self) -> RSTN_U0_CAN_CTRL_RSTN_APB_R {
-        RSTN_U0_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 15) & 1) != 0)
+    pub fn u0_can_ctrl_apb(&self) -> U0_CAN_CTRL_APB_R {
+        U0_CAN_CTRL_APB_R::new(((self.bits >> 15) & 1) != 0)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_can(&self) -> RSTN_U0_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 16) & 1) != 0)
+    pub fn u0_can_ctrl(&self) -> U0_CAN_CTRL_R {
+        U0_CAN_CTRL_R::new(((self.bits >> 16) & 1) != 0)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_can_ctrl_rstn_timer(&self) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 17) & 1) != 0)
+    pub fn u0_can_ctrl_timer(&self) -> U0_CAN_CTRL_TIMER_R {
+        U0_CAN_CTRL_TIMER_R::new(((self.bits >> 17) & 1) != 0)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_apb(&self) -> RSTN_U1_CAN_CTRL_RSTN_APB_R {
-        RSTN_U1_CAN_CTRL_RSTN_APB_R::new(((self.bits >> 18) & 1) != 0)
+    pub fn u1_can_ctrl_apb(&self) -> U1_CAN_CTRL_APB_R {
+        U1_CAN_CTRL_APB_R::new(((self.bits >> 18) & 1) != 0)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_can(&self) -> RSTN_U1_CAN_CTRL_RSTN_CAN_R {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_R::new(((self.bits >> 19) & 1) != 0)
+    pub fn u1_can_ctrl_can(&self) -> U1_CAN_CTRL_CAN_R {
+        U1_CAN_CTRL_CAN_R::new(((self.bits >> 19) & 1) != 0)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u1_can_ctrl_rstn_timer(&self) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_R {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_R::new(((self.bits >> 20) & 1) != 0)
+    pub fn u1_can_ctrl_timer(&self) -> U1_CAN_CTRL_TIMER_R {
+        U1_CAN_CTRL_TIMER_R::new(((self.bits >> 20) & 1) != 0)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_apb(&self) -> RSTN_U0_SI5_TIMER_RSTN_APB_R {
-        RSTN_U0_SI5_TIMER_RSTN_APB_R::new(((self.bits >> 21) & 1) != 0)
+    pub fn u0_si5_timer_apb(&self) -> U0_SI5_TIMER_APB_R {
+        U0_SI5_TIMER_APB_R::new(((self.bits >> 21) & 1) != 0)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer0(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_R::new(((self.bits >> 22) & 1) != 0)
+    pub fn u0_si5_timer_0(&self) -> U0_SI5_TIMER_0_R {
+        U0_SI5_TIMER_0_R::new(((self.bits >> 22) & 1) != 0)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_time10(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_R::new(((self.bits >> 23) & 1) != 0)
+    pub fn u0_si5_timer_1(&self) -> U0_SI5_TIMER_1_R {
+        U0_SI5_TIMER_1_R::new(((self.bits >> 23) & 1) != 0)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer2(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_R::new(((self.bits >> 24) & 1) != 0)
+    pub fn u0_si5_timer_2(&self) -> U0_SI5_TIMER_2_R {
+        U0_SI5_TIMER_2_R::new(((self.bits >> 24) & 1) != 0)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_si5_timer_rstn_timer3(&self) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_R {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_R::new(((self.bits >> 25) & 1) != 0)
+    pub fn u0_si5_timer_3(&self) -> U0_SI5_TIMER_3_R {
+        U0_SI5_TIMER_3_R::new(((self.bits >> 25) & 1) != 0)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_int_ctrl_rstn_apb(&self) -> RSTN_U0_INT_CTRL_RSTN_APB_R {
-        RSTN_U0_INT_CTRL_RSTN_APB_R::new(((self.bits >> 26) & 1) != 0)
+    pub fn u0_int_ctrl_apb(&self) -> U0_INT_CTRL_APB_R {
+        U0_INT_CTRL_APB_R::new(((self.bits >> 26) & 1) != 0)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_apb(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_R::new(((self.bits >> 27) & 1) != 0)
+    pub fn u0_temp_sensor_apb(&self) -> U0_TEMP_SENSOR_APB_R {
+        U0_TEMP_SENSOR_APB_R::new(((self.bits >> 27) & 1) != 0)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_temp_sensor_rstn_temp(&self) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_R::new(((self.bits >> 28) & 1) != 0)
+    pub fn u0_temp_sensor(&self) -> U0_TEMP_SENSOR_R {
+        U0_TEMP_SENSOR_R::new(((self.bits >> 28) & 1) != 0)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
-    pub fn rstn_u0_jtag_certification_rst_n(&self) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_R {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_R::new(((self.bits >> 29) & 1) != 0)
+    pub fn u0_jtag_rst(&self) -> U0_JTAG_RST_R {
+        U0_JTAG_RST_R::new(((self.bits >> 29) & 1) != 0)
     }
 }
 impl W {
     #[doc = "Bit 0 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwmdac_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWMDAC_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PWMDAC_RSTN_APB_W::new(self, 0)
+    pub fn u0_pwmdac_apb(&mut self) -> U0_PWMDAC_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PWMDAC_APB_W::new(self, 0)
     }
     #[doc = "Bit 1 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_dmic(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_DMIC_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_DMIC_W::new(self, 1)
+    pub fn u0_pdm_4mic_dmic(&mut self) -> U0_PDM_4MIC_DMIC_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PDM_4MIC_DMIC_W::new(self, 1)
     }
     #[doc = "Bit 2 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pdm_4mic_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PDM_4MIC_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PDM_4MIC_RSTN_APB_W::new(self, 2)
+    pub fn u0_pdm_4mic_apb(&mut self) -> U0_PDM_4MIC_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PDM_4MIC_APB_W::new(self, 2)
     }
     #[doc = "Bit 3 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_APB_W::new(self, 3)
+    pub fn u0_i2srx_apb(&mut self) -> U0_I2SRX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2SRX_APB_W::new(self, 3)
     }
     #[doc = "Bit 4 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2srx_3ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2SRX_3CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2SRX_3CH_RSTN_BCLK_W::new(self, 4)
+    pub fn u0_i2srx_bclk(&mut self) -> U0_I2SRX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2SRX_BCLK_W::new(self, 4)
     }
     #[doc = "Bit 5 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_APB_W::new(self, 5)
+    pub fn u0_i2stx_apb(&mut self) -> U0_I2STX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2STX_APB_W::new(self, 5)
     }
     #[doc = "Bit 6 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U0_I2STX_4CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_I2STX_4CH_RSTN_BCLK_W::new(self, 6)
+    pub fn u0_i2stx_bclk(&mut self) -> U0_I2STX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_I2STX_BCLK_W::new(self, 6)
     }
     #[doc = "Bit 7 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_APB_W::new(self, 7)
+    pub fn u1_i2stx_apb(&mut self) -> U1_I2STX_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_I2STX_APB_W::new(self, 7)
     }
     #[doc = "Bit 8 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_i2stx_4ch_rstn_bclk(
-        &mut self,
-    ) -> RSTN_U1_I2STX_4CH_RSTN_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_I2STX_4CH_RSTN_BCLK_W::new(self, 8)
+    pub fn u1_i2stx_bclk(&mut self) -> U1_I2STX_BCLK_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_I2STX_BCLK_W::new(self, 8)
     }
     #[doc = "Bit 9 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_ahb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_AHB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_AHB_W::new(self, 9)
+    pub fn u0_tdm16slot_ahb(&mut self) -> U0_TDM16SLOT_AHB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_AHB_W::new(self, 9)
     }
     #[doc = "Bit 10 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_tdm(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_TDM_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_TDM_W::new(self, 10)
+    pub fn u0_tdm16slot_tdm(&mut self) -> U0_TDM16SLOT_TDM_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_TDM_W::new(self, 10)
     }
     #[doc = "Bit 11 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_tdm16slot_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TDM16SLOT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TDM16SLOT_RSTN_APB_W::new(self, 11)
+    pub fn u0_tdm16slot_apb(&mut self) -> U0_TDM16SLOT_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TDM16SLOT_APB_W::new(self, 11)
     }
     #[doc = "Bit 12 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_pwm_8ch_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_PWM_8CH_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_PWM_8CH_RSTN_APB_W::new(self, 12)
+    pub fn u0_pwm_apb(&mut self) -> U0_PWM_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_PWM_APB_W::new(self, 12)
     }
     #[doc = "Bit 13 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
+    pub fn u0_dskit_wdt_rstn_apb(&mut self) -> U0_DSKIT_WDT_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_DSKIT_WDT_RSTN_APB_W::new(self, 13)
     }
     #[doc = "Bit 14 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_dskit_wdt_rstn_wdt(
-        &mut self,
-    ) -> RSTN_U0_DSKIT_WDT_RSTN_WDT_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_DSKIT_WDT_RSTN_WDT_W::new(self, 14)
+    pub fn u0_dskit_wdt(&mut self) -> U0_DSKIT_WDT_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_DSKIT_WDT_W::new(self, 14)
     }
     #[doc = "Bit 15 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_APB_W::new(self, 15)
+    pub fn u0_can_ctrl_apb(&mut self) -> U0_CAN_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_APB_W::new(self, 15)
     }
     #[doc = "Bit 16 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_CAN_W::new(self, 16)
+    pub fn u0_can_ctrl(&mut self) -> U0_CAN_CTRL_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_W::new(self, 16)
     }
     #[doc = "Bit 17 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U0_CAN_CTRL_RSTN_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_CAN_CTRL_RSTN_TIMER_W::new(self, 17)
+    pub fn u0_can_ctrl_timer(&mut self) -> U0_CAN_CTRL_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_CAN_CTRL_TIMER_W::new(self, 17)
     }
     #[doc = "Bit 18 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_APB_W::new(self, 18)
+    pub fn u1_can_ctrl_apb(&mut self) -> U1_CAN_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_APB_W::new(self, 18)
     }
     #[doc = "Bit 19 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_can(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_CAN_W::new(self, 19)
+    pub fn u1_can_ctrl_can(&mut self) -> U1_CAN_CTRL_CAN_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_CAN_W::new(self, 19)
     }
     #[doc = "Bit 20 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u1_can_ctrl_rstn_timer(
-        &mut self,
-    ) -> RSTN_U1_CAN_CTRL_RSTN_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U1_CAN_CTRL_RSTN_TIMER_W::new(self, 20)
+    pub fn u1_can_ctrl_timer(&mut self) -> U1_CAN_CTRL_TIMER_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U1_CAN_CTRL_TIMER_W::new(self, 20)
     }
     #[doc = "Bit 21 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_APB_W::new(self, 21)
+    pub fn u0_si5_timer_apb(&mut self) -> U0_SI5_TIMER_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_APB_W::new(self, 21)
     }
     #[doc = "Bit 22 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer0(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER0_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER0_W::new(self, 22)
+    pub fn u0_si5_timer_0(&mut self) -> U0_SI5_TIMER_0_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_0_W::new(self, 22)
     }
     #[doc = "Bit 23 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_time10(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIME10_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIME10_W::new(self, 23)
+    pub fn u0_si5_timer_1(&mut self) -> U0_SI5_TIMER_1_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_1_W::new(self, 23)
     }
     #[doc = "Bit 24 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer2(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER2_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER2_W::new(self, 24)
+    pub fn u0_si5_timer_2(&mut self) -> U0_SI5_TIMER_2_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_2_W::new(self, 24)
     }
     #[doc = "Bit 25 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_si5_timer_rstn_timer3(
-        &mut self,
-    ) -> RSTN_U0_SI5_TIMER_RSTN_TIMER3_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_SI5_TIMER_RSTN_TIMER3_W::new(self, 25)
+    pub fn u0_si5_timer_3(&mut self) -> U0_SI5_TIMER_3_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_SI5_TIMER_3_W::new(self, 25)
     }
     #[doc = "Bit 26 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_int_ctrl_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_INT_CTRL_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_INT_CTRL_RSTN_APB_W::new(self, 26)
+    pub fn u0_int_ctrl_apb(&mut self) -> U0_INT_CTRL_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_INT_CTRL_APB_W::new(self, 26)
     }
     #[doc = "Bit 27 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_apb(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_APB_W::new(self, 27)
+    pub fn u0_temp_sensor_apb(&mut self) -> U0_TEMP_SENSOR_APB_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TEMP_SENSOR_APB_W::new(self, 27)
     }
     #[doc = "Bit 28 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_temp_sensor_rstn_temp(
-        &mut self,
-    ) -> RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_TEMP_SENSOR_RSTN_TEMP_W::new(self, 28)
+    pub fn u0_temp_sensor(&mut self) -> U0_TEMP_SENSOR_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_TEMP_SENSOR_W::new(self, 28)
     }
     #[doc = "Bit 29 - 1: Assert reset, 0: De-assert reset"]
     #[inline(always)]
     #[must_use]
-    pub fn rstn_u0_jtag_certification_rst_n(
-        &mut self,
-    ) -> RSTN_U0_JTAG_CERTIFICATION_RST_N_W<SYSCRG_RST_STATUS_3_SPEC> {
-        RSTN_U0_JTAG_CERTIFICATION_RST_N_W::new(self, 29)
+    pub fn u0_jtag_rst(&mut self) -> U0_JTAG_RST_W<SYSCRG_RST_STATUS_3_SPEC> {
+        U0_JTAG_RST_W::new(self, 29)
     }
     #[doc = r" Writes raw bits to the register."]
     #[doc = r""]


### PR DESCRIPTION
Simplifies the reset field names for the `aoncrg`, `stgcrg`, and `syscrg` peripherals.