### PR TITLE
fixup/sys_pinctrl: `rts` feature and `sys_pinctrl` renaming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ members = [
 [features]
 visionfive2-12a = ["jh7110-vf2-12a-pac"]
 visionfive2-12a-rt = ["jh7110-vf2-12a-pac/rt"]
+visionfive2-12a-rts = ["jh7110-vf2-12a-pac/rts"]
 visionfive2-13b = ["jh7110-vf2-13b-pac"]
 visionfive2-13b-rt = ["jh7110-vf2-13b-pac/rt"]
+visionfive2-13b-rts = ["jh7110-vf2-13b-pac/rts"]
 all = ["visionfive2-12a", "visionfive2-13b"]

--- a/jh7110-vf2-12a-pac/Cargo.toml
+++ b/jh7110-vf2-12a-pac/Cargo.toml
@@ -24,3 +24,4 @@ optional = true
 default = ["critical-section"]
 critical-section = ["dep:critical-section"]
 rt = ["riscv-rt"]
+rts = ["riscv-rt/s-mode"]

--- a/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
+++ b/jh7110-vf2-12a-pac/jh7110-starfive-visionfive-2-v1.2a.svd
@@ -35812,7 +35812,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_0_3</name>
+          <name>gpo_dout_0</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
@@ -35845,7 +35845,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_4_7</name>
+          <name>gpo_dout_1</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
@@ -35878,7 +35878,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_8_11</name>
+          <name>gpo_dout_2</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
@@ -35911,7 +35911,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_12_15</name>
+          <name>gpo_dout_3</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
@@ -35944,7 +35944,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_16_19</name>
+          <name>gpo_dout_4</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
@@ -35977,7 +35977,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_20_23</name>
+          <name>gpo_dout_5</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
@@ -36010,7 +36010,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_24_27</name>
+          <name>gpo_dout_6</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
@@ -36043,7 +36043,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_28_31</name>
+          <name>gpo_dout_7</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
@@ -36076,7 +36076,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_32_35</name>
+          <name>gpo_dout_8</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
@@ -36109,7 +36109,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_36_39</name>
+          <name>gpo_dout_9</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
@@ -36142,7 +36142,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_40_43</name>
+          <name>gpo_dout_10</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
@@ -36175,7 +36175,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_44_47</name>
+          <name>gpo_dout_11</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
@@ -36208,7 +36208,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_48_51</name>
+          <name>gpo_dout_12</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
@@ -36241,7 +36241,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_52_55</name>
+          <name>gpo_dout_13</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
@@ -36274,7 +36274,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_56_59</name>
+          <name>gpo_dout_14</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
@@ -36307,7 +36307,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_60_63</name>
+          <name>gpo_dout_15</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT</description>
           <addressOffset>0x7c</addressOffset>
           <size>32</size>

--- a/jh7110-vf2-12a-pac/src/interrupt.rs
+++ b/jh7110-vf2-12a-pac/src/interrupt.rs
@@ -81,7 +81,7 @@ impl Interrupt {
         }
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 #[macro_export]
 #[doc = r" Assigns a handler to an interrupt"]
 #[doc = r""]

--- a/jh7110-vf2-12a-pac/src/lib.rs
+++ b/jh7110-vf2-12a-pac/src/lib.rs
@@ -9,7 +9,7 @@ use core::ops::Deref;
 use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 extern "C" {
     fn QSPI();
     fn UART0();
@@ -40,7 +40,7 @@ pub union Vector {
     pub _handler: unsafe extern "C" fn(),
     pub _reserved: usize,
 }
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 #[doc(hidden)]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 107] = [

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl.rs
@@ -17,22 +17,22 @@ pub struct RegisterBlock {
     gpo_doen_13: GPO_DOEN_13,
     gpo_doen_14: GPO_DOEN_14,
     gpo_doen_15: GPO_DOEN_15,
-    gpo_dout_0_3: GPO_DOUT_0_3,
-    gpo_dout_4_7: GPO_DOUT_4_7,
-    gpo_dout_8_11: GPO_DOUT_8_11,
-    gpo_dout_12_15: GPO_DOUT_12_15,
-    gpo_dout_16_19: GPO_DOUT_16_19,
-    gpo_dout_20_23: GPO_DOUT_20_23,
-    gpo_dout_24_27: GPO_DOUT_24_27,
-    gpo_dout_28_31: GPO_DOUT_28_31,
-    gpo_dout_32_35: GPO_DOUT_32_35,
-    gpo_dout_36_39: GPO_DOUT_36_39,
-    gpo_dout_40_43: GPO_DOUT_40_43,
-    gpo_dout_44_47: GPO_DOUT_44_47,
-    gpo_dout_48_51: GPO_DOUT_48_51,
-    gpo_dout_52_55: GPO_DOUT_52_55,
-    gpo_dout_56_59: GPO_DOUT_56_59,
-    gpo_dout_60_63: GPO_DOUT_60_63,
+    gpo_dout_0: GPO_DOUT_0,
+    gpo_dout_1: GPO_DOUT_1,
+    gpo_dout_2: GPO_DOUT_2,
+    gpo_dout_3: GPO_DOUT_3,
+    gpo_dout_4: GPO_DOUT_4,
+    gpo_dout_5: GPO_DOUT_5,
+    gpo_dout_6: GPO_DOUT_6,
+    gpo_dout_7: GPO_DOUT_7,
+    gpo_dout_8: GPO_DOUT_8,
+    gpo_dout_9: GPO_DOUT_9,
+    gpo_dout_10: GPO_DOUT_10,
+    gpo_dout_11: GPO_DOUT_11,
+    gpo_dout_12: GPO_DOUT_12,
+    gpo_dout_13: GPO_DOUT_13,
+    gpo_dout_14: GPO_DOUT_14,
+    gpo_dout_15: GPO_DOUT_15,
     gpi_0: GPI_0,
     gpi_1: GPI_1,
     gpi_2: GPI_2,
@@ -259,83 +259,83 @@ impl RegisterBlock {
     }
     #[doc = "0x40 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_0_3(&self) -> &GPO_DOUT_0_3 {
-        &self.gpo_dout_0_3
+    pub const fn gpo_dout_0(&self) -> &GPO_DOUT_0 {
+        &self.gpo_dout_0
     }
     #[doc = "0x44 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_4_7(&self) -> &GPO_DOUT_4_7 {
-        &self.gpo_dout_4_7
+    pub const fn gpo_dout_1(&self) -> &GPO_DOUT_1 {
+        &self.gpo_dout_1
     }
     #[doc = "0x48 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_8_11(&self) -> &GPO_DOUT_8_11 {
-        &self.gpo_dout_8_11
+    pub const fn gpo_dout_2(&self) -> &GPO_DOUT_2 {
+        &self.gpo_dout_2
     }
     #[doc = "0x4c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_12_15(&self) -> &GPO_DOUT_12_15 {
-        &self.gpo_dout_12_15
+    pub const fn gpo_dout_3(&self) -> &GPO_DOUT_3 {
+        &self.gpo_dout_3
     }
     #[doc = "0x50 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_16_19(&self) -> &GPO_DOUT_16_19 {
-        &self.gpo_dout_16_19
+    pub const fn gpo_dout_4(&self) -> &GPO_DOUT_4 {
+        &self.gpo_dout_4
     }
     #[doc = "0x54 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_20_23(&self) -> &GPO_DOUT_20_23 {
-        &self.gpo_dout_20_23
+    pub const fn gpo_dout_5(&self) -> &GPO_DOUT_5 {
+        &self.gpo_dout_5
     }
     #[doc = "0x58 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_24_27(&self) -> &GPO_DOUT_24_27 {
-        &self.gpo_dout_24_27
+    pub const fn gpo_dout_6(&self) -> &GPO_DOUT_6 {
+        &self.gpo_dout_6
     }
     #[doc = "0x5c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_28_31(&self) -> &GPO_DOUT_28_31 {
-        &self.gpo_dout_28_31
+    pub const fn gpo_dout_7(&self) -> &GPO_DOUT_7 {
+        &self.gpo_dout_7
     }
     #[doc = "0x60 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_32_35(&self) -> &GPO_DOUT_32_35 {
-        &self.gpo_dout_32_35
+    pub const fn gpo_dout_8(&self) -> &GPO_DOUT_8 {
+        &self.gpo_dout_8
     }
     #[doc = "0x64 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_36_39(&self) -> &GPO_DOUT_36_39 {
-        &self.gpo_dout_36_39
+    pub const fn gpo_dout_9(&self) -> &GPO_DOUT_9 {
+        &self.gpo_dout_9
     }
     #[doc = "0x68 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_40_43(&self) -> &GPO_DOUT_40_43 {
-        &self.gpo_dout_40_43
+    pub const fn gpo_dout_10(&self) -> &GPO_DOUT_10 {
+        &self.gpo_dout_10
     }
     #[doc = "0x6c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_44_47(&self) -> &GPO_DOUT_44_47 {
-        &self.gpo_dout_44_47
+    pub const fn gpo_dout_11(&self) -> &GPO_DOUT_11 {
+        &self.gpo_dout_11
     }
     #[doc = "0x70 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_48_51(&self) -> &GPO_DOUT_48_51 {
-        &self.gpo_dout_48_51
+    pub const fn gpo_dout_12(&self) -> &GPO_DOUT_12 {
+        &self.gpo_dout_12
     }
     #[doc = "0x74 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_52_55(&self) -> &GPO_DOUT_52_55 {
-        &self.gpo_dout_52_55
+    pub const fn gpo_dout_13(&self) -> &GPO_DOUT_13 {
+        &self.gpo_dout_13
     }
     #[doc = "0x78 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_56_59(&self) -> &GPO_DOUT_56_59 {
-        &self.gpo_dout_56_59
+    pub const fn gpo_dout_14(&self) -> &GPO_DOUT_14 {
+        &self.gpo_dout_14
     }
     #[doc = "0x7c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_60_63(&self) -> &GPO_DOUT_60_63 {
-        &self.gpo_dout_60_63
+    pub const fn gpo_dout_15(&self) -> &GPO_DOUT_15 {
+        &self.gpo_dout_15
     }
     #[doc = "0x80 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO GPI 0 - The register can be used to configure the selected GPIO connector number for input signals. The signal name is indicated in the \"Name\" column of the following table per StarFive naming conventions. For example, name \"u0_WAVE511_i_uart_rxsin_cfg\" indicates the corresponding input signal is \"u0_WAVE511.i_uart_rxsin\". See GPIO Input Signals (on page 107) for a complete list of the input GPIO signals."]
     #[inline(always)]
@@ -1128,86 +1128,86 @@ module"]
 pub type GPO_DOEN_15 = crate::Reg<gpo_doen_15::GPO_DOEN_15_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX 15 DOEN"]
 pub mod gpo_doen_15;
-#[doc = "gpo_dout_0_3 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_0_3`]
+#[doc = "gpo_dout_0 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_0`]
 module"]
-pub type GPO_DOUT_0_3 = crate::Reg<gpo_dout_0_3::GPO_DOUT_0_3_SPEC>;
+pub type GPO_DOUT_0 = crate::Reg<gpo_dout_0::GPO_DOUT_0_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT"]
-pub mod gpo_dout_0_3;
-#[doc = "gpo_dout_4_7 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_4_7`]
+pub mod gpo_dout_0;
+#[doc = "gpo_dout_1 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_1`]
 module"]
-pub type GPO_DOUT_4_7 = crate::Reg<gpo_dout_4_7::GPO_DOUT_4_7_SPEC>;
+pub type GPO_DOUT_1 = crate::Reg<gpo_dout_1::GPO_DOUT_1_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT"]
-pub mod gpo_dout_4_7;
-#[doc = "gpo_dout_8_11 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_8_11`]
+pub mod gpo_dout_1;
+#[doc = "gpo_dout_2 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_2`]
 module"]
-pub type GPO_DOUT_8_11 = crate::Reg<gpo_dout_8_11::GPO_DOUT_8_11_SPEC>;
+pub type GPO_DOUT_2 = crate::Reg<gpo_dout_2::GPO_DOUT_2_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT"]
-pub mod gpo_dout_8_11;
-#[doc = "gpo_dout_12_15 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_12_15`]
+pub mod gpo_dout_2;
+#[doc = "gpo_dout_3 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_3`]
 module"]
-pub type GPO_DOUT_12_15 = crate::Reg<gpo_dout_12_15::GPO_DOUT_12_15_SPEC>;
+pub type GPO_DOUT_3 = crate::Reg<gpo_dout_3::GPO_DOUT_3_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT"]
-pub mod gpo_dout_12_15;
-#[doc = "gpo_dout_16_19 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_16_19::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_16_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_16_19`]
+pub mod gpo_dout_3;
+#[doc = "gpo_dout_4 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_4`]
 module"]
-pub type GPO_DOUT_16_19 = crate::Reg<gpo_dout_16_19::GPO_DOUT_16_19_SPEC>;
+pub type GPO_DOUT_4 = crate::Reg<gpo_dout_4::GPO_DOUT_4_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT"]
-pub mod gpo_dout_16_19;
-#[doc = "gpo_dout_20_23 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_20_23::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_20_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_20_23`]
+pub mod gpo_dout_4;
+#[doc = "gpo_dout_5 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_5`]
 module"]
-pub type GPO_DOUT_20_23 = crate::Reg<gpo_dout_20_23::GPO_DOUT_20_23_SPEC>;
+pub type GPO_DOUT_5 = crate::Reg<gpo_dout_5::GPO_DOUT_5_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT"]
-pub mod gpo_dout_20_23;
-#[doc = "gpo_dout_24_27 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_24_27::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_24_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_24_27`]
+pub mod gpo_dout_5;
+#[doc = "gpo_dout_6 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_6::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_6`]
 module"]
-pub type GPO_DOUT_24_27 = crate::Reg<gpo_dout_24_27::GPO_DOUT_24_27_SPEC>;
+pub type GPO_DOUT_6 = crate::Reg<gpo_dout_6::GPO_DOUT_6_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT"]
-pub mod gpo_dout_24_27;
-#[doc = "gpo_dout_28_31 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_28_31::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_28_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_28_31`]
+pub mod gpo_dout_6;
+#[doc = "gpo_dout_7 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_7`]
 module"]
-pub type GPO_DOUT_28_31 = crate::Reg<gpo_dout_28_31::GPO_DOUT_28_31_SPEC>;
+pub type GPO_DOUT_7 = crate::Reg<gpo_dout_7::GPO_DOUT_7_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT"]
-pub mod gpo_dout_28_31;
-#[doc = "gpo_dout_32_35 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_32_35::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_32_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_32_35`]
+pub mod gpo_dout_7;
+#[doc = "gpo_dout_8 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_8`]
 module"]
-pub type GPO_DOUT_32_35 = crate::Reg<gpo_dout_32_35::GPO_DOUT_32_35_SPEC>;
+pub type GPO_DOUT_8 = crate::Reg<gpo_dout_8::GPO_DOUT_8_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT"]
-pub mod gpo_dout_32_35;
-#[doc = "gpo_dout_36_39 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_36_39::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_36_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_36_39`]
+pub mod gpo_dout_8;
+#[doc = "gpo_dout_9 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_9::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_9`]
 module"]
-pub type GPO_DOUT_36_39 = crate::Reg<gpo_dout_36_39::GPO_DOUT_36_39_SPEC>;
+pub type GPO_DOUT_9 = crate::Reg<gpo_dout_9::GPO_DOUT_9_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT"]
-pub mod gpo_dout_36_39;
-#[doc = "gpo_dout_40_43 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_40_43::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_40_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_40_43`]
+pub mod gpo_dout_9;
+#[doc = "gpo_dout_10 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_10::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_10`]
 module"]
-pub type GPO_DOUT_40_43 = crate::Reg<gpo_dout_40_43::GPO_DOUT_40_43_SPEC>;
+pub type GPO_DOUT_10 = crate::Reg<gpo_dout_10::GPO_DOUT_10_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT"]
-pub mod gpo_dout_40_43;
-#[doc = "gpo_dout_44_47 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_44_47::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_44_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_44_47`]
+pub mod gpo_dout_10;
+#[doc = "gpo_dout_11 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_11`]
 module"]
-pub type GPO_DOUT_44_47 = crate::Reg<gpo_dout_44_47::GPO_DOUT_44_47_SPEC>;
+pub type GPO_DOUT_11 = crate::Reg<gpo_dout_11::GPO_DOUT_11_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT"]
-pub mod gpo_dout_44_47;
-#[doc = "gpo_dout_48_51 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_48_51::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_48_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_48_51`]
+pub mod gpo_dout_11;
+#[doc = "gpo_dout_12 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_12`]
 module"]
-pub type GPO_DOUT_48_51 = crate::Reg<gpo_dout_48_51::GPO_DOUT_48_51_SPEC>;
+pub type GPO_DOUT_12 = crate::Reg<gpo_dout_12::GPO_DOUT_12_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT"]
-pub mod gpo_dout_48_51;
-#[doc = "gpo_dout_52_55 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_52_55::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_52_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_52_55`]
+pub mod gpo_dout_12;
+#[doc = "gpo_dout_13 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_13::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_13`]
 module"]
-pub type GPO_DOUT_52_55 = crate::Reg<gpo_dout_52_55::GPO_DOUT_52_55_SPEC>;
+pub type GPO_DOUT_13 = crate::Reg<gpo_dout_13::GPO_DOUT_13_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT"]
-pub mod gpo_dout_52_55;
-#[doc = "gpo_dout_56_59 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_56_59::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_56_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_56_59`]
+pub mod gpo_dout_13;
+#[doc = "gpo_dout_14 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_14::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_14`]
 module"]
-pub type GPO_DOUT_56_59 = crate::Reg<gpo_dout_56_59::GPO_DOUT_56_59_SPEC>;
+pub type GPO_DOUT_14 = crate::Reg<gpo_dout_14::GPO_DOUT_14_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT"]
-pub mod gpo_dout_56_59;
-#[doc = "gpo_dout_60_63 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_60_63::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_60_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_60_63`]
+pub mod gpo_dout_14;
+#[doc = "gpo_dout_15 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_15`]
 module"]
-pub type GPO_DOUT_60_63 = crate::Reg<gpo_dout_60_63::GPO_DOUT_60_63_SPEC>;
+pub type GPO_DOUT_15 = crate::Reg<gpo_dout_15::GPO_DOUT_15_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT"]
-pub mod gpo_dout_60_63;
+pub mod gpo_dout_15;
 #[doc = "gpi_0 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO GPI 0 - The register can be used to configure the selected GPIO connector number for input signals. The signal name is indicated in the \"Name\" column of the following table per StarFive naming conventions. For example, name \"u0_WAVE511_i_uart_rxsin_cfg\" indicates the corresponding input signal is \"u0_WAVE511.i_uart_rxsin\". See GPIO Input Signals (on page 107) for a complete list of the input GPIO signals.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpi_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpi_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpi_0`]
 module"]
 pub type GPI_0 = crate::Reg<gpi_0::GPI_0_SPEC>;

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_0.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_0.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_0_3` reader"]
-pub type R = crate::R<GPO_DOUT_0_3_SPEC>;
-#[doc = "Register `gpo_dout_0_3` writer"]
-pub type W = crate::W<GPO_DOUT_0_3_SPEC>;
+#[doc = "Register `gpo_dout_0` reader"]
+pub type R = crate::R<GPO_DOUT_0_SPEC>;
+#[doc = "Register `gpo_dout_0` writer"]
+pub type W = crate::W<GPO_DOUT_0_SPEC>;
 #[doc = "Field `dout_0` reader - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_0_R = crate::FieldReader;
 #[doc = "Field `dout_0` writer - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_0(&mut self) -> DOUT_0_W<GPO_DOUT_0_3_SPEC> {
+    pub fn dout_0(&mut self) -> DOUT_0_W<GPO_DOUT_0_SPEC> {
         DOUT_0_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO1. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_1(&mut self) -> DOUT_1_W<GPO_DOUT_0_3_SPEC> {
+    pub fn dout_1(&mut self) -> DOUT_1_W<GPO_DOUT_0_SPEC> {
         DOUT_1_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO2. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_2(&mut self) -> DOUT_2_W<GPO_DOUT_0_3_SPEC> {
+    pub fn dout_2(&mut self) -> DOUT_2_W<GPO_DOUT_0_SPEC> {
         DOUT_2_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO3. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_3(&mut self) -> DOUT_3_W<GPO_DOUT_0_3_SPEC> {
+    pub fn dout_3(&mut self) -> DOUT_3_W<GPO_DOUT_0_SPEC> {
         DOUT_3_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_0_3_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_0_3_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_0_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_0_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_0_3::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_0_3_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_0_3::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_0_3_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_0::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_0::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_0_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_0_3 to value 0x1600_0000"]
-impl crate::Resettable for GPO_DOUT_0_3_SPEC {
+#[doc = "`reset()` method sets gpo_dout_0 to value 0x1600_0000"]
+impl crate::Resettable for GPO_DOUT_0_SPEC {
     const RESET_VALUE: Self::Ux = 0x1600_0000;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_1.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_1.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_4_7` reader"]
-pub type R = crate::R<GPO_DOUT_4_7_SPEC>;
-#[doc = "Register `gpo_dout_4_7` writer"]
-pub type W = crate::W<GPO_DOUT_4_7_SPEC>;
+#[doc = "Register `gpo_dout_1` reader"]
+pub type R = crate::R<GPO_DOUT_1_SPEC>;
+#[doc = "Register `gpo_dout_1` writer"]
+pub type W = crate::W<GPO_DOUT_1_SPEC>;
 #[doc = "Field `dout_4` reader - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_4_R = crate::FieldReader;
 #[doc = "Field `dout_4` writer - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_4(&mut self) -> DOUT_4_W<GPO_DOUT_4_7_SPEC> {
+    pub fn dout_4(&mut self) -> DOUT_4_W<GPO_DOUT_1_SPEC> {
         DOUT_4_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO5. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_5(&mut self) -> DOUT_5_W<GPO_DOUT_4_7_SPEC> {
+    pub fn dout_5(&mut self) -> DOUT_5_W<GPO_DOUT_1_SPEC> {
         DOUT_5_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO6. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_6(&mut self) -> DOUT_6_W<GPO_DOUT_4_7_SPEC> {
+    pub fn dout_6(&mut self) -> DOUT_6_W<GPO_DOUT_1_SPEC> {
         DOUT_6_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO7. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_7(&mut self) -> DOUT_7_W<GPO_DOUT_4_7_SPEC> {
+    pub fn dout_7(&mut self) -> DOUT_7_W<GPO_DOUT_1_SPEC> {
         DOUT_7_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4_7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_4_7_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_4_7_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_1_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_1_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_4_7::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_4_7_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_4_7::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_4_7_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_1::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_1::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_1_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_4_7 to value 0x1400"]
-impl crate::Resettable for GPO_DOUT_4_7_SPEC {
+#[doc = "`reset()` method sets gpo_dout_1 to value 0x1400"]
+impl crate::Resettable for GPO_DOUT_1_SPEC {
     const RESET_VALUE: Self::Ux = 0x1400;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_10.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_10.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_40_43` reader"]
-pub type R = crate::R<GPO_DOUT_40_43_SPEC>;
-#[doc = "Register `gpo_dout_40_43` writer"]
-pub type W = crate::W<GPO_DOUT_40_43_SPEC>;
+#[doc = "Register `gpo_dout_10` reader"]
+pub type R = crate::R<GPO_DOUT_10_SPEC>;
+#[doc = "Register `gpo_dout_10` writer"]
+pub type W = crate::W<GPO_DOUT_10_SPEC>;
 #[doc = "Field `dout_40` reader - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_40_R = crate::FieldReader;
 #[doc = "Field `dout_40` writer - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_40(&mut self) -> DOUT_40_W<GPO_DOUT_40_43_SPEC> {
+    pub fn dout_40(&mut self) -> DOUT_40_W<GPO_DOUT_10_SPEC> {
         DOUT_40_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO41. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_41(&mut self) -> DOUT_41_W<GPO_DOUT_40_43_SPEC> {
+    pub fn dout_41(&mut self) -> DOUT_41_W<GPO_DOUT_10_SPEC> {
         DOUT_41_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO42. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_42(&mut self) -> DOUT_42_W<GPO_DOUT_40_43_SPEC> {
+    pub fn dout_42(&mut self) -> DOUT_42_W<GPO_DOUT_10_SPEC> {
         DOUT_42_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO43. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_43(&mut self) -> DOUT_43_W<GPO_DOUT_40_43_SPEC> {
+    pub fn dout_43(&mut self) -> DOUT_43_W<GPO_DOUT_10_SPEC> {
         DOUT_43_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_40_43::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_40_43::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_40_43_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_40_43_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_10::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_10_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_10_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_40_43::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_40_43_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_40_43::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_40_43_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_10::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_10_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_10::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_10_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_40_43 to value 0x004e_4f00"]
-impl crate::Resettable for GPO_DOUT_40_43_SPEC {
+#[doc = "`reset()` method sets gpo_dout_10 to value 0x004e_4f00"]
+impl crate::Resettable for GPO_DOUT_10_SPEC {
     const RESET_VALUE: Self::Ux = 0x004e_4f00;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_11.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_11.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_44_47` reader"]
-pub type R = crate::R<GPO_DOUT_44_47_SPEC>;
-#[doc = "Register `gpo_dout_44_47` writer"]
-pub type W = crate::W<GPO_DOUT_44_47_SPEC>;
+#[doc = "Register `gpo_dout_11` reader"]
+pub type R = crate::R<GPO_DOUT_11_SPEC>;
+#[doc = "Register `gpo_dout_11` writer"]
+pub type W = crate::W<GPO_DOUT_11_SPEC>;
 #[doc = "Field `dout_44` reader - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_44_R = crate::FieldReader;
 #[doc = "Field `dout_44` writer - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_44(&mut self) -> DOUT_44_W<GPO_DOUT_44_47_SPEC> {
+    pub fn dout_44(&mut self) -> DOUT_44_W<GPO_DOUT_11_SPEC> {
         DOUT_44_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO45. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_45(&mut self) -> DOUT_45_W<GPO_DOUT_44_47_SPEC> {
+    pub fn dout_45(&mut self) -> DOUT_45_W<GPO_DOUT_11_SPEC> {
         DOUT_45_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO46. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_46(&mut self) -> DOUT_46_W<GPO_DOUT_44_47_SPEC> {
+    pub fn dout_46(&mut self) -> DOUT_46_W<GPO_DOUT_11_SPEC> {
         DOUT_46_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO47. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_47(&mut self) -> DOUT_47_W<GPO_DOUT_44_47_SPEC> {
+    pub fn dout_47(&mut self) -> DOUT_47_W<GPO_DOUT_11_SPEC> {
         DOUT_47_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_44_47::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_44_47::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_44_47_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_44_47_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_11::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_11_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_11_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_44_47::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_44_47_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_44_47::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_44_47_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_11::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_11_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_11::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_11_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_44_47 to value 0x005b_5c00"]
-impl crate::Resettable for GPO_DOUT_44_47_SPEC {
+#[doc = "`reset()` method sets gpo_dout_11 to value 0x005b_5c00"]
+impl crate::Resettable for GPO_DOUT_11_SPEC {
     const RESET_VALUE: Self::Ux = 0x005b_5c00;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_12.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_12.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_48_51` reader"]
-pub type R = crate::R<GPO_DOUT_48_51_SPEC>;
-#[doc = "Register `gpo_dout_48_51` writer"]
-pub type W = crate::W<GPO_DOUT_48_51_SPEC>;
+#[doc = "Register `gpo_dout_12` reader"]
+pub type R = crate::R<GPO_DOUT_12_SPEC>;
+#[doc = "Register `gpo_dout_12` writer"]
+pub type W = crate::W<GPO_DOUT_12_SPEC>;
 #[doc = "Field `dout_48` reader - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_48_R = crate::FieldReader;
 #[doc = "Field `dout_48` writer - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_48(&mut self) -> DOUT_48_W<GPO_DOUT_48_51_SPEC> {
+    pub fn dout_48(&mut self) -> DOUT_48_W<GPO_DOUT_12_SPEC> {
         DOUT_48_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO49. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_49(&mut self) -> DOUT_49_W<GPO_DOUT_48_51_SPEC> {
+    pub fn dout_49(&mut self) -> DOUT_49_W<GPO_DOUT_12_SPEC> {
         DOUT_49_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO50. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_50(&mut self) -> DOUT_50_W<GPO_DOUT_48_51_SPEC> {
+    pub fn dout_50(&mut self) -> DOUT_50_W<GPO_DOUT_12_SPEC> {
         DOUT_50_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO51. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_51(&mut self) -> DOUT_51_W<GPO_DOUT_48_51_SPEC> {
+    pub fn dout_51(&mut self) -> DOUT_51_W<GPO_DOUT_12_SPEC> {
         DOUT_51_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_48_51::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_48_51::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_48_51_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_48_51_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_12_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_12_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_48_51::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_48_51_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_48_51::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_48_51_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_12::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_12_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_12::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_12_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_48_51 to value 0x2000_1e1f"]
-impl crate::Resettable for GPO_DOUT_48_51_SPEC {
+#[doc = "`reset()` method sets gpo_dout_12 to value 0x2000_1e1f"]
+impl crate::Resettable for GPO_DOUT_12_SPEC {
     const RESET_VALUE: Self::Ux = 0x2000_1e1f;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_13.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_13.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_52_55` reader"]
-pub type R = crate::R<GPO_DOUT_52_55_SPEC>;
-#[doc = "Register `gpo_dout_52_55` writer"]
-pub type W = crate::W<GPO_DOUT_52_55_SPEC>;
+#[doc = "Register `gpo_dout_13` reader"]
+pub type R = crate::R<GPO_DOUT_13_SPEC>;
+#[doc = "Register `gpo_dout_13` writer"]
+pub type W = crate::W<GPO_DOUT_13_SPEC>;
 #[doc = "Field `dout_52` reader - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_52_R = crate::FieldReader;
 #[doc = "Field `dout_52` writer - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_52(&mut self) -> DOUT_52_W<GPO_DOUT_52_55_SPEC> {
+    pub fn dout_52(&mut self) -> DOUT_52_W<GPO_DOUT_13_SPEC> {
         DOUT_52_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO53. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_53(&mut self) -> DOUT_53_W<GPO_DOUT_52_55_SPEC> {
+    pub fn dout_53(&mut self) -> DOUT_53_W<GPO_DOUT_13_SPEC> {
         DOUT_53_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO54. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_54(&mut self) -> DOUT_54_W<GPO_DOUT_52_55_SPEC> {
+    pub fn dout_54(&mut self) -> DOUT_54_W<GPO_DOUT_13_SPEC> {
         DOUT_54_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO55. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_55(&mut self) -> DOUT_55_W<GPO_DOUT_52_55_SPEC> {
+    pub fn dout_55(&mut self) -> DOUT_55_W<GPO_DOUT_13_SPEC> {
         DOUT_55_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_52_55::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_52_55::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_52_55_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_52_55_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_13::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_13_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_13_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_52_55::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_52_55_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_52_55::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_52_55_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_13::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_13_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_13::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_13_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_52_55 to value 0x4b00_494a"]
-impl crate::Resettable for GPO_DOUT_52_55_SPEC {
+#[doc = "`reset()` method sets gpo_dout_13 to value 0x4b00_494a"]
+impl crate::Resettable for GPO_DOUT_13_SPEC {
     const RESET_VALUE: Self::Ux = 0x4b00_494a;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_14.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_14.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_56_59` reader"]
-pub type R = crate::R<GPO_DOUT_56_59_SPEC>;
-#[doc = "Register `gpo_dout_56_59` writer"]
-pub type W = crate::W<GPO_DOUT_56_59_SPEC>;
+#[doc = "Register `gpo_dout_14` reader"]
+pub type R = crate::R<GPO_DOUT_14_SPEC>;
+#[doc = "Register `gpo_dout_14` writer"]
+pub type W = crate::W<GPO_DOUT_14_SPEC>;
 #[doc = "Field `dout_56` reader - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_56_R = crate::FieldReader;
 #[doc = "Field `dout_56` writer - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_56(&mut self) -> DOUT_56_W<GPO_DOUT_56_59_SPEC> {
+    pub fn dout_56(&mut self) -> DOUT_56_W<GPO_DOUT_14_SPEC> {
         DOUT_56_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO57. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_57(&mut self) -> DOUT_57_W<GPO_DOUT_56_59_SPEC> {
+    pub fn dout_57(&mut self) -> DOUT_57_W<GPO_DOUT_14_SPEC> {
         DOUT_57_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO58. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_58(&mut self) -> DOUT_58_W<GPO_DOUT_56_59_SPEC> {
+    pub fn dout_58(&mut self) -> DOUT_58_W<GPO_DOUT_14_SPEC> {
         DOUT_58_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO59. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_59(&mut self) -> DOUT_59_W<GPO_DOUT_56_59_SPEC> {
+    pub fn dout_59(&mut self) -> DOUT_59_W<GPO_DOUT_14_SPEC> {
         DOUT_59_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_56_59::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_56_59::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_56_59_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_56_59_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_14::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_14_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_14_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_56_59::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_56_59_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_56_59::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_56_59_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_14::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_14_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_14::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_14_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_56_59 to value 0x5800_5657"]
-impl crate::Resettable for GPO_DOUT_56_59_SPEC {
+#[doc = "`reset()` method sets gpo_dout_14 to value 0x5800_5657"]
+impl crate::Resettable for GPO_DOUT_14_SPEC {
     const RESET_VALUE: Self::Ux = 0x5800_5657;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_15.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_15.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_60_63` reader"]
-pub type R = crate::R<GPO_DOUT_60_63_SPEC>;
-#[doc = "Register `gpo_dout_60_63` writer"]
-pub type W = crate::W<GPO_DOUT_60_63_SPEC>;
+#[doc = "Register `gpo_dout_15` reader"]
+pub type R = crate::R<GPO_DOUT_15_SPEC>;
+#[doc = "Register `gpo_dout_15` writer"]
+pub type W = crate::W<GPO_DOUT_15_SPEC>;
 #[doc = "Field `dout_60` reader - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_60_R = crate::FieldReader;
 #[doc = "Field `dout_60` writer - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_60(&mut self) -> DOUT_60_W<GPO_DOUT_60_63_SPEC> {
+    pub fn dout_60(&mut self) -> DOUT_60_W<GPO_DOUT_15_SPEC> {
         DOUT_60_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO61. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_61(&mut self) -> DOUT_61_W<GPO_DOUT_60_63_SPEC> {
+    pub fn dout_61(&mut self) -> DOUT_61_W<GPO_DOUT_15_SPEC> {
         DOUT_61_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO62. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_62(&mut self) -> DOUT_62_W<GPO_DOUT_60_63_SPEC> {
+    pub fn dout_62(&mut self) -> DOUT_62_W<GPO_DOUT_15_SPEC> {
         DOUT_62_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO63. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_63(&mut self) -> DOUT_63_W<GPO_DOUT_60_63_SPEC> {
+    pub fn dout_63(&mut self) -> DOUT_63_W<GPO_DOUT_15_SPEC> {
         DOUT_63_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_60_63::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_60_63::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_60_63_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_60_63_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_15::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_15_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_15_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_60_63::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_60_63_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_60_63::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_60_63_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_15::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_15_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_15::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_15_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_60_63 to value 0x5f00_5d5e"]
-impl crate::Resettable for GPO_DOUT_60_63_SPEC {
+#[doc = "`reset()` method sets gpo_dout_15 to value 0x5f00_5d5e"]
+impl crate::Resettable for GPO_DOUT_15_SPEC {
     const RESET_VALUE: Self::Ux = 0x5f00_5d5e;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_2.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_2.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_8_11` reader"]
-pub type R = crate::R<GPO_DOUT_8_11_SPEC>;
-#[doc = "Register `gpo_dout_8_11` writer"]
-pub type W = crate::W<GPO_DOUT_8_11_SPEC>;
+#[doc = "Register `gpo_dout_2` reader"]
+pub type R = crate::R<GPO_DOUT_2_SPEC>;
+#[doc = "Register `gpo_dout_2` writer"]
+pub type W = crate::W<GPO_DOUT_2_SPEC>;
 #[doc = "Field `dout_8` reader - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_8_R = crate::FieldReader;
 #[doc = "Field `dout_8` writer - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_8(&mut self) -> DOUT_8_W<GPO_DOUT_8_11_SPEC> {
+    pub fn dout_8(&mut self) -> DOUT_8_W<GPO_DOUT_2_SPEC> {
         DOUT_8_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO9. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_9(&mut self) -> DOUT_9_W<GPO_DOUT_8_11_SPEC> {
+    pub fn dout_9(&mut self) -> DOUT_9_W<GPO_DOUT_2_SPEC> {
         DOUT_9_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO10. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_10(&mut self) -> DOUT_10_W<GPO_DOUT_8_11_SPEC> {
+    pub fn dout_10(&mut self) -> DOUT_10_W<GPO_DOUT_2_SPEC> {
         DOUT_10_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO11. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_11(&mut self) -> DOUT_11_W<GPO_DOUT_8_11_SPEC> {
+    pub fn dout_11(&mut self) -> DOUT_11_W<GPO_DOUT_2_SPEC> {
         DOUT_11_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8_11::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_8_11_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_8_11_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_2_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_2_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_8_11::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_8_11_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_8_11::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_8_11_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_2::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_2::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_2_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_8_11 to value 0x1500_0000"]
-impl crate::Resettable for GPO_DOUT_8_11_SPEC {
+#[doc = "`reset()` method sets gpo_dout_2 to value 0x1500_0000"]
+impl crate::Resettable for GPO_DOUT_2_SPEC {
     const RESET_VALUE: Self::Ux = 0x1500_0000;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_3.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_3.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_12_15` reader"]
-pub type R = crate::R<GPO_DOUT_12_15_SPEC>;
-#[doc = "Register `gpo_dout_12_15` writer"]
-pub type W = crate::W<GPO_DOUT_12_15_SPEC>;
+#[doc = "Register `gpo_dout_3` reader"]
+pub type R = crate::R<GPO_DOUT_3_SPEC>;
+#[doc = "Register `gpo_dout_3` writer"]
+pub type W = crate::W<GPO_DOUT_3_SPEC>;
 #[doc = "Field `dout_12` reader - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_12_R = crate::FieldReader;
 #[doc = "Field `dout_12` writer - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_12(&mut self) -> DOUT_12_W<GPO_DOUT_12_15_SPEC> {
+    pub fn dout_12(&mut self) -> DOUT_12_W<GPO_DOUT_3_SPEC> {
         DOUT_12_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO13. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_13(&mut self) -> DOUT_13_W<GPO_DOUT_12_15_SPEC> {
+    pub fn dout_13(&mut self) -> DOUT_13_W<GPO_DOUT_3_SPEC> {
         DOUT_13_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO14. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_14(&mut self) -> DOUT_14_W<GPO_DOUT_12_15_SPEC> {
+    pub fn dout_14(&mut self) -> DOUT_14_W<GPO_DOUT_3_SPEC> {
         DOUT_14_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO15. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_15(&mut self) -> DOUT_15_W<GPO_DOUT_12_15_SPEC> {
+    pub fn dout_15(&mut self) -> DOUT_15_W<GPO_DOUT_3_SPEC> {
         DOUT_15_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12_15::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_12_15_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_12_15_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_3_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_3_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_12_15::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_12_15_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_12_15::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_12_15_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_3::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_3::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_3_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_12_15 to value 0"]
-impl crate::Resettable for GPO_DOUT_12_15_SPEC {
+#[doc = "`reset()` method sets gpo_dout_3 to value 0"]
+impl crate::Resettable for GPO_DOUT_3_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_4.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_4.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_16_19` reader"]
-pub type R = crate::R<GPO_DOUT_16_19_SPEC>;
-#[doc = "Register `gpo_dout_16_19` writer"]
-pub type W = crate::W<GPO_DOUT_16_19_SPEC>;
+#[doc = "Register `gpo_dout_4` reader"]
+pub type R = crate::R<GPO_DOUT_4_SPEC>;
+#[doc = "Register `gpo_dout_4` writer"]
+pub type W = crate::W<GPO_DOUT_4_SPEC>;
 #[doc = "Field `dout_16` reader - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_16_R = crate::FieldReader;
 #[doc = "Field `dout_16` writer - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_16(&mut self) -> DOUT_16_W<GPO_DOUT_16_19_SPEC> {
+    pub fn dout_16(&mut self) -> DOUT_16_W<GPO_DOUT_4_SPEC> {
         DOUT_16_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO17. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_17(&mut self) -> DOUT_17_W<GPO_DOUT_16_19_SPEC> {
+    pub fn dout_17(&mut self) -> DOUT_17_W<GPO_DOUT_4_SPEC> {
         DOUT_17_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO18. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_18(&mut self) -> DOUT_18_W<GPO_DOUT_16_19_SPEC> {
+    pub fn dout_18(&mut self) -> DOUT_18_W<GPO_DOUT_4_SPEC> {
         DOUT_18_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO19. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_19(&mut self) -> DOUT_19_W<GPO_DOUT_16_19_SPEC> {
+    pub fn dout_19(&mut self) -> DOUT_19_W<GPO_DOUT_4_SPEC> {
         DOUT_19_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_16_19::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_16_19::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_16_19_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_16_19_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_4_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_4_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_16_19::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_16_19_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_16_19::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_16_19_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_4::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_4_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_4::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_4_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_16_19 to value 0x2000_0000"]
-impl crate::Resettable for GPO_DOUT_16_19_SPEC {
+#[doc = "`reset()` method sets gpo_dout_4 to value 0x2000_0000"]
+impl crate::Resettable for GPO_DOUT_4_SPEC {
     const RESET_VALUE: Self::Ux = 0x2000_0000;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_5.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_5.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_20_23` reader"]
-pub type R = crate::R<GPO_DOUT_20_23_SPEC>;
-#[doc = "Register `gpo_dout_20_23` writer"]
-pub type W = crate::W<GPO_DOUT_20_23_SPEC>;
+#[doc = "Register `gpo_dout_5` reader"]
+pub type R = crate::R<GPO_DOUT_5_SPEC>;
+#[doc = "Register `gpo_dout_5` writer"]
+pub type W = crate::W<GPO_DOUT_5_SPEC>;
 #[doc = "Field `dout_20` reader - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_20_R = crate::FieldReader;
 #[doc = "Field `dout_20` writer - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_20(&mut self) -> DOUT_20_W<GPO_DOUT_20_23_SPEC> {
+    pub fn dout_20(&mut self) -> DOUT_20_W<GPO_DOUT_5_SPEC> {
         DOUT_20_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO21. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_21(&mut self) -> DOUT_21_W<GPO_DOUT_20_23_SPEC> {
+    pub fn dout_21(&mut self) -> DOUT_21_W<GPO_DOUT_5_SPEC> {
         DOUT_21_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO22. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_22(&mut self) -> DOUT_22_W<GPO_DOUT_20_23_SPEC> {
+    pub fn dout_22(&mut self) -> DOUT_22_W<GPO_DOUT_5_SPEC> {
         DOUT_22_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO23. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_23(&mut self) -> DOUT_23_W<GPO_DOUT_20_23_SPEC> {
+    pub fn dout_23(&mut self) -> DOUT_23_W<GPO_DOUT_5_SPEC> {
         DOUT_23_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_20_23::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_20_23::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_20_23_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_20_23_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_5_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_5_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_20_23::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_20_23_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_20_23::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_20_23_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_5::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_5_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_5::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_5_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_20_23 to value 0x0055_0000"]
-impl crate::Resettable for GPO_DOUT_20_23_SPEC {
+#[doc = "`reset()` method sets gpo_dout_5 to value 0x0055_0000"]
+impl crate::Resettable for GPO_DOUT_5_SPEC {
     const RESET_VALUE: Self::Ux = 0x0055_0000;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_6.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_6.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_24_27` reader"]
-pub type R = crate::R<GPO_DOUT_24_27_SPEC>;
-#[doc = "Register `gpo_dout_24_27` writer"]
-pub type W = crate::W<GPO_DOUT_24_27_SPEC>;
+#[doc = "Register `gpo_dout_6` reader"]
+pub type R = crate::R<GPO_DOUT_6_SPEC>;
+#[doc = "Register `gpo_dout_6` writer"]
+pub type W = crate::W<GPO_DOUT_6_SPEC>;
 #[doc = "Field `dout_24` reader - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_24_R = crate::FieldReader;
 #[doc = "Field `dout_24` writer - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_24(&mut self) -> DOUT_24_W<GPO_DOUT_24_27_SPEC> {
+    pub fn dout_24(&mut self) -> DOUT_24_W<GPO_DOUT_6_SPEC> {
         DOUT_24_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO25. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_25(&mut self) -> DOUT_25_W<GPO_DOUT_24_27_SPEC> {
+    pub fn dout_25(&mut self) -> DOUT_25_W<GPO_DOUT_6_SPEC> {
         DOUT_25_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO26. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_26(&mut self) -> DOUT_26_W<GPO_DOUT_24_27_SPEC> {
+    pub fn dout_26(&mut self) -> DOUT_26_W<GPO_DOUT_6_SPEC> {
         DOUT_26_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO27. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_27(&mut self) -> DOUT_27_W<GPO_DOUT_24_27_SPEC> {
+    pub fn dout_27(&mut self) -> DOUT_27_W<GPO_DOUT_6_SPEC> {
         DOUT_27_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_24_27::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_24_27::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_24_27_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_24_27_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_6::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_6_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_6_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_24_27::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_24_27_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_24_27::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_24_27_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_6::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_6_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_6::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_6_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_24_27 to value 0"]
-impl crate::Resettable for GPO_DOUT_24_27_SPEC {
+#[doc = "`reset()` method sets gpo_dout_6 to value 0"]
+impl crate::Resettable for GPO_DOUT_6_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_7.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_7.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_28_31` reader"]
-pub type R = crate::R<GPO_DOUT_28_31_SPEC>;
-#[doc = "Register `gpo_dout_28_31` writer"]
-pub type W = crate::W<GPO_DOUT_28_31_SPEC>;
+#[doc = "Register `gpo_dout_7` reader"]
+pub type R = crate::R<GPO_DOUT_7_SPEC>;
+#[doc = "Register `gpo_dout_7` writer"]
+pub type W = crate::W<GPO_DOUT_7_SPEC>;
 #[doc = "Field `dout_28` reader - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_28_R = crate::FieldReader;
 #[doc = "Field `dout_28` writer - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_28(&mut self) -> DOUT_28_W<GPO_DOUT_28_31_SPEC> {
+    pub fn dout_28(&mut self) -> DOUT_28_W<GPO_DOUT_7_SPEC> {
         DOUT_28_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO29. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_29(&mut self) -> DOUT_29_W<GPO_DOUT_28_31_SPEC> {
+    pub fn dout_29(&mut self) -> DOUT_29_W<GPO_DOUT_7_SPEC> {
         DOUT_29_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO30. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_30(&mut self) -> DOUT_30_W<GPO_DOUT_28_31_SPEC> {
+    pub fn dout_30(&mut self) -> DOUT_30_W<GPO_DOUT_7_SPEC> {
         DOUT_30_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO31. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_31(&mut self) -> DOUT_31_W<GPO_DOUT_28_31_SPEC> {
+    pub fn dout_31(&mut self) -> DOUT_31_W<GPO_DOUT_7_SPEC> {
         DOUT_31_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_28_31::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_28_31::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_28_31_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_28_31_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_7_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_7_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_28_31::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_28_31_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_28_31::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_28_31_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_7::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_7_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_7::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_7_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_28_31 to value 0"]
-impl crate::Resettable for GPO_DOUT_28_31_SPEC {
+#[doc = "`reset()` method sets gpo_dout_7 to value 0"]
+impl crate::Resettable for GPO_DOUT_7_SPEC {
     const RESET_VALUE: Self::Ux = 0;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_8.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_8.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_32_35` reader"]
-pub type R = crate::R<GPO_DOUT_32_35_SPEC>;
-#[doc = "Register `gpo_dout_32_35` writer"]
-pub type W = crate::W<GPO_DOUT_32_35_SPEC>;
+#[doc = "Register `gpo_dout_8` reader"]
+pub type R = crate::R<GPO_DOUT_8_SPEC>;
+#[doc = "Register `gpo_dout_8` writer"]
+pub type W = crate::W<GPO_DOUT_8_SPEC>;
 #[doc = "Field `dout_32` reader - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_32_R = crate::FieldReader;
 #[doc = "Field `dout_32` writer - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_32(&mut self) -> DOUT_32_W<GPO_DOUT_32_35_SPEC> {
+    pub fn dout_32(&mut self) -> DOUT_32_W<GPO_DOUT_8_SPEC> {
         DOUT_32_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO33. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_33(&mut self) -> DOUT_33_W<GPO_DOUT_32_35_SPEC> {
+    pub fn dout_33(&mut self) -> DOUT_33_W<GPO_DOUT_8_SPEC> {
         DOUT_33_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO34. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_34(&mut self) -> DOUT_34_W<GPO_DOUT_32_35_SPEC> {
+    pub fn dout_34(&mut self) -> DOUT_34_W<GPO_DOUT_8_SPEC> {
         DOUT_34_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO35. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_35(&mut self) -> DOUT_35_W<GPO_DOUT_32_35_SPEC> {
+    pub fn dout_35(&mut self) -> DOUT_35_W<GPO_DOUT_8_SPEC> {
         DOUT_35_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_32_35::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_32_35::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_32_35_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_32_35_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_8_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_8_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_32_35::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_32_35_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_32_35::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_32_35_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_8::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_8_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_8::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_8_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_32_35 to value 0x0d00_0000"]
-impl crate::Resettable for GPO_DOUT_32_35_SPEC {
+#[doc = "`reset()` method sets gpo_dout_8 to value 0x0d00_0000"]
+impl crate::Resettable for GPO_DOUT_8_SPEC {
     const RESET_VALUE: Self::Ux = 0x0d00_0000;
 }

--- a/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_9.rs
+++ b/jh7110-vf2-12a-pac/src/sys_pinctrl/gpo_dout_9.rs
@@ -1,7 +1,7 @@
-#[doc = "Register `gpo_dout_36_39` reader"]
-pub type R = crate::R<GPO_DOUT_36_39_SPEC>;
-#[doc = "Register `gpo_dout_36_39` writer"]
-pub type W = crate::W<GPO_DOUT_36_39_SPEC>;
+#[doc = "Register `gpo_dout_9` reader"]
+pub type R = crate::R<GPO_DOUT_9_SPEC>;
+#[doc = "Register `gpo_dout_9` writer"]
+pub type W = crate::W<GPO_DOUT_9_SPEC>;
 #[doc = "Field `dout_36` reader - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
 pub type DOUT_36_R = crate::FieldReader;
 #[doc = "Field `dout_36` writer - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
@@ -44,25 +44,25 @@ impl W {
     #[doc = "Bits 0:6 - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_36(&mut self) -> DOUT_36_W<GPO_DOUT_36_39_SPEC> {
+    pub fn dout_36(&mut self) -> DOUT_36_W<GPO_DOUT_9_SPEC> {
         DOUT_36_W::new(self, 0)
     }
     #[doc = "Bits 8:14 - The selected output signal for GPIO37. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_37(&mut self) -> DOUT_37_W<GPO_DOUT_36_39_SPEC> {
+    pub fn dout_37(&mut self) -> DOUT_37_W<GPO_DOUT_9_SPEC> {
         DOUT_37_W::new(self, 8)
     }
     #[doc = "Bits 16:22 - The selected output signal for GPIO38. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_38(&mut self) -> DOUT_38_W<GPO_DOUT_36_39_SPEC> {
+    pub fn dout_38(&mut self) -> DOUT_38_W<GPO_DOUT_9_SPEC> {
         DOUT_38_W::new(self, 16)
     }
     #[doc = "Bits 24:30 - The selected output signal for GPIO39. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
     #[inline(always)]
     #[must_use]
-    pub fn dout_39(&mut self) -> DOUT_39_W<GPO_DOUT_36_39_SPEC> {
+    pub fn dout_39(&mut self) -> DOUT_39_W<GPO_DOUT_9_SPEC> {
         DOUT_39_W::new(self, 24)
     }
     #[doc = r" Writes raw bits to the register."]
@@ -76,19 +76,19 @@ impl W {
         self
     }
 }
-#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_36_39::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_36_39::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
-pub struct GPO_DOUT_36_39_SPEC;
-impl crate::RegisterSpec for GPO_DOUT_36_39_SPEC {
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_9::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_9_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_9_SPEC {
     type Ux = u32;
 }
-#[doc = "`read()` method returns [`gpo_dout_36_39::R`](R) reader structure"]
-impl crate::Readable for GPO_DOUT_36_39_SPEC {}
-#[doc = "`write(|w| ..)` method takes [`gpo_dout_36_39::W`](W) writer structure"]
-impl crate::Writable for GPO_DOUT_36_39_SPEC {
+#[doc = "`read()` method returns [`gpo_dout_9::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_9_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_9::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_9_SPEC {
     const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
     const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
 }
-#[doc = "`reset()` method sets gpo_dout_36_39 to value 0x5453_0f0e"]
-impl crate::Resettable for GPO_DOUT_36_39_SPEC {
+#[doc = "`reset()` method sets gpo_dout_9 to value 0x5453_0f0e"]
+impl crate::Resettable for GPO_DOUT_9_SPEC {
     const RESET_VALUE: Self::Ux = 0x5453_0f0e;
 }

--- a/jh7110-vf2-13b-pac/Cargo.toml
+++ b/jh7110-vf2-13b-pac/Cargo.toml
@@ -19,3 +19,4 @@ vcell = "0.1.3"
 default = ["critical-section"]
 critical-section = ["dep:critical-section"]
 rt = ["riscv-rt"]
+rts = ["riscv-rt/s-mode"]

--- a/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
+++ b/jh7110-vf2-13b-pac/jh7110-starfive-visionfive-2-v1.3b.svd
@@ -35710,7 +35710,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_0_3</name>
+          <name>gpo_dout_0</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT</description>
           <addressOffset>0x40</addressOffset>
           <size>32</size>
@@ -35743,7 +35743,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_4_7</name>
+          <name>gpo_dout_1</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT</description>
           <addressOffset>0x44</addressOffset>
           <size>32</size>
@@ -35776,7 +35776,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_8_11</name>
+          <name>gpo_dout_2</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT</description>
           <addressOffset>0x48</addressOffset>
           <size>32</size>
@@ -35809,7 +35809,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_12_15</name>
+          <name>gpo_dout_3</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT</description>
           <addressOffset>0x4c</addressOffset>
           <size>32</size>
@@ -35842,7 +35842,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_16_19</name>
+          <name>gpo_dout_4</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT</description>
           <addressOffset>0x50</addressOffset>
           <size>32</size>
@@ -35875,7 +35875,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_20_23</name>
+          <name>gpo_dout_5</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT</description>
           <addressOffset>0x54</addressOffset>
           <size>32</size>
@@ -35908,7 +35908,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_24_27</name>
+          <name>gpo_dout_6</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT</description>
           <addressOffset>0x58</addressOffset>
           <size>32</size>
@@ -35941,7 +35941,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_28_31</name>
+          <name>gpo_dout_7</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT</description>
           <addressOffset>0x5c</addressOffset>
           <size>32</size>
@@ -35974,7 +35974,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_32_35</name>
+          <name>gpo_dout_8</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT</description>
           <addressOffset>0x60</addressOffset>
           <size>32</size>
@@ -36007,7 +36007,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_36_39</name>
+          <name>gpo_dout_9</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT</description>
           <addressOffset>0x64</addressOffset>
           <size>32</size>
@@ -36040,7 +36040,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_40_43</name>
+          <name>gpo_dout_10</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT</description>
           <addressOffset>0x68</addressOffset>
           <size>32</size>
@@ -36073,7 +36073,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_44_47</name>
+          <name>gpo_dout_11</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT</description>
           <addressOffset>0x6c</addressOffset>
           <size>32</size>
@@ -36106,7 +36106,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_48_51</name>
+          <name>gpo_dout_12</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT</description>
           <addressOffset>0x70</addressOffset>
           <size>32</size>
@@ -36139,7 +36139,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_52_55</name>
+          <name>gpo_dout_13</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT</description>
           <addressOffset>0x74</addressOffset>
           <size>32</size>
@@ -36172,7 +36172,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_56_59</name>
+          <name>gpo_dout_14</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT</description>
           <addressOffset>0x78</addressOffset>
           <size>32</size>
@@ -36205,7 +36205,7 @@
           </fields>
         </register>
         <register>
-          <name>gpo_dout_60_63</name>
+          <name>gpo_dout_15</name>
           <description>SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT</description>
           <addressOffset>0x7c</addressOffset>
           <size>32</size>

--- a/jh7110-vf2-13b-pac/src/interrupt.rs
+++ b/jh7110-vf2-13b-pac/src/interrupt.rs
@@ -81,7 +81,7 @@ impl Interrupt {
         }
     }
 }
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 #[macro_export]
 #[doc = r" Assigns a handler to an interrupt"]
 #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/interrupt.rs
+++ b/jh7110-vf2-13b-pac/src/interrupt.rs
@@ -81,7 +81,7 @@ impl Interrupt {
         }
     }
 }
-#[cfg(any(feature = "rt", feature = "rts"))]
+#[cfg(feature = "rt")]
 #[macro_export]
 #[doc = r" Assigns a handler to an interrupt"]
 #[doc = r""]

--- a/jh7110-vf2-13b-pac/src/lib.rs
+++ b/jh7110-vf2-13b-pac/src/lib.rs
@@ -9,7 +9,7 @@ use core::ops::Deref;
 use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
-#[cfg(any(feature = "rt", feature = "rts"))]
+#[cfg(feature = "rt")]
 extern "C" {
     fn QSPI();
     fn UART0();
@@ -40,7 +40,7 @@ pub union Vector {
     pub _handler: unsafe extern "C" fn(),
     pub _reserved: usize,
 }
-#[cfg(any(feature = "rt", feature = "rts"))]
+#[cfg(feature = "rt")]
 #[doc(hidden)]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 107] = [

--- a/jh7110-vf2-13b-pac/src/lib.rs
+++ b/jh7110-vf2-13b-pac/src/lib.rs
@@ -9,7 +9,7 @@ use core::ops::Deref;
 use generic::*;
 #[doc = r"Common register and bit access and modify traits"]
 pub mod generic;
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 extern "C" {
     fn QSPI();
     fn UART0();
@@ -40,7 +40,7 @@ pub union Vector {
     pub _handler: unsafe extern "C" fn(),
     pub _reserved: usize,
 }
-#[cfg(feature = "rt")]
+#[cfg(any(feature = "rt", feature = "rts"))]
 #[doc(hidden)]
 #[no_mangle]
 pub static __EXTERNAL_INTERRUPTS: [Vector; 107] = [

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl.rs
@@ -17,22 +17,22 @@ pub struct RegisterBlock {
     gpo_doen_13: GPO_DOEN_13,
     gpo_doen_14: GPO_DOEN_14,
     gpo_doen_15: GPO_DOEN_15,
-    gpo_dout_0_3: GPO_DOUT_0_3,
-    gpo_dout_4_7: GPO_DOUT_4_7,
-    gpo_dout_8_11: GPO_DOUT_8_11,
-    gpo_dout_12_15: GPO_DOUT_12_15,
-    gpo_dout_16_19: GPO_DOUT_16_19,
-    gpo_dout_20_23: GPO_DOUT_20_23,
-    gpo_dout_24_27: GPO_DOUT_24_27,
-    gpo_dout_28_31: GPO_DOUT_28_31,
-    gpo_dout_32_35: GPO_DOUT_32_35,
-    gpo_dout_36_39: GPO_DOUT_36_39,
-    gpo_dout_40_43: GPO_DOUT_40_43,
-    gpo_dout_44_47: GPO_DOUT_44_47,
-    gpo_dout_48_51: GPO_DOUT_48_51,
-    gpo_dout_52_55: GPO_DOUT_52_55,
-    gpo_dout_56_59: GPO_DOUT_56_59,
-    gpo_dout_60_63: GPO_DOUT_60_63,
+    gpo_dout_0: GPO_DOUT_0,
+    gpo_dout_1: GPO_DOUT_1,
+    gpo_dout_2: GPO_DOUT_2,
+    gpo_dout_3: GPO_DOUT_3,
+    gpo_dout_4: GPO_DOUT_4,
+    gpo_dout_5: GPO_DOUT_5,
+    gpo_dout_6: GPO_DOUT_6,
+    gpo_dout_7: GPO_DOUT_7,
+    gpo_dout_8: GPO_DOUT_8,
+    gpo_dout_9: GPO_DOUT_9,
+    gpo_dout_10: GPO_DOUT_10,
+    gpo_dout_11: GPO_DOUT_11,
+    gpo_dout_12: GPO_DOUT_12,
+    gpo_dout_13: GPO_DOUT_13,
+    gpo_dout_14: GPO_DOUT_14,
+    gpo_dout_15: GPO_DOUT_15,
     gpi_0: GPI_0,
     gpi_1: GPI_1,
     gpi_2: GPI_2,
@@ -259,83 +259,83 @@ impl RegisterBlock {
     }
     #[doc = "0x40 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_0_3(&self) -> &GPO_DOUT_0_3 {
-        &self.gpo_dout_0_3
+    pub const fn gpo_dout_0(&self) -> &GPO_DOUT_0 {
+        &self.gpo_dout_0
     }
     #[doc = "0x44 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_4_7(&self) -> &GPO_DOUT_4_7 {
-        &self.gpo_dout_4_7
+    pub const fn gpo_dout_1(&self) -> &GPO_DOUT_1 {
+        &self.gpo_dout_1
     }
     #[doc = "0x48 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_8_11(&self) -> &GPO_DOUT_8_11 {
-        &self.gpo_dout_8_11
+    pub const fn gpo_dout_2(&self) -> &GPO_DOUT_2 {
+        &self.gpo_dout_2
     }
     #[doc = "0x4c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_12_15(&self) -> &GPO_DOUT_12_15 {
-        &self.gpo_dout_12_15
+    pub const fn gpo_dout_3(&self) -> &GPO_DOUT_3 {
+        &self.gpo_dout_3
     }
     #[doc = "0x50 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_16_19(&self) -> &GPO_DOUT_16_19 {
-        &self.gpo_dout_16_19
+    pub const fn gpo_dout_4(&self) -> &GPO_DOUT_4 {
+        &self.gpo_dout_4
     }
     #[doc = "0x54 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_20_23(&self) -> &GPO_DOUT_20_23 {
-        &self.gpo_dout_20_23
+    pub const fn gpo_dout_5(&self) -> &GPO_DOUT_5 {
+        &self.gpo_dout_5
     }
     #[doc = "0x58 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_24_27(&self) -> &GPO_DOUT_24_27 {
-        &self.gpo_dout_24_27
+    pub const fn gpo_dout_6(&self) -> &GPO_DOUT_6 {
+        &self.gpo_dout_6
     }
     #[doc = "0x5c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_28_31(&self) -> &GPO_DOUT_28_31 {
-        &self.gpo_dout_28_31
+    pub const fn gpo_dout_7(&self) -> &GPO_DOUT_7 {
+        &self.gpo_dout_7
     }
     #[doc = "0x60 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_32_35(&self) -> &GPO_DOUT_32_35 {
-        &self.gpo_dout_32_35
+    pub const fn gpo_dout_8(&self) -> &GPO_DOUT_8 {
+        &self.gpo_dout_8
     }
     #[doc = "0x64 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_36_39(&self) -> &GPO_DOUT_36_39 {
-        &self.gpo_dout_36_39
+    pub const fn gpo_dout_9(&self) -> &GPO_DOUT_9 {
+        &self.gpo_dout_9
     }
     #[doc = "0x68 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_40_43(&self) -> &GPO_DOUT_40_43 {
-        &self.gpo_dout_40_43
+    pub const fn gpo_dout_10(&self) -> &GPO_DOUT_10 {
+        &self.gpo_dout_10
     }
     #[doc = "0x6c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_44_47(&self) -> &GPO_DOUT_44_47 {
-        &self.gpo_dout_44_47
+    pub const fn gpo_dout_11(&self) -> &GPO_DOUT_11 {
+        &self.gpo_dout_11
     }
     #[doc = "0x70 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_48_51(&self) -> &GPO_DOUT_48_51 {
-        &self.gpo_dout_48_51
+    pub const fn gpo_dout_12(&self) -> &GPO_DOUT_12 {
+        &self.gpo_dout_12
     }
     #[doc = "0x74 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_52_55(&self) -> &GPO_DOUT_52_55 {
-        &self.gpo_dout_52_55
+    pub const fn gpo_dout_13(&self) -> &GPO_DOUT_13 {
+        &self.gpo_dout_13
     }
     #[doc = "0x78 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_56_59(&self) -> &GPO_DOUT_56_59 {
-        &self.gpo_dout_56_59
+    pub const fn gpo_dout_14(&self) -> &GPO_DOUT_14 {
+        &self.gpo_dout_14
     }
     #[doc = "0x7c - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT"]
     #[inline(always)]
-    pub const fn gpo_dout_60_63(&self) -> &GPO_DOUT_60_63 {
-        &self.gpo_dout_60_63
+    pub const fn gpo_dout_15(&self) -> &GPO_DOUT_15 {
+        &self.gpo_dout_15
     }
     #[doc = "0x80 - SYS IOMUX CFG SAIF SYSCFG FMUX GPIO GPI 0 - The register can be used to configure the selected GPIO connector number for input signals. The signal name is indicated in the \"Name\" column of the following table per StarFive naming conventions. For example, name \"u0_WAVE511_i_uart_rxsin_cfg\" indicates the corresponding input signal is \"u0_WAVE511.i_uart_rxsin\". See GPIO Input Signals (on page 107) for a complete list of the input GPIO signals."]
     #[inline(always)]
@@ -1128,86 +1128,86 @@ module"]
 pub type GPO_DOEN_15 = crate::Reg<gpo_doen_15::GPO_DOEN_15_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX 15 DOEN"]
 pub mod gpo_doen_15;
-#[doc = "gpo_dout_0_3 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_0_3`]
+#[doc = "gpo_dout_0 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_0`]
 module"]
-pub type GPO_DOUT_0_3 = crate::Reg<gpo_dout_0_3::GPO_DOUT_0_3_SPEC>;
+pub type GPO_DOUT_0 = crate::Reg<gpo_dout_0::GPO_DOUT_0_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT"]
-pub mod gpo_dout_0_3;
-#[doc = "gpo_dout_4_7 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_4_7`]
+pub mod gpo_dout_0;
+#[doc = "gpo_dout_1 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_1::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_1::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_1`]
 module"]
-pub type GPO_DOUT_4_7 = crate::Reg<gpo_dout_4_7::GPO_DOUT_4_7_SPEC>;
+pub type GPO_DOUT_1 = crate::Reg<gpo_dout_1::GPO_DOUT_1_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT"]
-pub mod gpo_dout_4_7;
-#[doc = "gpo_dout_8_11 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_8_11`]
+pub mod gpo_dout_1;
+#[doc = "gpo_dout_2 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_2::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_2::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_2`]
 module"]
-pub type GPO_DOUT_8_11 = crate::Reg<gpo_dout_8_11::GPO_DOUT_8_11_SPEC>;
+pub type GPO_DOUT_2 = crate::Reg<gpo_dout_2::GPO_DOUT_2_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT"]
-pub mod gpo_dout_8_11;
-#[doc = "gpo_dout_12_15 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_12_15`]
+pub mod gpo_dout_2;
+#[doc = "gpo_dout_3 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_3::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_3::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_3`]
 module"]
-pub type GPO_DOUT_12_15 = crate::Reg<gpo_dout_12_15::GPO_DOUT_12_15_SPEC>;
+pub type GPO_DOUT_3 = crate::Reg<gpo_dout_3::GPO_DOUT_3_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT"]
-pub mod gpo_dout_12_15;
-#[doc = "gpo_dout_16_19 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_16_19::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_16_19::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_16_19`]
+pub mod gpo_dout_3;
+#[doc = "gpo_dout_4 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_4`]
 module"]
-pub type GPO_DOUT_16_19 = crate::Reg<gpo_dout_16_19::GPO_DOUT_16_19_SPEC>;
+pub type GPO_DOUT_4 = crate::Reg<gpo_dout_4::GPO_DOUT_4_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT"]
-pub mod gpo_dout_16_19;
-#[doc = "gpo_dout_20_23 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_20_23::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_20_23::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_20_23`]
+pub mod gpo_dout_4;
+#[doc = "gpo_dout_5 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_5::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_5::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_5`]
 module"]
-pub type GPO_DOUT_20_23 = crate::Reg<gpo_dout_20_23::GPO_DOUT_20_23_SPEC>;
+pub type GPO_DOUT_5 = crate::Reg<gpo_dout_5::GPO_DOUT_5_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT"]
-pub mod gpo_dout_20_23;
-#[doc = "gpo_dout_24_27 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_24_27::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_24_27::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_24_27`]
+pub mod gpo_dout_5;
+#[doc = "gpo_dout_6 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_6::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_6::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_6`]
 module"]
-pub type GPO_DOUT_24_27 = crate::Reg<gpo_dout_24_27::GPO_DOUT_24_27_SPEC>;
+pub type GPO_DOUT_6 = crate::Reg<gpo_dout_6::GPO_DOUT_6_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT"]
-pub mod gpo_dout_24_27;
-#[doc = "gpo_dout_28_31 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_28_31::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_28_31::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_28_31`]
+pub mod gpo_dout_6;
+#[doc = "gpo_dout_7 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_7::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_7::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_7`]
 module"]
-pub type GPO_DOUT_28_31 = crate::Reg<gpo_dout_28_31::GPO_DOUT_28_31_SPEC>;
+pub type GPO_DOUT_7 = crate::Reg<gpo_dout_7::GPO_DOUT_7_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT"]
-pub mod gpo_dout_28_31;
-#[doc = "gpo_dout_32_35 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_32_35::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_32_35::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_32_35`]
+pub mod gpo_dout_7;
+#[doc = "gpo_dout_8 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_8`]
 module"]
-pub type GPO_DOUT_32_35 = crate::Reg<gpo_dout_32_35::GPO_DOUT_32_35_SPEC>;
+pub type GPO_DOUT_8 = crate::Reg<gpo_dout_8::GPO_DOUT_8_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT"]
-pub mod gpo_dout_32_35;
-#[doc = "gpo_dout_36_39 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_36_39::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_36_39::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_36_39`]
+pub mod gpo_dout_8;
+#[doc = "gpo_dout_9 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_9::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_9::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_9`]
 module"]
-pub type GPO_DOUT_36_39 = crate::Reg<gpo_dout_36_39::GPO_DOUT_36_39_SPEC>;
+pub type GPO_DOUT_9 = crate::Reg<gpo_dout_9::GPO_DOUT_9_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT"]
-pub mod gpo_dout_36_39;
-#[doc = "gpo_dout_40_43 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_40_43::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_40_43::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_40_43`]
+pub mod gpo_dout_9;
+#[doc = "gpo_dout_10 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_10::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_10::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_10`]
 module"]
-pub type GPO_DOUT_40_43 = crate::Reg<gpo_dout_40_43::GPO_DOUT_40_43_SPEC>;
+pub type GPO_DOUT_10 = crate::Reg<gpo_dout_10::GPO_DOUT_10_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT"]
-pub mod gpo_dout_40_43;
-#[doc = "gpo_dout_44_47 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_44_47::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_44_47::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_44_47`]
+pub mod gpo_dout_10;
+#[doc = "gpo_dout_11 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_11::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_11::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_11`]
 module"]
-pub type GPO_DOUT_44_47 = crate::Reg<gpo_dout_44_47::GPO_DOUT_44_47_SPEC>;
+pub type GPO_DOUT_11 = crate::Reg<gpo_dout_11::GPO_DOUT_11_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT"]
-pub mod gpo_dout_44_47;
-#[doc = "gpo_dout_48_51 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_48_51::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_48_51::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_48_51`]
+pub mod gpo_dout_11;
+#[doc = "gpo_dout_12 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_12`]
 module"]
-pub type GPO_DOUT_48_51 = crate::Reg<gpo_dout_48_51::GPO_DOUT_48_51_SPEC>;
+pub type GPO_DOUT_12 = crate::Reg<gpo_dout_12::GPO_DOUT_12_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT"]
-pub mod gpo_dout_48_51;
-#[doc = "gpo_dout_52_55 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_52_55::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_52_55::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_52_55`]
+pub mod gpo_dout_12;
+#[doc = "gpo_dout_13 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_13::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_13::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_13`]
 module"]
-pub type GPO_DOUT_52_55 = crate::Reg<gpo_dout_52_55::GPO_DOUT_52_55_SPEC>;
+pub type GPO_DOUT_13 = crate::Reg<gpo_dout_13::GPO_DOUT_13_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT"]
-pub mod gpo_dout_52_55;
-#[doc = "gpo_dout_56_59 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_56_59::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_56_59::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_56_59`]
+pub mod gpo_dout_13;
+#[doc = "gpo_dout_14 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_14::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_14::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_14`]
 module"]
-pub type GPO_DOUT_56_59 = crate::Reg<gpo_dout_56_59::GPO_DOUT_56_59_SPEC>;
+pub type GPO_DOUT_14 = crate::Reg<gpo_dout_14::GPO_DOUT_14_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT"]
-pub mod gpo_dout_56_59;
-#[doc = "gpo_dout_60_63 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_60_63::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_60_63::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_60_63`]
+pub mod gpo_dout_14;
+#[doc = "gpo_dout_15 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_15::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_15::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpo_dout_15`]
 module"]
-pub type GPO_DOUT_60_63 = crate::Reg<gpo_dout_60_63::GPO_DOUT_60_63_SPEC>;
+pub type GPO_DOUT_15 = crate::Reg<gpo_dout_15::GPO_DOUT_15_SPEC>;
 #[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT"]
-pub mod gpo_dout_60_63;
+pub mod gpo_dout_15;
 #[doc = "gpi_0 (rw) register accessor: SYS IOMUX CFG SAIF SYSCFG FMUX GPIO GPI 0 - The register can be used to configure the selected GPIO connector number for input signals. The signal name is indicated in the \"Name\" column of the following table per StarFive naming conventions. For example, name \"u0_WAVE511_i_uart_rxsin_cfg\" indicates the corresponding input signal is \"u0_WAVE511.i_uart_rxsin\". See GPIO Input Signals (on page 107) for a complete list of the input GPIO signals.\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpi_0::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpi_0::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@gpi_0`]
 module"]
 pub type GPI_0 = crate::Reg<gpi_0::GPI_0_SPEC>;

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_0.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_0.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_0` reader"]
+pub type R = crate::R<GPO_DOUT_0_SPEC>;
+#[doc = "Register `gpo_dout_0` writer"]
+pub type W = crate::W<GPO_DOUT_0_SPEC>;
+#[doc = "Field `dout_0` reader - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_0_R = crate::FieldReader;
+#[doc = "Field `dout_0` writer - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_0_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_1` reader - The selected output signal for GPIO1. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_1_R = crate::FieldReader;
+#[doc = "Field `dout_1` writer - The selected output signal for GPIO1. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_1_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_2` reader - The selected output signal for GPIO2. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_2_R = crate::FieldReader;
+#[doc = "Field `dout_2` writer - The selected output signal for GPIO2. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_2_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_3` reader - The selected output signal for GPIO3. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_3_R = crate::FieldReader;
+#[doc = "Field `dout_3` writer - The selected output signal for GPIO3. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_3_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_0(&self) -> DOUT_0_R {
+        DOUT_0_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO1. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_1(&self) -> DOUT_1_R {
+        DOUT_1_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO2. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_2(&self) -> DOUT_2_R {
+        DOUT_2_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO3. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_3(&self) -> DOUT_3_R {
+        DOUT_3_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO0. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_0(&mut self) -> DOUT_0_W<GPO_DOUT_0_SPEC> {
+        DOUT_0_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO1. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_1(&mut self) -> DOUT_1_W<GPO_DOUT_0_SPEC> {
+        DOUT_1_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO2. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_2(&mut self) -> DOUT_2_W<GPO_DOUT_0_SPEC> {
+        DOUT_2_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO3. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_3(&mut self) -> DOUT_3_W<GPO_DOUT_0_SPEC> {
+        DOUT_3_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 0-3 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_0::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_0::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_0_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_0_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_0::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_0_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_0::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_0_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_0 to value 0x1600_0000"]
+impl crate::Resettable for GPO_DOUT_0_SPEC {
+    const RESET_VALUE: Self::Ux = 0x1600_0000;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_1.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_1.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_1` reader"]
+pub type R = crate::R<GPO_DOUT_1_SPEC>;
+#[doc = "Register `gpo_dout_1` writer"]
+pub type W = crate::W<GPO_DOUT_1_SPEC>;
+#[doc = "Field `dout_4` reader - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_4_R = crate::FieldReader;
+#[doc = "Field `dout_4` writer - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_4_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_5` reader - The selected output signal for GPIO5. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_5_R = crate::FieldReader;
+#[doc = "Field `dout_5` writer - The selected output signal for GPIO5. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_5_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_6` reader - The selected output signal for GPIO6. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_6_R = crate::FieldReader;
+#[doc = "Field `dout_6` writer - The selected output signal for GPIO6. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_6_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_7` reader - The selected output signal for GPIO7. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_7_R = crate::FieldReader;
+#[doc = "Field `dout_7` writer - The selected output signal for GPIO7. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_7_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_4(&self) -> DOUT_4_R {
+        DOUT_4_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO5. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_5(&self) -> DOUT_5_R {
+        DOUT_5_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO6. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_6(&self) -> DOUT_6_R {
+        DOUT_6_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO7. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_7(&self) -> DOUT_7_R {
+        DOUT_7_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO4. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_4(&mut self) -> DOUT_4_W<GPO_DOUT_1_SPEC> {
+        DOUT_4_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO5. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_5(&mut self) -> DOUT_5_W<GPO_DOUT_1_SPEC> {
+        DOUT_5_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO6. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_6(&mut self) -> DOUT_6_W<GPO_DOUT_1_SPEC> {
+        DOUT_6_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO7. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_7(&mut self) -> DOUT_7_W<GPO_DOUT_1_SPEC> {
+        DOUT_7_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 4-7 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_1::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_1::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_1_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_1_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_1::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_1_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_1::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_1_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_1 to value 0x1400"]
+impl crate::Resettable for GPO_DOUT_1_SPEC {
+    const RESET_VALUE: Self::Ux = 0x1400;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_10.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_10.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_10` reader"]
+pub type R = crate::R<GPO_DOUT_10_SPEC>;
+#[doc = "Register `gpo_dout_10` writer"]
+pub type W = crate::W<GPO_DOUT_10_SPEC>;
+#[doc = "Field `dout_40` reader - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_40_R = crate::FieldReader;
+#[doc = "Field `dout_40` writer - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_40_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_41` reader - The selected output signal for GPIO41. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_41_R = crate::FieldReader;
+#[doc = "Field `dout_41` writer - The selected output signal for GPIO41. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_41_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_42` reader - The selected output signal for GPIO42. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_42_R = crate::FieldReader;
+#[doc = "Field `dout_42` writer - The selected output signal for GPIO42. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_42_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_43` reader - The selected output signal for GPIO43. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_43_R = crate::FieldReader;
+#[doc = "Field `dout_43` writer - The selected output signal for GPIO43. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_43_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_40(&self) -> DOUT_40_R {
+        DOUT_40_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO41. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_41(&self) -> DOUT_41_R {
+        DOUT_41_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO42. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_42(&self) -> DOUT_42_R {
+        DOUT_42_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO43. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_43(&self) -> DOUT_43_R {
+        DOUT_43_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO40. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_40(&mut self) -> DOUT_40_W<GPO_DOUT_10_SPEC> {
+        DOUT_40_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO41. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_41(&mut self) -> DOUT_41_W<GPO_DOUT_10_SPEC> {
+        DOUT_41_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO42. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_42(&mut self) -> DOUT_42_W<GPO_DOUT_10_SPEC> {
+        DOUT_42_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO43. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_43(&mut self) -> DOUT_43_W<GPO_DOUT_10_SPEC> {
+        DOUT_43_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 40-43 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_10::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_10::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_10_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_10_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_10::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_10_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_10::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_10_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_10 to value 0x004e_4f00"]
+impl crate::Resettable for GPO_DOUT_10_SPEC {
+    const RESET_VALUE: Self::Ux = 0x004e_4f00;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_11.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_11.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_11` reader"]
+pub type R = crate::R<GPO_DOUT_11_SPEC>;
+#[doc = "Register `gpo_dout_11` writer"]
+pub type W = crate::W<GPO_DOUT_11_SPEC>;
+#[doc = "Field `dout_44` reader - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_44_R = crate::FieldReader;
+#[doc = "Field `dout_44` writer - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_44_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_45` reader - The selected output signal for GPIO45. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_45_R = crate::FieldReader;
+#[doc = "Field `dout_45` writer - The selected output signal for GPIO45. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_45_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_46` reader - The selected output signal for GPIO46. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_46_R = crate::FieldReader;
+#[doc = "Field `dout_46` writer - The selected output signal for GPIO46. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_46_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_47` reader - The selected output signal for GPIO47. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_47_R = crate::FieldReader;
+#[doc = "Field `dout_47` writer - The selected output signal for GPIO47. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_47_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_44(&self) -> DOUT_44_R {
+        DOUT_44_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO45. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_45(&self) -> DOUT_45_R {
+        DOUT_45_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO46. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_46(&self) -> DOUT_46_R {
+        DOUT_46_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO47. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_47(&self) -> DOUT_47_R {
+        DOUT_47_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO44. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_44(&mut self) -> DOUT_44_W<GPO_DOUT_11_SPEC> {
+        DOUT_44_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO45. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_45(&mut self) -> DOUT_45_W<GPO_DOUT_11_SPEC> {
+        DOUT_45_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO46. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_46(&mut self) -> DOUT_46_W<GPO_DOUT_11_SPEC> {
+        DOUT_46_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO47. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_47(&mut self) -> DOUT_47_W<GPO_DOUT_11_SPEC> {
+        DOUT_47_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 44-47 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_11::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_11::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_11_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_11_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_11::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_11_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_11::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_11_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_11 to value 0x005b_5c00"]
+impl crate::Resettable for GPO_DOUT_11_SPEC {
+    const RESET_VALUE: Self::Ux = 0x005b_5c00;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_12.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_12.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_12` reader"]
+pub type R = crate::R<GPO_DOUT_12_SPEC>;
+#[doc = "Register `gpo_dout_12` writer"]
+pub type W = crate::W<GPO_DOUT_12_SPEC>;
+#[doc = "Field `dout_48` reader - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_48_R = crate::FieldReader;
+#[doc = "Field `dout_48` writer - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_48_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_49` reader - The selected output signal for GPIO49. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_49_R = crate::FieldReader;
+#[doc = "Field `dout_49` writer - The selected output signal for GPIO49. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_49_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_50` reader - The selected output signal for GPIO50. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_50_R = crate::FieldReader;
+#[doc = "Field `dout_50` writer - The selected output signal for GPIO50. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_50_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_51` reader - The selected output signal for GPIO51. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_51_R = crate::FieldReader;
+#[doc = "Field `dout_51` writer - The selected output signal for GPIO51. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_51_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_48(&self) -> DOUT_48_R {
+        DOUT_48_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO49. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_49(&self) -> DOUT_49_R {
+        DOUT_49_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO50. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_50(&self) -> DOUT_50_R {
+        DOUT_50_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO51. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_51(&self) -> DOUT_51_R {
+        DOUT_51_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO48. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_48(&mut self) -> DOUT_48_W<GPO_DOUT_12_SPEC> {
+        DOUT_48_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO49. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_49(&mut self) -> DOUT_49_W<GPO_DOUT_12_SPEC> {
+        DOUT_49_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO50. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_50(&mut self) -> DOUT_50_W<GPO_DOUT_12_SPEC> {
+        DOUT_50_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO51. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_51(&mut self) -> DOUT_51_W<GPO_DOUT_12_SPEC> {
+        DOUT_51_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 48-51 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_12::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_12::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_12_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_12_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_12::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_12_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_12::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_12_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_12 to value 0x2000_1e1f"]
+impl crate::Resettable for GPO_DOUT_12_SPEC {
+    const RESET_VALUE: Self::Ux = 0x2000_1e1f;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_13.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_13.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_13` reader"]
+pub type R = crate::R<GPO_DOUT_13_SPEC>;
+#[doc = "Register `gpo_dout_13` writer"]
+pub type W = crate::W<GPO_DOUT_13_SPEC>;
+#[doc = "Field `dout_52` reader - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_52_R = crate::FieldReader;
+#[doc = "Field `dout_52` writer - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_52_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_53` reader - The selected output signal for GPIO53. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_53_R = crate::FieldReader;
+#[doc = "Field `dout_53` writer - The selected output signal for GPIO53. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_53_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_54` reader - The selected output signal for GPIO54. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_54_R = crate::FieldReader;
+#[doc = "Field `dout_54` writer - The selected output signal for GPIO54. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_54_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_55` reader - The selected output signal for GPIO55. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_55_R = crate::FieldReader;
+#[doc = "Field `dout_55` writer - The selected output signal for GPIO55. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_55_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_52(&self) -> DOUT_52_R {
+        DOUT_52_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO53. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_53(&self) -> DOUT_53_R {
+        DOUT_53_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO54. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_54(&self) -> DOUT_54_R {
+        DOUT_54_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO55. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_55(&self) -> DOUT_55_R {
+        DOUT_55_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO52. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_52(&mut self) -> DOUT_52_W<GPO_DOUT_13_SPEC> {
+        DOUT_52_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO53. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_53(&mut self) -> DOUT_53_W<GPO_DOUT_13_SPEC> {
+        DOUT_53_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO54. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_54(&mut self) -> DOUT_54_W<GPO_DOUT_13_SPEC> {
+        DOUT_54_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO55. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_55(&mut self) -> DOUT_55_W<GPO_DOUT_13_SPEC> {
+        DOUT_55_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 52-55 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_13::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_13::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_13_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_13_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_13::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_13_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_13::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_13_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_13 to value 0x4b00_494a"]
+impl crate::Resettable for GPO_DOUT_13_SPEC {
+    const RESET_VALUE: Self::Ux = 0x4b00_494a;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_14.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_14.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_14` reader"]
+pub type R = crate::R<GPO_DOUT_14_SPEC>;
+#[doc = "Register `gpo_dout_14` writer"]
+pub type W = crate::W<GPO_DOUT_14_SPEC>;
+#[doc = "Field `dout_56` reader - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_56_R = crate::FieldReader;
+#[doc = "Field `dout_56` writer - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_56_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_57` reader - The selected output signal for GPIO57. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_57_R = crate::FieldReader;
+#[doc = "Field `dout_57` writer - The selected output signal for GPIO57. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_57_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_58` reader - The selected output signal for GPIO58. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_58_R = crate::FieldReader;
+#[doc = "Field `dout_58` writer - The selected output signal for GPIO58. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_58_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_59` reader - The selected output signal for GPIO59. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_59_R = crate::FieldReader;
+#[doc = "Field `dout_59` writer - The selected output signal for GPIO59. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_59_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_56(&self) -> DOUT_56_R {
+        DOUT_56_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO57. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_57(&self) -> DOUT_57_R {
+        DOUT_57_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO58. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_58(&self) -> DOUT_58_R {
+        DOUT_58_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO59. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_59(&self) -> DOUT_59_R {
+        DOUT_59_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO56. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_56(&mut self) -> DOUT_56_W<GPO_DOUT_14_SPEC> {
+        DOUT_56_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO57. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_57(&mut self) -> DOUT_57_W<GPO_DOUT_14_SPEC> {
+        DOUT_57_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO58. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_58(&mut self) -> DOUT_58_W<GPO_DOUT_14_SPEC> {
+        DOUT_58_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO59. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_59(&mut self) -> DOUT_59_W<GPO_DOUT_14_SPEC> {
+        DOUT_59_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 56-59 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_14::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_14::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_14_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_14_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_14::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_14_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_14::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_14_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_14 to value 0x5800_5657"]
+impl crate::Resettable for GPO_DOUT_14_SPEC {
+    const RESET_VALUE: Self::Ux = 0x5800_5657;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_15.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_15.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_15` reader"]
+pub type R = crate::R<GPO_DOUT_15_SPEC>;
+#[doc = "Register `gpo_dout_15` writer"]
+pub type W = crate::W<GPO_DOUT_15_SPEC>;
+#[doc = "Field `dout_60` reader - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_60_R = crate::FieldReader;
+#[doc = "Field `dout_60` writer - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_60_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_61` reader - The selected output signal for GPIO61. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_61_R = crate::FieldReader;
+#[doc = "Field `dout_61` writer - The selected output signal for GPIO61. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_61_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_62` reader - The selected output signal for GPIO62. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_62_R = crate::FieldReader;
+#[doc = "Field `dout_62` writer - The selected output signal for GPIO62. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_62_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_63` reader - The selected output signal for GPIO63. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_63_R = crate::FieldReader;
+#[doc = "Field `dout_63` writer - The selected output signal for GPIO63. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_63_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_60(&self) -> DOUT_60_R {
+        DOUT_60_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO61. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_61(&self) -> DOUT_61_R {
+        DOUT_61_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO62. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_62(&self) -> DOUT_62_R {
+        DOUT_62_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO63. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_63(&self) -> DOUT_63_R {
+        DOUT_63_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO60. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_60(&mut self) -> DOUT_60_W<GPO_DOUT_15_SPEC> {
+        DOUT_60_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO61. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_61(&mut self) -> DOUT_61_W<GPO_DOUT_15_SPEC> {
+        DOUT_61_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO62. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_62(&mut self) -> DOUT_62_W<GPO_DOUT_15_SPEC> {
+        DOUT_62_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO63. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_63(&mut self) -> DOUT_63_W<GPO_DOUT_15_SPEC> {
+        DOUT_63_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 60-63 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_15::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_15::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_15_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_15_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_15::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_15_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_15::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_15_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_15 to value 0x5f00_5d5e"]
+impl crate::Resettable for GPO_DOUT_15_SPEC {
+    const RESET_VALUE: Self::Ux = 0x5f00_5d5e;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_2.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_2.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_2` reader"]
+pub type R = crate::R<GPO_DOUT_2_SPEC>;
+#[doc = "Register `gpo_dout_2` writer"]
+pub type W = crate::W<GPO_DOUT_2_SPEC>;
+#[doc = "Field `dout_8` reader - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_8_R = crate::FieldReader;
+#[doc = "Field `dout_8` writer - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_8_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_9` reader - The selected output signal for GPIO9. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_9_R = crate::FieldReader;
+#[doc = "Field `dout_9` writer - The selected output signal for GPIO9. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_9_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_10` reader - The selected output signal for GPIO10. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_10_R = crate::FieldReader;
+#[doc = "Field `dout_10` writer - The selected output signal for GPIO10. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_10_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_11` reader - The selected output signal for GPIO11. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_11_R = crate::FieldReader;
+#[doc = "Field `dout_11` writer - The selected output signal for GPIO11. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_11_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_8(&self) -> DOUT_8_R {
+        DOUT_8_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO9. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_9(&self) -> DOUT_9_R {
+        DOUT_9_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO10. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_10(&self) -> DOUT_10_R {
+        DOUT_10_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO11. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_11(&self) -> DOUT_11_R {
+        DOUT_11_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO8. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_8(&mut self) -> DOUT_8_W<GPO_DOUT_2_SPEC> {
+        DOUT_8_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO9. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_9(&mut self) -> DOUT_9_W<GPO_DOUT_2_SPEC> {
+        DOUT_9_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO10. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_10(&mut self) -> DOUT_10_W<GPO_DOUT_2_SPEC> {
+        DOUT_10_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO11. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_11(&mut self) -> DOUT_11_W<GPO_DOUT_2_SPEC> {
+        DOUT_11_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 8-11 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_2::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_2::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_2_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_2_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_2::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_2_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_2::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_2_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_2 to value 0x1500_0000"]
+impl crate::Resettable for GPO_DOUT_2_SPEC {
+    const RESET_VALUE: Self::Ux = 0x1500_0000;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_3.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_3.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_3` reader"]
+pub type R = crate::R<GPO_DOUT_3_SPEC>;
+#[doc = "Register `gpo_dout_3` writer"]
+pub type W = crate::W<GPO_DOUT_3_SPEC>;
+#[doc = "Field `dout_12` reader - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_12_R = crate::FieldReader;
+#[doc = "Field `dout_12` writer - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_12_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_13` reader - The selected output signal for GPIO13. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_13_R = crate::FieldReader;
+#[doc = "Field `dout_13` writer - The selected output signal for GPIO13. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_13_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_14` reader - The selected output signal for GPIO14. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_14_R = crate::FieldReader;
+#[doc = "Field `dout_14` writer - The selected output signal for GPIO14. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_14_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_15` reader - The selected output signal for GPIO15. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_15_R = crate::FieldReader;
+#[doc = "Field `dout_15` writer - The selected output signal for GPIO15. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_15_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_12(&self) -> DOUT_12_R {
+        DOUT_12_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO13. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_13(&self) -> DOUT_13_R {
+        DOUT_13_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO14. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_14(&self) -> DOUT_14_R {
+        DOUT_14_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO15. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_15(&self) -> DOUT_15_R {
+        DOUT_15_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO12. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_12(&mut self) -> DOUT_12_W<GPO_DOUT_3_SPEC> {
+        DOUT_12_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO13. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_13(&mut self) -> DOUT_13_W<GPO_DOUT_3_SPEC> {
+        DOUT_13_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO14. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_14(&mut self) -> DOUT_14_W<GPO_DOUT_3_SPEC> {
+        DOUT_14_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO15. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_15(&mut self) -> DOUT_15_W<GPO_DOUT_3_SPEC> {
+        DOUT_15_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 12-15 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_3::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_3::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_3_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_3_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_3::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_3_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_3::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_3_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_3 to value 0"]
+impl crate::Resettable for GPO_DOUT_3_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_4.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_4.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_4` reader"]
+pub type R = crate::R<GPO_DOUT_4_SPEC>;
+#[doc = "Register `gpo_dout_4` writer"]
+pub type W = crate::W<GPO_DOUT_4_SPEC>;
+#[doc = "Field `dout_16` reader - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_16_R = crate::FieldReader;
+#[doc = "Field `dout_16` writer - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_16_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_17` reader - The selected output signal for GPIO17. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_17_R = crate::FieldReader;
+#[doc = "Field `dout_17` writer - The selected output signal for GPIO17. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_17_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_18` reader - The selected output signal for GPIO18. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_18_R = crate::FieldReader;
+#[doc = "Field `dout_18` writer - The selected output signal for GPIO18. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_18_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_19` reader - The selected output signal for GPIO19. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_19_R = crate::FieldReader;
+#[doc = "Field `dout_19` writer - The selected output signal for GPIO19. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_19_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_16(&self) -> DOUT_16_R {
+        DOUT_16_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO17. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_17(&self) -> DOUT_17_R {
+        DOUT_17_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO18. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_18(&self) -> DOUT_18_R {
+        DOUT_18_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO19. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_19(&self) -> DOUT_19_R {
+        DOUT_19_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO16. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_16(&mut self) -> DOUT_16_W<GPO_DOUT_4_SPEC> {
+        DOUT_16_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO17. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_17(&mut self) -> DOUT_17_W<GPO_DOUT_4_SPEC> {
+        DOUT_17_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO18. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_18(&mut self) -> DOUT_18_W<GPO_DOUT_4_SPEC> {
+        DOUT_18_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO19. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_19(&mut self) -> DOUT_19_W<GPO_DOUT_4_SPEC> {
+        DOUT_19_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 16-19 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_4::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_4::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_4_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_4_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_4::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_4_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_4::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_4_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_4 to value 0x2000_0000"]
+impl crate::Resettable for GPO_DOUT_4_SPEC {
+    const RESET_VALUE: Self::Ux = 0x2000_0000;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_5.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_5.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_5` reader"]
+pub type R = crate::R<GPO_DOUT_5_SPEC>;
+#[doc = "Register `gpo_dout_5` writer"]
+pub type W = crate::W<GPO_DOUT_5_SPEC>;
+#[doc = "Field `dout_20` reader - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_20_R = crate::FieldReader;
+#[doc = "Field `dout_20` writer - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_20_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_21` reader - The selected output signal for GPIO21. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_21_R = crate::FieldReader;
+#[doc = "Field `dout_21` writer - The selected output signal for GPIO21. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_21_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_22` reader - The selected output signal for GPIO22. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_22_R = crate::FieldReader;
+#[doc = "Field `dout_22` writer - The selected output signal for GPIO22. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_22_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_23` reader - The selected output signal for GPIO23. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_23_R = crate::FieldReader;
+#[doc = "Field `dout_23` writer - The selected output signal for GPIO23. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_23_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_20(&self) -> DOUT_20_R {
+        DOUT_20_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO21. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_21(&self) -> DOUT_21_R {
+        DOUT_21_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO22. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_22(&self) -> DOUT_22_R {
+        DOUT_22_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO23. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_23(&self) -> DOUT_23_R {
+        DOUT_23_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO20. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_20(&mut self) -> DOUT_20_W<GPO_DOUT_5_SPEC> {
+        DOUT_20_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO21. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_21(&mut self) -> DOUT_21_W<GPO_DOUT_5_SPEC> {
+        DOUT_21_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO22. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_22(&mut self) -> DOUT_22_W<GPO_DOUT_5_SPEC> {
+        DOUT_22_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO23. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_23(&mut self) -> DOUT_23_W<GPO_DOUT_5_SPEC> {
+        DOUT_23_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 20-23 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_5::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_5::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_5_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_5_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_5::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_5_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_5::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_5_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_5 to value 0x0055_0000"]
+impl crate::Resettable for GPO_DOUT_5_SPEC {
+    const RESET_VALUE: Self::Ux = 0x0055_0000;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_6.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_6.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_6` reader"]
+pub type R = crate::R<GPO_DOUT_6_SPEC>;
+#[doc = "Register `gpo_dout_6` writer"]
+pub type W = crate::W<GPO_DOUT_6_SPEC>;
+#[doc = "Field `dout_24` reader - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_24_R = crate::FieldReader;
+#[doc = "Field `dout_24` writer - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_24_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_25` reader - The selected output signal for GPIO25. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_25_R = crate::FieldReader;
+#[doc = "Field `dout_25` writer - The selected output signal for GPIO25. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_25_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_26` reader - The selected output signal for GPIO26. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_26_R = crate::FieldReader;
+#[doc = "Field `dout_26` writer - The selected output signal for GPIO26. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_26_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_27` reader - The selected output signal for GPIO27. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_27_R = crate::FieldReader;
+#[doc = "Field `dout_27` writer - The selected output signal for GPIO27. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_27_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_24(&self) -> DOUT_24_R {
+        DOUT_24_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO25. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_25(&self) -> DOUT_25_R {
+        DOUT_25_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO26. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_26(&self) -> DOUT_26_R {
+        DOUT_26_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO27. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_27(&self) -> DOUT_27_R {
+        DOUT_27_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO24. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_24(&mut self) -> DOUT_24_W<GPO_DOUT_6_SPEC> {
+        DOUT_24_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO25. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_25(&mut self) -> DOUT_25_W<GPO_DOUT_6_SPEC> {
+        DOUT_25_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO26. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_26(&mut self) -> DOUT_26_W<GPO_DOUT_6_SPEC> {
+        DOUT_26_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO27. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_27(&mut self) -> DOUT_27_W<GPO_DOUT_6_SPEC> {
+        DOUT_27_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 24-27 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_6::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_6::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_6_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_6_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_6::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_6_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_6::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_6_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_6 to value 0"]
+impl crate::Resettable for GPO_DOUT_6_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_7.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_7.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_7` reader"]
+pub type R = crate::R<GPO_DOUT_7_SPEC>;
+#[doc = "Register `gpo_dout_7` writer"]
+pub type W = crate::W<GPO_DOUT_7_SPEC>;
+#[doc = "Field `dout_28` reader - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_28_R = crate::FieldReader;
+#[doc = "Field `dout_28` writer - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_28_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_29` reader - The selected output signal for GPIO29. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_29_R = crate::FieldReader;
+#[doc = "Field `dout_29` writer - The selected output signal for GPIO29. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_29_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_30` reader - The selected output signal for GPIO30. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_30_R = crate::FieldReader;
+#[doc = "Field `dout_30` writer - The selected output signal for GPIO30. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_30_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_31` reader - The selected output signal for GPIO31. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_31_R = crate::FieldReader;
+#[doc = "Field `dout_31` writer - The selected output signal for GPIO31. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_31_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_28(&self) -> DOUT_28_R {
+        DOUT_28_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO29. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_29(&self) -> DOUT_29_R {
+        DOUT_29_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO30. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_30(&self) -> DOUT_30_R {
+        DOUT_30_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO31. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_31(&self) -> DOUT_31_R {
+        DOUT_31_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO28. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_28(&mut self) -> DOUT_28_W<GPO_DOUT_7_SPEC> {
+        DOUT_28_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO29. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_29(&mut self) -> DOUT_29_W<GPO_DOUT_7_SPEC> {
+        DOUT_29_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO30. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_30(&mut self) -> DOUT_30_W<GPO_DOUT_7_SPEC> {
+        DOUT_30_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO31. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_31(&mut self) -> DOUT_31_W<GPO_DOUT_7_SPEC> {
+        DOUT_31_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 28-31 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_7::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_7::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_7_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_7_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_7::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_7_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_7::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_7_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_7 to value 0"]
+impl crate::Resettable for GPO_DOUT_7_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_8.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_8.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_8` reader"]
+pub type R = crate::R<GPO_DOUT_8_SPEC>;
+#[doc = "Register `gpo_dout_8` writer"]
+pub type W = crate::W<GPO_DOUT_8_SPEC>;
+#[doc = "Field `dout_32` reader - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_32_R = crate::FieldReader;
+#[doc = "Field `dout_32` writer - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_32_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_33` reader - The selected output signal for GPIO33. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_33_R = crate::FieldReader;
+#[doc = "Field `dout_33` writer - The selected output signal for GPIO33. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_33_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_34` reader - The selected output signal for GPIO34. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_34_R = crate::FieldReader;
+#[doc = "Field `dout_34` writer - The selected output signal for GPIO34. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_34_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_35` reader - The selected output signal for GPIO35. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_35_R = crate::FieldReader;
+#[doc = "Field `dout_35` writer - The selected output signal for GPIO35. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_35_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_32(&self) -> DOUT_32_R {
+        DOUT_32_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO33. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_33(&self) -> DOUT_33_R {
+        DOUT_33_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO34. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_34(&self) -> DOUT_34_R {
+        DOUT_34_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO35. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_35(&self) -> DOUT_35_R {
+        DOUT_35_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO32. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_32(&mut self) -> DOUT_32_W<GPO_DOUT_8_SPEC> {
+        DOUT_32_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO33. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_33(&mut self) -> DOUT_33_W<GPO_DOUT_8_SPEC> {
+        DOUT_33_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO34. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_34(&mut self) -> DOUT_34_W<GPO_DOUT_8_SPEC> {
+        DOUT_34_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO35. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_35(&mut self) -> DOUT_35_W<GPO_DOUT_8_SPEC> {
+        DOUT_35_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 32-35 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_8::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_8::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_8_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_8_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_8::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_8_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_8::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_8_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_8 to value 0x0d00_0000"]
+impl crate::Resettable for GPO_DOUT_8_SPEC {
+    const RESET_VALUE: Self::Ux = 0x0d00_0000;
+}

--- a/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_9.rs
+++ b/jh7110-vf2-13b-pac/src/sys_pinctrl/gpo_dout_9.rs
@@ -1,0 +1,94 @@
+#[doc = "Register `gpo_dout_9` reader"]
+pub type R = crate::R<GPO_DOUT_9_SPEC>;
+#[doc = "Register `gpo_dout_9` writer"]
+pub type W = crate::W<GPO_DOUT_9_SPEC>;
+#[doc = "Field `dout_36` reader - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_36_R = crate::FieldReader;
+#[doc = "Field `dout_36` writer - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_36_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_37` reader - The selected output signal for GPIO37. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_37_R = crate::FieldReader;
+#[doc = "Field `dout_37` writer - The selected output signal for GPIO37. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_37_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_38` reader - The selected output signal for GPIO38. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_38_R = crate::FieldReader;
+#[doc = "Field `dout_38` writer - The selected output signal for GPIO38. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_38_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+#[doc = "Field `dout_39` reader - The selected output signal for GPIO39. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_39_R = crate::FieldReader;
+#[doc = "Field `dout_39` writer - The selected output signal for GPIO39. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+pub type DOUT_39_W<'a, REG> = crate::FieldWriter<'a, REG, 7>;
+impl R {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_36(&self) -> DOUT_36_R {
+        DOUT_36_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO37. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_37(&self) -> DOUT_37_R {
+        DOUT_37_R::new(((self.bits >> 8) & 0x7f) as u8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO38. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_38(&self) -> DOUT_38_R {
+        DOUT_38_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO39. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    pub fn dout_39(&self) -> DOUT_39_R {
+        DOUT_39_R::new(((self.bits >> 24) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - The selected output signal for GPIO36. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_36(&mut self) -> DOUT_36_W<GPO_DOUT_9_SPEC> {
+        DOUT_36_W::new(self, 0)
+    }
+    #[doc = "Bits 8:14 - The selected output signal for GPIO37. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_37(&mut self) -> DOUT_37_W<GPO_DOUT_9_SPEC> {
+        DOUT_37_W::new(self, 8)
+    }
+    #[doc = "Bits 16:22 - The selected output signal for GPIO38. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_38(&mut self) -> DOUT_38_W<GPO_DOUT_9_SPEC> {
+        DOUT_38_W::new(self, 16)
+    }
+    #[doc = "Bits 24:30 - The selected output signal for GPIO39. The register value indicates the selected GPIO output index signal index from GPIO output signal list 0-107. See Table 2-41: GPIO OEN List for SYS_IOMUX (on page 97) for more information."]
+    #[inline(always)]
+    #[must_use]
+    pub fn dout_39(&mut self) -> DOUT_39_W<GPO_DOUT_9_SPEC> {
+        DOUT_39_W::new(self, 24)
+    }
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "SYS IOMUX CFG SAIF SYSCFG FMUX GPIO 36-39 DOUT\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`gpo_dout_9::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`gpo_dout_9::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct GPO_DOUT_9_SPEC;
+impl crate::RegisterSpec for GPO_DOUT_9_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`gpo_dout_9::R`](R) reader structure"]
+impl crate::Readable for GPO_DOUT_9_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`gpo_dout_9::W`](W) writer structure"]
+impl crate::Writable for GPO_DOUT_9_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets gpo_dout_9 to value 0x5453_0f0e"]
+impl crate::Resettable for GPO_DOUT_9_SPEC {
+    const RESET_VALUE: Self::Ux = 0x5453_0f0e;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 #![no_std]
 
-#[cfg(any(feature = "visionfive2-12a", feature = "visionfive2-12a-rt"))]
+#[cfg(any(feature = "visionfive2-12a", feature = "visionfive2-12a-rt", feature = "visionfive2-12a-rts"))]
 pub extern crate jh7110_vf2_12a_pac;
 
-#[cfg(any(feature = "visionfive2-13b", feature = "visionfive2-13b-rt"))]
+#[cfg(any(feature = "visionfive2-13b", feature = "visionfive2-13b-rt", feature = "visionfive2-13b-rts"))]
 pub extern crate jh7110_vf2_13b_pac;


### PR DESCRIPTION
Enables the `rts` feature to allow running with the `riscv-rt` crate in supervisor mode.

Changes the `gpo_dout` registers to use index-based naming to match `gpo_doen` registers, for consistency.