### PR TITLE
version: bump to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jh71xx-pac"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["rmsyn <rmsynchls@gmail.com>"]
 repository = "https://github.com/rmsyn/jh71xx-pac"


### PR DESCRIPTION
Bumps the minor version to include backwards-incompatible changes:

- PAC unification
- minor renaming