### PR TITLE
dmc: add DDR memory controller peripherals

### DIFF
--- a/jh7110.dts
+++ b/jh7110.dts
@@ -297,6 +297,14 @@
 		#size-cells = <0x02>;
 		ranges;
 
+		rstgen: reset-controller {
+                        compatible = "starfive,jh7110-reset";
+                        reg = <0x00 0x13020000 0x00 0x10000>, <0x00 0x10230000 0x00 0x10000>, <0x00 0x17000000 0x00 0x10000>, <0x00 0x19810000 0x00 0x10000>, <0x00 0x295c0000 0x00 0x10000>;
+                        reg-names = "syscrg", "stgcrg", "aoncrg", "ispcrg", "voutcrg";
+                        #reset-cells = <0x01>;
+                        phandle = <0x13>;
+                };
+
 		clint: timer@2000000 {
 			compatible = "starfive,jh7110-clint";
 			reg = <0x00 0x2000000 0x00 0x10000>;
@@ -474,6 +482,22 @@
 			status = "okay";
 			pinctrl-names = "default";
 			pinctrl-0 = <&tdm_pins>;
+		};
+
+		dmc_ctrl: dmc@100b0000 {
+			compatible = "starfive,jh7110-dmc-ctrl";
+			reg = <0x0 0x15700000 0x0 0x10000>;
+			resets = <&rstgen 38>, <&rstgen 39>, <&rstgen 40>;
+			reset-names = "axi", "osc", "apb";
+			clock-frequency = <2133>;
+		};
+
+		dmc_phy: dmc@100c0000 {
+			compatible = "starfive,jh7110-dmc-phy";
+			reg = <0x0 0x13000000 0x0 0x10000>;
+			resets = <&rstgen 38>, <&rstgen 39>, <&rstgen 40>;
+			reset-names = "axi", "osc", "apb";
+			clock-frequency = <2133>;
 		};
 
 		usb0: usb@10100000 {

--- a/jh7110.svd
+++ b/jh7110.svd
@@ -11398,6 +11398,70 @@
       </addressBlock>
     </peripheral>
     <peripheral>
+      <name>dmc_ctrl</name>
+      <description>From starfive,jh7110-dmc-ctrl, peripheral generator</description>
+      <baseAddress>0x15700000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>1024</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>csr[%s]</name>
+          <description>DDR Memory Control CSR register</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0</resetValue>
+        </register>
+        <register>
+          <dim>1024</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>sec[%s]</name>
+          <description>DDR Memory Control SEC register</description>
+          <addressOffset>0x1000</addressOffset>
+          <resetValue>0</resetValue>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>dmc_phy</name>
+      <description>From starfive,jh7110-dmc-phy, peripheral generator</description>
+      <baseAddress>0x13000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>512</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>csr[%s]</name>
+          <description>DDR Memory Control PHY CSR</description>
+          <addressOffset>0x0</addressOffset>
+          <resetValue>0</resetValue>
+        </register>
+        <register>
+          <dim>512</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>base[%s]</name>
+          <description>DDR Memory Control PHY Base register</description>
+          <addressOffset>0x800</addressOffset>
+          <resetValue>0</resetValue>
+        </register>
+        <register>
+          <dim>512</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>ac_base[%s]</name>
+          <description>DDR Memory Control PHY AC Base register</description>
+          <addressOffset>0x1000</addressOffset>
+          <resetValue>0</resetValue>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
       <name>starfive_jh7110_usb_phy_0</name>
       <description>From starfive,jh7110-usb-phy, peripheral generator</description>
       <baseAddress>0x10200000</baseAddress>

--- a/src/dmc_ctrl.rs
+++ b/src/dmc_ctrl.rs
@@ -1,0 +1,40 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    csr: [CSR; 1024],
+    sec: [SEC; 1024],
+}
+impl RegisterBlock {
+    #[doc = "0x00..0x1000 - DDR Memory Control CSR register"]
+    #[inline(always)]
+    pub const fn csr(&self, n: usize) -> &CSR {
+        &self.csr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x00..0x1000 - DDR Memory Control CSR register"]
+    #[inline(always)]
+    pub fn csr_iter(&self) -> impl Iterator<Item = &CSR> {
+        self.csr.iter()
+    }
+    #[doc = "0x1000..0x2000 - DDR Memory Control SEC register"]
+    #[inline(always)]
+    pub const fn sec(&self, n: usize) -> &SEC {
+        &self.sec[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x1000..0x2000 - DDR Memory Control SEC register"]
+    #[inline(always)]
+    pub fn sec_iter(&self) -> impl Iterator<Item = &SEC> {
+        self.sec.iter()
+    }
+}
+#[doc = "csr (rw) register accessor: DDR Memory Control CSR register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`csr::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`csr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@csr`]
+module"]
+pub type CSR = crate::Reg<csr::CSR_SPEC>;
+#[doc = "DDR Memory Control CSR register"]
+pub mod csr;
+#[doc = "sec (rw) register accessor: DDR Memory Control SEC register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sec::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sec::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@sec`]
+module"]
+pub type SEC = crate::Reg<sec::SEC_SPEC>;
+#[doc = "DDR Memory Control SEC register"]
+pub mod sec;

--- a/src/dmc_ctrl/csr.rs
+++ b/src/dmc_ctrl/csr.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `csr[%s]` reader"]
+pub type R = crate::R<CSR_SPEC>;
+#[doc = "Register `csr[%s]` writer"]
+pub type W = crate::W<CSR_SPEC>;
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl core::fmt::Debug for crate::generic::Reg<CSR_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "DDR Memory Control CSR register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`csr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`csr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CSR_SPEC;
+impl crate::RegisterSpec for CSR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`csr::R`](R) reader structure"]
+impl crate::Readable for CSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`csr::W`](W) writer structure"]
+impl crate::Writable for CSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets csr[%s]
+to value 0"]
+impl crate::Resettable for CSR_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/src/dmc_ctrl/sec.rs
+++ b/src/dmc_ctrl/sec.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `sec[%s]` reader"]
+pub type R = crate::R<SEC_SPEC>;
+#[doc = "Register `sec[%s]` writer"]
+pub type W = crate::W<SEC_SPEC>;
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl core::fmt::Debug for crate::generic::Reg<SEC_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "DDR Memory Control SEC register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`sec::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`sec::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct SEC_SPEC;
+impl crate::RegisterSpec for SEC_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`sec::R`](R) reader structure"]
+impl crate::Readable for SEC_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`sec::W`](W) writer structure"]
+impl crate::Writable for SEC_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets sec[%s]
+to value 0"]
+impl crate::Resettable for SEC_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/src/dmc_phy.rs
+++ b/src/dmc_phy.rs
@@ -1,0 +1,57 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    csr: [CSR; 512],
+    base: [BASE; 512],
+    ac_base: [AC_BASE; 512],
+}
+impl RegisterBlock {
+    #[doc = "0x00..0x800 - DDR Memory Control PHY CSR"]
+    #[inline(always)]
+    pub const fn csr(&self, n: usize) -> &CSR {
+        &self.csr[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x00..0x800 - DDR Memory Control PHY CSR"]
+    #[inline(always)]
+    pub fn csr_iter(&self) -> impl Iterator<Item = &CSR> {
+        self.csr.iter()
+    }
+    #[doc = "0x800..0x1000 - DDR Memory Control PHY Base register"]
+    #[inline(always)]
+    pub const fn base(&self, n: usize) -> &BASE {
+        &self.base[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x800..0x1000 - DDR Memory Control PHY Base register"]
+    #[inline(always)]
+    pub fn base_iter(&self) -> impl Iterator<Item = &BASE> {
+        self.base.iter()
+    }
+    #[doc = "0x1000..0x1800 - DDR Memory Control PHY AC Base register"]
+    #[inline(always)]
+    pub const fn ac_base(&self, n: usize) -> &AC_BASE {
+        &self.ac_base[n]
+    }
+    #[doc = "Iterator for array of:"]
+    #[doc = "0x1000..0x1800 - DDR Memory Control PHY AC Base register"]
+    #[inline(always)]
+    pub fn ac_base_iter(&self) -> impl Iterator<Item = &AC_BASE> {
+        self.ac_base.iter()
+    }
+}
+#[doc = "csr (rw) register accessor: DDR Memory Control PHY CSR\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`csr::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`csr::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@csr`]
+module"]
+pub type CSR = crate::Reg<csr::CSR_SPEC>;
+#[doc = "DDR Memory Control PHY CSR"]
+pub mod csr;
+#[doc = "base (rw) register accessor: DDR Memory Control PHY Base register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`base::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`base::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@base`]
+module"]
+pub type BASE = crate::Reg<base::BASE_SPEC>;
+#[doc = "DDR Memory Control PHY Base register"]
+pub mod base;
+#[doc = "ac_base (rw) register accessor: DDR Memory Control PHY AC Base register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ac_base::R`].  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ac_base::W`]. You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [`mod@ac_base`]
+module"]
+pub type AC_BASE = crate::Reg<ac_base::AC_BASE_SPEC>;
+#[doc = "DDR Memory Control PHY AC Base register"]
+pub mod ac_base;

--- a/src/dmc_phy/ac_base.rs
+++ b/src/dmc_phy/ac_base.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `ac_base[%s]` reader"]
+pub type R = crate::R<AC_BASE_SPEC>;
+#[doc = "Register `ac_base[%s]` writer"]
+pub type W = crate::W<AC_BASE_SPEC>;
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl core::fmt::Debug for crate::generic::Reg<AC_BASE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "DDR Memory Control PHY AC Base register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`ac_base::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`ac_base::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct AC_BASE_SPEC;
+impl crate::RegisterSpec for AC_BASE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`ac_base::R`](R) reader structure"]
+impl crate::Readable for AC_BASE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`ac_base::W`](W) writer structure"]
+impl crate::Writable for AC_BASE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets ac_base[%s]
+to value 0"]
+impl crate::Resettable for AC_BASE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/src/dmc_phy/base.rs
+++ b/src/dmc_phy/base.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `base[%s]` reader"]
+pub type R = crate::R<BASE_SPEC>;
+#[doc = "Register `base[%s]` writer"]
+pub type W = crate::W<BASE_SPEC>;
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl core::fmt::Debug for crate::generic::Reg<BASE_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "DDR Memory Control PHY Base register\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`base::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`base::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct BASE_SPEC;
+impl crate::RegisterSpec for BASE_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`base::R`](R) reader structure"]
+impl crate::Readable for BASE_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`base::W`](W) writer structure"]
+impl crate::Writable for BASE_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets base[%s]
+to value 0"]
+impl crate::Resettable for BASE_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/src/dmc_phy/csr.rs
+++ b/src/dmc_phy/csr.rs
@@ -1,0 +1,43 @@
+#[doc = "Register `csr[%s]` reader"]
+pub type R = crate::R<CSR_SPEC>;
+#[doc = "Register `csr[%s]` writer"]
+pub type W = crate::W<CSR_SPEC>;
+impl core::fmt::Debug for R {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.bits())
+    }
+}
+impl core::fmt::Debug for crate::generic::Reg<CSR_SPEC> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(&self.read(), f)
+    }
+}
+impl W {
+    #[doc = r" Writes raw bits to the register."]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Passing incorrect value can cause undefined behaviour. See reference manual"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: u32) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "DDR Memory Control PHY CSR\n\nYou can [`read`](crate::generic::Reg::read) this register and get [`csr::R`](R).  You can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero) this register using [`csr::W`](W). You can also [`modify`](crate::generic::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
+pub struct CSR_SPEC;
+impl crate::RegisterSpec for CSR_SPEC {
+    type Ux = u32;
+}
+#[doc = "`read()` method returns [`csr::R`](R) reader structure"]
+impl crate::Readable for CSR_SPEC {}
+#[doc = "`write(|w| ..)` method takes [`csr::W`](W) writer structure"]
+impl crate::Writable for CSR_SPEC {
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = 0;
+}
+#[doc = "`reset()` method sets csr[%s]
+to value 0"]
+impl crate::Resettable for CSR_SPEC {
+    const RESET_VALUE: Self::Ux = 0;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,6 +661,98 @@ impl core::fmt::Debug for SPI2 {
 }
 #[doc = "From arm,pl022, peripheral generator"]
 pub mod spi2;
+#[doc = "From starfive,jh7110-dmc-ctrl, peripheral generator"]
+pub struct DMC_CTRL {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for DMC_CTRL {}
+impl DMC_CTRL {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const dmc_ctrl::RegisterBlock = 0x1570_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const dmc_ctrl::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for DMC_CTRL {
+    type Target = dmc_ctrl::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for DMC_CTRL {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DMC_CTRL").finish()
+    }
+}
+#[doc = "From starfive,jh7110-dmc-ctrl, peripheral generator"]
+pub mod dmc_ctrl;
+#[doc = "From starfive,jh7110-dmc-phy, peripheral generator"]
+pub struct DMC_PHY {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for DMC_PHY {}
+impl DMC_PHY {
+    #[doc = r"Pointer to the register block"]
+    pub const PTR: *const dmc_phy::RegisterBlock = 0x1300_0000 as *const _;
+    #[doc = r"Return the pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const dmc_phy::RegisterBlock {
+        Self::PTR
+    }
+    #[doc = r" Steal an instance of this peripheral"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r""]
+    #[doc = r" Ensure that the new instance of the peripheral cannot be used in a way"]
+    #[doc = r" that may race with any existing instances, for example by only"]
+    #[doc = r" accessing read-only or write-only registers, or by consuming the"]
+    #[doc = r" original peripheral and using critical sections to coordinate"]
+    #[doc = r" access between multiple new instances."]
+    #[doc = r""]
+    #[doc = r" Additionally, other software such as HALs may rely on only one"]
+    #[doc = r" peripheral instance existing to ensure memory safety; ensure"]
+    #[doc = r" no stolen instances are passed to such software."]
+    pub unsafe fn steal() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+impl Deref for DMC_PHY {
+    type Target = dmc_phy::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*Self::PTR }
+    }
+}
+impl core::fmt::Debug for DMC_PHY {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("DMC_PHY").finish()
+    }
+}
+#[doc = "From starfive,jh7110-dmc-phy, peripheral generator"]
+pub mod dmc_phy;
 #[doc = "From starfive,jh7110-stgcrg, peripheral generator"]
 pub struct STGCRG {
     _marker: PhantomData<*const ()>,
@@ -1746,6 +1838,10 @@ pub struct Peripherals {
     pub SPI1: SPI1,
     #[doc = "SPI2"]
     pub SPI2: SPI2,
+    #[doc = "DMC_CTRL"]
+    pub DMC_CTRL: DMC_CTRL,
+    #[doc = "DMC_PHY"]
+    pub DMC_PHY: DMC_PHY,
     #[doc = "STGCRG"]
     pub STGCRG: STGCRG,
     #[doc = "STG_SYSCON"]
@@ -1845,6 +1941,12 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             SPI2: SPI2 {
+                _marker: PhantomData,
+            },
+            DMC_CTRL: DMC_CTRL {
+                _marker: PhantomData,
+            },
+            DMC_PHY: DMC_PHY {
                 _marker: PhantomData,
             },
             STGCRG: STGCRG {


### PR DESCRIPTION
Updates the DTS and `cmsis-svd-generator` to generate DDR memory controller CTRL and PHY peripheral registers.