### PR TITLE
fixup: dmc: extend DMC PHY register arrays

### DIFF
--- a/jh7110.svd
+++ b/jh7110.svd
@@ -11416,7 +11416,7 @@
           <resetValue>0</resetValue>
         </register>
         <register>
-          <dim>1024</dim>
+          <dim>2048</dim>
           <dimIncrement>0x4</dimIncrement>
           <name>sec[%s]</name>
           <description>DDR Memory Control SEC register</description>
@@ -11436,7 +11436,7 @@
       </addressBlock>
       <registers>
         <register>
-          <dim>512</dim>
+          <dim>2048</dim>
           <dimIncrement>0x4</dimIncrement>
           <name>csr[%s]</name>
           <description>DDR Memory Control PHY CSR</description>
@@ -11444,11 +11444,11 @@
           <resetValue>0</resetValue>
         </register>
         <register>
-          <dim>512</dim>
+          <dim>2048</dim>
           <dimIncrement>0x4</dimIncrement>
           <name>base[%s]</name>
           <description>DDR Memory Control PHY Base register</description>
-          <addressOffset>0x800</addressOffset>
+          <addressOffset>0x2000</addressOffset>
           <resetValue>0</resetValue>
         </register>
         <register>
@@ -11456,7 +11456,7 @@
           <dimIncrement>0x4</dimIncrement>
           <name>ac_base[%s]</name>
           <description>DDR Memory Control PHY AC Base register</description>
-          <addressOffset>0x1000</addressOffset>
+          <addressOffset>0x4000</addressOffset>
           <resetValue>0</resetValue>
         </register>
       </registers>

--- a/src/dmc_ctrl.rs
+++ b/src/dmc_ctrl.rs
@@ -2,7 +2,7 @@
 #[repr(C)]
 pub struct RegisterBlock {
     csr: [CSR; 1024],
-    sec: [SEC; 1024],
+    sec: [SEC; 2048],
 }
 impl RegisterBlock {
     #[doc = "0x00..0x1000 - DDR Memory Control CSR register"]
@@ -16,13 +16,13 @@ impl RegisterBlock {
     pub fn csr_iter(&self) -> impl Iterator<Item = &CSR> {
         self.csr.iter()
     }
-    #[doc = "0x1000..0x2000 - DDR Memory Control SEC register"]
+    #[doc = "0x1000..0x3000 - DDR Memory Control SEC register"]
     #[inline(always)]
     pub const fn sec(&self, n: usize) -> &SEC {
         &self.sec[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x1000..0x2000 - DDR Memory Control SEC register"]
+    #[doc = "0x1000..0x3000 - DDR Memory Control SEC register"]
     #[inline(always)]
     pub fn sec_iter(&self) -> impl Iterator<Item = &SEC> {
         self.sec.iter()

--- a/src/dmc_phy.rs
+++ b/src/dmc_phy.rs
@@ -1,40 +1,40 @@
 #[doc = r"Register block"]
 #[repr(C)]
 pub struct RegisterBlock {
-    csr: [CSR; 512],
-    base: [BASE; 512],
+    csr: [CSR; 2048],
+    base: [BASE; 2048],
     ac_base: [AC_BASE; 2048],
 }
 impl RegisterBlock {
-    #[doc = "0x00..0x800 - DDR Memory Control PHY CSR"]
+    #[doc = "0x00..0x2000 - DDR Memory Control PHY CSR"]
     #[inline(always)]
     pub const fn csr(&self, n: usize) -> &CSR {
         &self.csr[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x00..0x800 - DDR Memory Control PHY CSR"]
+    #[doc = "0x00..0x2000 - DDR Memory Control PHY CSR"]
     #[inline(always)]
     pub fn csr_iter(&self) -> impl Iterator<Item = &CSR> {
         self.csr.iter()
     }
-    #[doc = "0x800..0x1000 - DDR Memory Control PHY Base register"]
+    #[doc = "0x2000..0x4000 - DDR Memory Control PHY Base register"]
     #[inline(always)]
     pub const fn base(&self, n: usize) -> &BASE {
         &self.base[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x800..0x1000 - DDR Memory Control PHY Base register"]
+    #[doc = "0x2000..0x4000 - DDR Memory Control PHY Base register"]
     #[inline(always)]
     pub fn base_iter(&self) -> impl Iterator<Item = &BASE> {
         self.base.iter()
     }
-    #[doc = "0x1000..0x3000 - DDR Memory Control PHY AC Base register"]
+    #[doc = "0x4000..0x6000 - DDR Memory Control PHY AC Base register"]
     #[inline(always)]
     pub const fn ac_base(&self, n: usize) -> &AC_BASE {
         &self.ac_base[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x1000..0x3000 - DDR Memory Control PHY AC Base register"]
+    #[doc = "0x4000..0x6000 - DDR Memory Control PHY AC Base register"]
     #[inline(always)]
     pub fn ac_base_iter(&self) -> impl Iterator<Item = &AC_BASE> {
         self.ac_base.iter()


### PR DESCRIPTION
Extends all DMC PHY register arrays to 2048 32-bit registers.

Adjusts register base addresses accordingly.